### PR TITLE
Change encodeMessageForChannel to take object

### DIFF
--- a/src/common/webviewEvents.test.ts
+++ b/src/common/webviewEvents.test.ts
@@ -11,10 +11,10 @@ describe("webviewEvents", () => {
     describe("parseMessageFromChannel", () => {
         it("calls emit on events", async () => {
             for (const e of webviewEventNames) {
-                const expectedArgs = [{
+                const expectedArgs = {
                     name: e,
                     someArg: "hello",
-                }];
+                };
 
                 // Generate a message we can use for parsing
                 let data = "";
@@ -38,10 +38,10 @@ describe("webviewEvents", () => {
     describe("postMessageAcrossChannel", () => {
         it("calls postMessageCallback with encoded data", async () => {
             for (const e of webviewEventNames) {
-                const expectedArgs = [{
+                const expectedArgs = {
                     name: e,
                     someArg: "hello",
-                }];
+                };
                 const expectedFormat = `${e}:${JSON.stringify(expectedArgs)}`;
 
                 const mockPostMessage = jest.fn();

--- a/src/common/webviewEvents.ts
+++ b/src/common/webviewEvents.ts
@@ -50,13 +50,13 @@ export function parseMessageFromChannel(
  * The message can be parsed on the other side using parseMessageFromChannel
  * @param postMessageObject The object which contains the postMessage function
  * @param eventType The type of the message to post
- * @param args Any arguments to encode and post
+ * @param args The argument object to encode and post
  * @param origin The origin (if any) to use with the postMessage call
  */
 export function encodeMessageForChannel(
     postMessageCallback: (message: string) => void,
     eventType: WebviewEvent,
-    args?: any[]) {
+    args?: object) {
     const message = `${eventType}:${JSON.stringify(args)}`;
     postMessageCallback(message);
 }

--- a/src/devtoolsPanel.test.ts
+++ b/src/devtoolsPanel.test.ts
@@ -168,7 +168,7 @@ describe("devtoolsPanel", () => {
             expect(mockWebviewEvents.encodeMessageForChannel).toHaveBeenCalledWith(
                 expect.any(Function),
                 "websocket",
-                [expectedEvent, expectedMessage],
+                {event: expectedEvent, message: expectedMessage},
             );
 
             // Ensure that the encoded message is actually passed over to the webview
@@ -226,7 +226,7 @@ describe("devtoolsPanel", () => {
                 expect(mockWebviewEvents.encodeMessageForChannel).toHaveBeenCalledWith(
                     expect.any(Function),
                     "getState",
-                    [{ ...expectedId, preferences: expectedState }],
+                    { ...expectedId, preferences: expectedState },
                 );
 
                 // Ensure that the encoded message is actually passed over to the webview
@@ -248,7 +248,7 @@ describe("devtoolsPanel", () => {
                 expect(mockWebviewEvents.encodeMessageForChannel).toHaveBeenCalledWith(
                     expect.any(Function),
                     "getState",
-                    [{ ...expectedId, preferences: SETTINGS_PREF_DEFAULTS }],
+                    { ...expectedId, preferences: SETTINGS_PREF_DEFAULTS },
                 );
             });
 
@@ -308,7 +308,7 @@ describe("devtoolsPanel", () => {
                 expect(mockWebviewEvents.encodeMessageForChannel).toHaveBeenCalledWith(
                     expect.any(Function),
                     "getUrl",
-                    [{ id: expectedRequest.id, content: expectedContent }],
+                    { id: expectedRequest.id, content: expectedContent },
                 );
 
                 // Ensure that the encoded message is actually passed over to the webview
@@ -337,7 +337,7 @@ describe("devtoolsPanel", () => {
                 expect(mockWebviewEvents.encodeMessageForChannel).toHaveBeenCalledWith(
                     expect.any(Function),
                     "getUrl",
-                    [{ id: expectedRequest.id, content: "" }],
+                    { id: expectedRequest.id, content: "" },
                 );
             });
         });

--- a/src/devtoolsPanel.ts
+++ b/src/devtoolsPanel.ts
@@ -70,7 +70,7 @@ export class DevToolsPanel {
     }
 
     private postToDevTools(e: WebSocketEvent, message?: string) {
-        encodeMessageForChannel((msg) => this.panel.webview.postMessage(msg), "websocket", [e, message]);
+        encodeMessageForChannel((msg) => this.panel.webview.postMessage(msg), "websocket", { event: e, message });
     }
 
     private onSocketReady() {
@@ -88,7 +88,7 @@ export class DevToolsPanel {
     private onSocketGetState(message: string) {
         const { id } = JSON.parse(message) as { id: number };
         const preferences: any = this.context.workspaceState.get(SETTINGS_PREF_NAME) || SETTINGS_PREF_DEFAULTS;
-        encodeMessageForChannel((msg) => this.panel.webview.postMessage(msg), "getState", [{ id, preferences }]);
+        encodeMessageForChannel((msg) => this.panel.webview.postMessage(msg), "getState", { id, preferences });
     }
 
     private onSocketSetState(message: string) {
@@ -110,7 +110,7 @@ export class DevToolsPanel {
             // Response will not have content
         }
 
-        encodeMessageForChannel((msg) => this.panel.webview.postMessage(msg), "getUrl", [{ id: request.id, content }]);
+        encodeMessageForChannel((msg) => this.panel.webview.postMessage(msg), "getUrl", { id: request.id, content });
     }
 
     private update() {

--- a/src/host/toolsHost.test.ts
+++ b/src/host/toolsHost.test.ts
@@ -42,7 +42,7 @@ describe("toolsHost", () => {
             expect(mockWebviewEvents.encodeMessageForChannel).toHaveBeenCalledWith(
                 expect.any(Function),
                 "getState",
-                expect.objectContaining([{ id: 0 }]),
+                expect.objectContaining({ id: 0 }),
             );
 
             // Ensure that the encoded message is actually passed over to the extension
@@ -88,7 +88,7 @@ describe("toolsHost", () => {
             expect(mockWebviewEvents.encodeMessageForChannel).toHaveBeenCalledWith(
                 expect.any(Function),
                 "setState",
-                [expectedPref],
+                expectedPref,
             );
 
             // Ensure that the encoded message is actually passed over to the extension
@@ -114,7 +114,7 @@ describe("toolsHost", () => {
             expect(mockWebviewEvents.encodeMessageForChannel).toHaveBeenCalledWith(
                 expect.any(Function),
                 "telemetry",
-                expect.objectContaining([expectedTelemetry]),
+                expect.objectContaining(expectedTelemetry),
             );
 
             // Ensure that the encoded message is actually passed over to the extension
@@ -140,7 +140,7 @@ describe("toolsHost", () => {
             expect(mockWebviewEvents.encodeMessageForChannel).toHaveBeenCalledWith(
                 expect.any(Function),
                 "telemetry",
-                expect.objectContaining([expectedTelemetry]),
+                expect.objectContaining(expectedTelemetry),
             );
 
             // Ensure that the encoded message is actually passed over to the extension
@@ -156,7 +156,7 @@ describe("toolsHost", () => {
             const { default: toolsHost } = await import("./toolsHost");
             const host = new toolsHost(mockResourceLoader);
 
-            const expectedArgs = {id: 0, content: "some content"};
+            const expectedArgs = { id: 0, content: "some content" };
             host.onMessageFromChannel("getUrl", JSON.stringify(expectedArgs));
 
             expect(mockResourceLoader.onResolvedUrlFromChannel).toHaveBeenCalledWith(
@@ -176,12 +176,12 @@ describe("toolsHost", () => {
             const { default: toolsHost } = await import("./toolsHost");
             const host = new toolsHost(mockResourceLoader);
 
-            const expectedArgs = ["message", "some websocket message"];
+            const expectedArgs = { event: "message", message: "some websocket message" };
             host.onMessageFromChannel("websocket", JSON.stringify(expectedArgs));
 
             expect(mockToolsWS.instance.onMessageFromChannel).toHaveBeenCalledWith(
-                expectedArgs[0],
-                expectedArgs[1],
+                expectedArgs.event,
+                expectedArgs.message,
             );
         });
     });

--- a/src/host/toolsHost.ts
+++ b/src/host/toolsHost.ts
@@ -23,12 +23,12 @@ export default class ToolsHost {
         // Load the preference via the extension workspaceState
         const id = this.getStateNextId++;
         this.getStateCallbacks.set(id, callback);
-        encodeMessageForChannel((msg) => window.parent.postMessage(msg, "*"), "getState", [{ id }]);
+        encodeMessageForChannel((msg) => window.parent.postMessage(msg, "*"), "getState", { id });
     }
 
     public setPreference(name: string, value: string) {
         // Save the preference via the extension workspaceState
-        encodeMessageForChannel((msg) => window.parent.postMessage(msg, "*"), "setState", [{ name, value }]);
+        encodeMessageForChannel((msg) => window.parent.postMessage(msg, "*"), "setState", { name, value });
     }
 
     public recordEnumeratedHistogram(actionName: string, actionCode: number, bucketSize: number) {
@@ -64,8 +64,8 @@ export default class ToolsHost {
             }
 
             case "websocket": {
-                const [webSocketEvent, message] = JSON.parse(args);
-                this.fireWebSocketCallback(webSocketEvent, message);
+                const { event, message } = JSON.parse(args);
+                this.fireWebSocketCallback(event, message);
                 break;
             }
         }
@@ -74,7 +74,7 @@ export default class ToolsHost {
 
     private sendTelemetry(telemetry: ITelemetryData) {
         // Forward the data to the extension
-        encodeMessageForChannel((msg) => window.parent.postMessage(msg, "*"), "telemetry", [telemetry]);
+        encodeMessageForChannel((msg) => window.parent.postMessage(msg, "*"), "telemetry", telemetry);
     }
 
     private fireGetStateCallback(id: number, preferences: object) {

--- a/src/host/toolsWebSocket.test.ts
+++ b/src/host/toolsWebSocket.test.ts
@@ -35,7 +35,6 @@ describe("toolsWebSocket", () => {
             expect(mockWebviewEvents.encodeMessageForChannel).toHaveBeenCalledWith(
                 expect.any(Function),
                 "ready",
-                [""],
             );
 
             const expectedPostedMessage = "encodedMessage";
@@ -56,7 +55,7 @@ describe("toolsWebSocket", () => {
             expect(mockWebviewEvents.encodeMessageForChannel).toHaveBeenCalledWith(
                 expect.any(Function),
                 "websocket",
-                [expectedMessage],
+                { message: expectedMessage },
             );
 
             const expectedPostedMessage = "encodedMessage";

--- a/src/host/toolsWebSocket.ts
+++ b/src/host/toolsWebSocket.ts
@@ -27,12 +27,12 @@ export default class ToolsWebSocket {
     constructor(url: string) {
         ToolsWebSocket.devtoolsWebSocket = this;
         // Inform the extension that we are ready to receive messages
-        encodeMessageForChannel((msg) => window.parent.postMessage(msg, "*"), "ready", [""]);
+        encodeMessageForChannel((msg) => window.parent.postMessage(msg, "*"), "ready");
     }
 
     public send(message: string) {
         // Forward the message to the extension
-        encodeMessageForChannel((msg) => window.parent.postMessage(msg, "*"), "websocket", [message]);
+        encodeMessageForChannel((msg) => window.parent.postMessage(msg, "*"), "websocket", { message });
     }
 
     public onMessageFromChannel(e: WebSocketEvent, message?: string) {

--- a/src/panelSocket.test.ts
+++ b/src/panelSocket.test.ts
@@ -93,7 +93,7 @@ describe("panelSocket", () => {
 
         // Queue up some messages and make sure they haven't been sent
         for (const m of expectedMessages) {
-            panelSocket.onMessageFromWebview(`websocket:"${m}"`);
+            panelSocket.onMessageFromWebview(`websocket:${JSON.stringify({ message: m })}`);
         }
         expect(mockWebSocket.send).not.toBeCalled();
 
@@ -105,8 +105,9 @@ describe("panelSocket", () => {
         });
 
         // Now the websocket is open, send a final message that should not be queued up
-        panelSocket.onMessageFromWebview(`websocket:"{final}"`);
-        expect(mockWebSocket.send).toHaveBeenLastCalledWith("{final}");
+        const expectedFinalMessage = "{final}";
+        panelSocket.onMessageFromWebview(`websocket:${JSON.stringify({ message: expectedFinalMessage })}`);
+        expect(mockWebSocket.send).toHaveBeenLastCalledWith(expectedFinalMessage);
     });
 
     it("posts back messages once connected", async () => {

--- a/src/panelSocket.ts
+++ b/src/panelSocket.ts
@@ -45,14 +45,14 @@ export class PanelSocket extends EventEmitter {
                 this.connectToTarget();
             }
 
-            const data = JSON.parse(args[0]);
-            if (data && data[0] === "{") {
+            const { message } = JSON.parse(args[0]);
+            if (message && message[0] === "{") {
                 if (!this.isConnected) {
                     // DevTools are sending a message before the real websocket has finished opening so cache it
-                    this.messages.push(data);
+                    this.messages.push(message);
                 } else {
                     // Websocket ready so send the message directly
-                    this.socket!.send(data);
+                    this.socket!.send(message);
                 }
             }
         }


### PR DESCRIPTION
This PR changes the encodeMessageForChannel function to accept a single argument object rather than forcing an array. The array was causing complications when the tools were actually trying to post websocket messages and made the logic harder to understand. Most places were sending an array with only one element anyway.

* Changes argument type to object
* Coverted to use object destructuring
* Updated tests