### PR TITLE
Change postMessageAcrossChannel to support real websocket

### DIFF
--- a/src/common/webviewEvents.test.ts
+++ b/src/common/webviewEvents.test.ts
@@ -2,8 +2,8 @@
 // Licensed under the MIT License.
 
 import {
+    encodeMessageForChannel,
     parseMessageFromChannel,
-    postMessageAcrossChannel,
     webviewEventNames,
 } from "../common/webviewEvents";
 
@@ -17,14 +17,8 @@ describe("webviewEvents", () => {
                 }];
 
                 // Generate a message we can use for parsing
-                const mockPostMessageObject = {
-                    postMessage: jest.fn(),
-                };
-                postMessageAcrossChannel(mockPostMessageObject, e, expectedArgs);
-
-                // Grab the data from the postMessage
-                expect(mockPostMessageObject.postMessage).toHaveBeenCalled();
-                const data = mockPostMessageObject.postMessage.mock.calls[0][0];
+                let data = "";
+                encodeMessageForChannel((msg) => data = msg, e, expectedArgs);
 
                 // Ensure parsing it calls the correct emit event
                 const mockEmit = jest.fn();
@@ -42,23 +36,17 @@ describe("webviewEvents", () => {
     });
 
     describe("postMessageAcrossChannel", () => {
-        it("calls postMessage with origin", async () => {
+        it("calls postMessageCallback with encoded data", async () => {
             for (const e of webviewEventNames) {
-                const expectedOrigin = "*";
                 const expectedArgs = [{
                     name: e,
                     someArg: "hello",
                 }];
                 const expectedFormat = `${e}:${JSON.stringify(expectedArgs)}`;
 
-                const mockPostMessageObject = {
-                    postMessage: jest.fn(),
-                };
-                postMessageAcrossChannel(mockPostMessageObject, e, expectedArgs);
-                expect(mockPostMessageObject.postMessage).toHaveBeenCalledWith(expectedFormat);
-
-                postMessageAcrossChannel(mockPostMessageObject, e, expectedArgs, expectedOrigin);
-                expect(mockPostMessageObject.postMessage).toHaveBeenCalledWith(expectedFormat, expectedOrigin);
+                const mockPostMessage = jest.fn();
+                encodeMessageForChannel(mockPostMessage, e, expectedArgs);
+                expect(mockPostMessage).toHaveBeenCalledWith(expectedFormat);
             }
         });
     });

--- a/src/common/webviewEvents.ts
+++ b/src/common/webviewEvents.ts
@@ -38,15 +38,10 @@ export function parseMessageFromChannel(
  * @param args Any arguments to encode and post
  * @param origin The origin (if any) to use with the postMessage call
  */
-export function postMessageAcrossChannel(
-    postMessageObject: { postMessage: (data: string, origin?: string) => void },
+export function encodeMessageForChannel(
+    postMessageCallback: (message: string) => void,
     eventType: WebviewEvent,
-    args: any[] | undefined,
-    origin?: string) {
+    args?: any[]) {
     const message = `${eventType}:${JSON.stringify(args)}`;
-    if (origin) {
-        postMessageObject.postMessage.call(postMessageObject, message, origin);
-    } else {
-        postMessageObject.postMessage.call(postMessageObject, message);
-    }
+    postMessageCallback(message);
 }

--- a/src/devtoolsPanel.ts
+++ b/src/devtoolsPanel.ts
@@ -3,7 +3,7 @@
 
 import * as path from "path";
 import * as vscode from "vscode";
-import { postMessageAcrossChannel } from "./common/webviewEvents";
+import { encodeMessageForChannel } from "./common/webviewEvents";
 import { PanelSocket } from "./panelSocket";
 import {
     fetchUri,
@@ -70,7 +70,7 @@ export class DevToolsPanel {
     }
 
     private postToDevTools(message: string) {
-        postMessageAcrossChannel(this.panel.webview, "websocket", [message]);
+        encodeMessageForChannel((msg) => this.panel.webview.postMessage(msg), "websocket", [message]);
     }
 
     private onSocketReady() {
@@ -88,7 +88,7 @@ export class DevToolsPanel {
     private onSocketGetState(message: string) {
         const { id } = JSON.parse(message) as { id: number };
         const preferences: any = this.context.workspaceState.get(SETTINGS_PREF_NAME) || SETTINGS_PREF_DEFAULTS;
-        postMessageAcrossChannel(this.panel.webview, "getState", [{ id, preferences }]);
+        encodeMessageForChannel((msg) => this.panel.webview.postMessage(msg), "getState", [{ id, preferences }]);
     }
 
     private onSocketSetState(message: string) {
@@ -110,7 +110,7 @@ export class DevToolsPanel {
             // Response will not have content
         }
 
-        postMessageAcrossChannel(this.panel.webview, "getUrl", [{ id: request.id, content }]);
+        encodeMessageForChannel((msg) => this.panel.webview.postMessage(msg), "getUrl", [{ id: request.id, content }]);
     }
 
     private update() {


### PR DESCRIPTION
As part of an upcoming PR, I noticed that the current implementation of postMessageAcrossChannel did not work correctly for real web-based websockets (only for the node-based one currently in use by the extension).

This PR fixes the issue by redefining the function to only encode the data, and accept a callback that the caller can use to post the message in whatever way in needs to for its type of socket.

* Renamed postMessageAcrossChannel to encodeMessageForChannel
* Accept a callback to prevent callers from forgetting to post the encoded message
* Updated callers and tests