### PR TITLE
Adding ToolsWebSocket used in the webview

### DIFF
--- a/src/host/toolsWebSocket.test.ts
+++ b/src/host/toolsWebSocket.test.ts
@@ -1,0 +1,113 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import { getFirstCallback } from "../test/helpers";
+
+describe("toolsWebSocket", () => {
+    let mockWebviewEvents: { encodeMessageForChannel: jest.Mock };
+
+    beforeEach(() => {
+        mockWebviewEvents = {
+            encodeMessageForChannel: jest.fn(),
+        };
+        jest.doMock("../common/webviewEvents", () => mockWebviewEvents);
+        jest.resetModules();
+
+        window.parent.postMessage = jest.fn();
+    });
+
+    describe("constructor", () => {
+        it("updates instance property", async () => {
+            const tws = await import("./toolsWebSocket");
+
+            const websocket = new tws.ToolsWebSocket("some url");
+            expect(tws.ToolsWebSocket.instance).toEqual(websocket);
+
+            const websocket2 = new tws.ToolsWebSocket("some other url");
+            expect(tws.ToolsWebSocket.instance).toEqual(websocket2);
+        });
+
+        it("sends ready event", async () => {
+            const tws = await import("./toolsWebSocket");
+            const websocket = new tws.ToolsWebSocket("some url");
+            expect(websocket).toBeDefined();
+
+            expect(mockWebviewEvents.encodeMessageForChannel).toHaveBeenCalledWith(
+                expect.any(Function),
+                "ready",
+                [""],
+            );
+
+            const expectedPostedMessage = "encodedMessage";
+            const postMessage = getFirstCallback(mockWebviewEvents.encodeMessageForChannel);
+            postMessage.callback.call(postMessage.thisObj, expectedPostedMessage);
+            expect(window.parent.postMessage).toHaveBeenCalledWith(expectedPostedMessage, "*");
+        });
+    });
+
+    describe("send", () => {
+        it("forwards messages correctly", async () => {
+            const tws = await import("./toolsWebSocket");
+            const websocket = new tws.ToolsWebSocket("some url");
+            mockWebviewEvents.encodeMessageForChannel.mockClear();
+
+            const expectedMessage = "some message string";
+            websocket.send(expectedMessage);
+            expect(mockWebviewEvents.encodeMessageForChannel).toHaveBeenCalledWith(
+                expect.any(Function),
+                "websocket",
+                [expectedMessage],
+            );
+
+            const expectedPostedMessage = "encodedMessage";
+            const postMessage = getFirstCallback(mockWebviewEvents.encodeMessageForChannel);
+            postMessage.callback.call(postMessage.thisObj, expectedPostedMessage);
+            expect(window.parent.postMessage).toHaveBeenCalledWith(expectedPostedMessage, "*");
+        });
+    });
+
+    describe("onMessageFromChannel", () => {
+        it("parses control messages and calls correct handlers", async () => {
+            const tws = await import("./toolsWebSocket");
+            const websocket = new tws.ToolsWebSocket("some url");
+
+            websocket.onerror = jest.fn();
+            websocket.onMessageFromChannel("error");
+            expect(websocket.onerror).toBeCalled();
+
+            websocket.onopen = jest.fn();
+            websocket.onMessageFromChannel("open");
+            expect(websocket.onopen).toBeCalled();
+
+            websocket.onclose = jest.fn();
+            websocket.onMessageFromChannel("close");
+            expect(websocket.onclose).toBeCalled();
+        });
+
+        it("forwards websocket messages to onmessage", async () => {
+            const tws = await import("./toolsWebSocket");
+            const websocket = new tws.ToolsWebSocket("some url");
+
+            websocket.onmessage = jest.fn();
+
+            const expectedMessage = "{ request: 1 }";
+            websocket.onMessageFromChannel("message", expectedMessage);
+            expect(websocket.onmessage).toBeCalledWith({ data: expectedMessage });
+
+            const expectedMessage2 = `{ name: "my Name" }`;
+            websocket.onMessageFromChannel("message", expectedMessage2);
+            expect(websocket.onmessage).toBeCalledWith({ data: expectedMessage2 });
+        });
+
+        it("ignores websocket messages with no message data", async () => {
+            const tws = await import("./toolsWebSocket");
+            const websocket = new tws.ToolsWebSocket("some url");
+
+            websocket.onmessage = jest.fn();
+
+            (websocket.onmessage as jest.Mock).mockClear();
+            websocket.onMessageFromChannel("message");
+            expect(websocket.onmessage).not.toBeCalled();
+        });
+    });
+});

--- a/src/host/toolsWebSocket.ts
+++ b/src/host/toolsWebSocket.ts
@@ -1,0 +1,66 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import { encodeMessageForChannel, WebSocketEvent } from "../common/webviewEvents";
+
+interface IMessageEvent {
+    data: string;
+}
+
+/**
+ * Class used to override the real WebSocket constructor in the webview.
+ * This is required as a VSCode webview cannot create a WebSocket connection,
+ * so instead we replace it and forward all messages to/from the extension
+ * which is able to create the real websocket connection to the target page.
+ */
+export class ToolsWebSocket {
+    private static devtoolsWebSocket: ToolsWebSocket;
+    public static get instance() {
+        return ToolsWebSocket.devtoolsWebSocket;
+    }
+
+    public onopen: (() => void) | undefined;
+    public onclose: (() => void) | undefined;
+    public onerror: (() => void) | undefined;
+    public onmessage: ((e: IMessageEvent) => void) | undefined;
+
+    constructor(url: string) {
+        ToolsWebSocket.devtoolsWebSocket = this;
+        // Inform the extension that we are ready to receive messages
+        encodeMessageForChannel((msg) => window.parent.postMessage(msg, "*"), "ready", [""]);
+    }
+
+    public send(message: string) {
+        // Forward the message to the extension
+        encodeMessageForChannel((msg) => window.parent.postMessage(msg, "*"), "websocket", [message]);
+    }
+
+    public onMessageFromChannel(e: WebSocketEvent, message?: string) {
+        switch (e) {
+            case "open":
+                if (this.onopen) {
+                    this.onopen();
+                }
+                break;
+
+            case "close":
+                if (this.onclose) {
+                    this.onclose();
+                }
+                break;
+
+            case "error":
+                if (this.onerror) {
+                    this.onerror();
+                }
+                break;
+
+            default:
+                // Messages from the target page's websocket should just be forwarded to the tools
+                if (this.onmessage && message) {
+                    this.onmessage({ data: message });
+                }
+                break;
+        }
+    }
+}


### PR DESCRIPTION
This PR adds a new class to be used by the webview that hosts the devtools which replaces the standard websocket. In a VSCode webview you are unable to create a regular websocket connection directly. So instead this class will be used to replace the window.WebSocket class, and will forward messages between the devtools hosted in the webview, and the extension which is able to create a real connection.

* Added  new ToolsWebSocket class
* Added unit tests
