### PR TITLE
Update webpack and launch configs to fix sourcemaps, fixes #4

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -7,7 +7,7 @@
             "request": "launch",
             "runtimeExecutable": "${execPath}",
             "args": [
-                "--extensionDevelopmentPath=${workspaceRoot}"
+                "--extensionDevelopmentPath=${workspaceFolder}"
             ],
             "stopOnEntry": false,
             "sourceMaps": true,

--- a/webpack.config.ts
+++ b/webpack.config.ts
@@ -1,7 +1,7 @@
 import path from "path";
 
 const commonConfig = {
-    devtool: "inline-source-map",
+    devtool: "source-map",
     mode: "development",
     module: {
         rules: [
@@ -39,6 +39,7 @@ module.exports = [
         },
         name: "extension",
         output: {
+            devtoolModuleFilenameTemplate: "../[resource-path]",
             filename: "[name].js",
             libraryTarget: "commonjs2",
             path: path.resolve(__dirname, "out"),


### PR DESCRIPTION
This PR fixes #4 
* Updating the webpack config to use file sourcemaps and the devtoolModuleFilenameTemplate value from the [VSCode guide on bundling extensions](https://code.visualstudio.com/api/working-with-extensions/bundling-extension)
* Changes workspaceRoot to workspaceFolder in launch.json
