### PR TITLE
Adding new ToolsHost class with tests

### DIFF
--- a/src/common/webviewEvents.ts
+++ b/src/common/webviewEvents.ts
@@ -20,10 +20,6 @@ export const webSocketEventNames: WebSocketEvent[] = [
 ];
 
 export type TelemetryEvent = "enumerated" | "performance";
-export const telemetryEventNames: TelemetryEvent[] = [
-    "enumerated",
-    "performance",
-];
 
 export interface ITelemetryData {
     event: TelemetryEvent;

--- a/src/host/toolsHost.test.ts
+++ b/src/host/toolsHost.test.ts
@@ -17,8 +17,8 @@ describe("toolsHost", () => {
 
     describe("isHostedMode", () => {
         it("returns true", async () => {
-            const th = await import("./toolsHost");
-            const host = new th.ToolsHost();
+            const { default: toolsHost } = await import("./toolsHost");
+            const host = new toolsHost();
 
             expect(host.isHostedMode()).toEqual(true);
         });
@@ -26,8 +26,8 @@ describe("toolsHost", () => {
 
     describe("getPreferences", () => {
         it("calls across to webview", async () => {
-            const th = await import("./toolsHost");
-            const host = new th.ToolsHost();
+            const { default: toolsHost } = await import("./toolsHost");
+            const host = new toolsHost();
 
             const mockCallback = jest.fn();
             host.getPreferences(mockCallback);
@@ -46,8 +46,8 @@ describe("toolsHost", () => {
         });
 
         it("fires callbacks on response from extension", async () => {
-            const th = await import("./toolsHost");
-            const host = new th.ToolsHost();
+            const { default: toolsHost } = await import("./toolsHost");
+            const host = new toolsHost();
 
             const mockCallback = jest.fn();
             host.getPreferences(mockCallback);
@@ -69,8 +69,8 @@ describe("toolsHost", () => {
 
     describe("setPreferences", () => {
         it("calls across to webview", async () => {
-            const th = await import("./toolsHost");
-            const host = new th.ToolsHost();
+            const { default: toolsHost } = await import("./toolsHost");
+            const host = new toolsHost();
 
             const expectedPref = {
                 name: "myPreference",
@@ -94,8 +94,8 @@ describe("toolsHost", () => {
 
     describe("recordEnumeratedHistogram", () => {
         it("calls across to extension", async () => {
-            const th = await import("./toolsHost");
-            const host = new th.ToolsHost();
+            const { default: toolsHost } = await import("./toolsHost");
+            const host = new toolsHost();
 
             const expectedTelemetry = {
                 data: 1000,
@@ -120,8 +120,8 @@ describe("toolsHost", () => {
 
     describe("recordPerformanceHistogram", () => {
         it("calls across to extension", async () => {
-            const th = await import("./toolsHost");
-            const host = new th.ToolsHost();
+            const { default: toolsHost } = await import("./toolsHost");
+            const host = new toolsHost();
 
             const expectedTelemetry = {
                 data: 500,
@@ -146,11 +146,11 @@ describe("toolsHost", () => {
 
     describe("onMessageFromChannel", () => {
         it("does nothing yet on getUrl message", async () => {
-            const th = await import("./toolsHost");
-            const host = new th.ToolsHost();
+            const { default: toolsHost } = await import("./toolsHost");
+            const host = new toolsHost();
 
-            const expectedArgs = "some content";
-            host.onMessageFromChannel("getUrl", expectedArgs);
+            const expectedArgs = {id: 0, content: "some content"};
+            host.onMessageFromChannel("getUrl", JSON.stringify(expectedArgs));
 
             // TODO: Change test once implemented
             expect(window.parent.postMessage).not.toHaveBeenCalled();
@@ -158,21 +158,19 @@ describe("toolsHost", () => {
 
         it("calls onMessageFromChannel on websocket message", async () => {
             const mockToolsWS = {
-                ToolsWebSocket: {
-                    instance: {
-                        onMessageFromChannel: jest.fn(),
-                    },
+                instance: {
+                    onMessageFromChannel: jest.fn(),
                 },
             };
             jest.doMock("./toolsWebSocket", () => mockToolsWS);
 
-            const th = await import("./toolsHost");
-            const host = new th.ToolsHost();
+            const { default: toolsHost } = await import("./toolsHost");
+            const host = new toolsHost();
 
             const expectedArgs = ["message", "some websocket message"];
             host.onMessageFromChannel("websocket", JSON.stringify(expectedArgs));
 
-            expect(mockToolsWS.ToolsWebSocket.instance.onMessageFromChannel).toHaveBeenCalledWith(
+            expect(mockToolsWS.instance.onMessageFromChannel).toHaveBeenCalledWith(
                 expectedArgs[0],
                 expectedArgs[1],
             );

--- a/src/host/toolsWebSocket.test.ts
+++ b/src/host/toolsWebSocket.test.ts
@@ -18,18 +18,18 @@ describe("toolsWebSocket", () => {
 
     describe("constructor", () => {
         it("updates instance property", async () => {
-            const tws = await import("./toolsWebSocket");
+            const { default: toolsWebSocket } = await import("./toolsWebSocket");
 
-            const websocket = new tws.ToolsWebSocket("some url");
-            expect(tws.ToolsWebSocket.instance).toEqual(websocket);
+            const websocket = new toolsWebSocket("some url");
+            expect(toolsWebSocket.instance).toEqual(websocket);
 
-            const websocket2 = new tws.ToolsWebSocket("some other url");
-            expect(tws.ToolsWebSocket.instance).toEqual(websocket2);
+            const websocket2 = new toolsWebSocket("some other url");
+            expect(toolsWebSocket.instance).toEqual(websocket2);
         });
 
         it("sends ready event", async () => {
-            const tws = await import("./toolsWebSocket");
-            const websocket = new tws.ToolsWebSocket("some url");
+            const { default: toolsWebSocket } = await import("./toolsWebSocket");
+            const websocket = new toolsWebSocket("some url");
             expect(websocket).toBeDefined();
 
             expect(mockWebviewEvents.encodeMessageForChannel).toHaveBeenCalledWith(
@@ -47,8 +47,8 @@ describe("toolsWebSocket", () => {
 
     describe("send", () => {
         it("forwards messages correctly", async () => {
-            const tws = await import("./toolsWebSocket");
-            const websocket = new tws.ToolsWebSocket("some url");
+            const { default: toolsWebSocket } = await import("./toolsWebSocket");
+            const websocket = new toolsWebSocket("some url");
             mockWebviewEvents.encodeMessageForChannel.mockClear();
 
             const expectedMessage = "some message string";
@@ -68,8 +68,8 @@ describe("toolsWebSocket", () => {
 
     describe("onMessageFromChannel", () => {
         it("parses control messages and calls correct handlers", async () => {
-            const tws = await import("./toolsWebSocket");
-            const websocket = new tws.ToolsWebSocket("some url");
+            const { default: toolsWebSocket } = await import("./toolsWebSocket");
+            const websocket = new toolsWebSocket("some url");
 
             websocket.onerror = jest.fn();
             websocket.onMessageFromChannel("error");
@@ -85,8 +85,8 @@ describe("toolsWebSocket", () => {
         });
 
         it("forwards websocket messages to onmessage", async () => {
-            const tws = await import("./toolsWebSocket");
-            const websocket = new tws.ToolsWebSocket("some url");
+            const { default: toolsWebSocket } = await import("./toolsWebSocket");
+            const websocket = new toolsWebSocket("some url");
 
             websocket.onmessage = jest.fn();
 
@@ -100,8 +100,8 @@ describe("toolsWebSocket", () => {
         });
 
         it("ignores websocket messages with no message data", async () => {
-            const tws = await import("./toolsWebSocket");
-            const websocket = new tws.ToolsWebSocket("some url");
+            const { default: toolsWebSocket } = await import("./toolsWebSocket");
+            const websocket = new toolsWebSocket("some url");
 
             websocket.onmessage = jest.fn();
 

--- a/src/host/toolsWebSocket.ts
+++ b/src/host/toolsWebSocket.ts
@@ -13,7 +13,7 @@ interface IMessageEvent {
  * so instead we replace it and forward all messages to/from the extension
  * which is able to create the real websocket connection to the target page.
  */
-export class ToolsWebSocket {
+export default class ToolsWebSocket {
     private static devtoolsWebSocket: ToolsWebSocket;
     public static get instance() {
         return ToolsWebSocket.devtoolsWebSocket;


### PR DESCRIPTION
This PR adds a new ToolsHost class that is responsible for implementing the FrontendHost APIs that are used by the devtools.

* Adds new class that implements the minimum functions needed for hosting devtools
* Forwards preferences, url requests, and websocket messages to the correct place
* Sends histogram data to extension
* Added unit tests