### PR TITLE
Adding icons for upcoming sidepanel view

### DIFF
--- a/resources/dark/app.svg
+++ b/resources/dark/app.svg
@@ -1,0 +1,92 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="22"
+   height="22"
+   version="1.1"
+   id="svg5288"
+   sodipodi:docname="app.svg"
+   inkscape:version="0.92.3 (2405546, 2018-03-11)">
+  <metadata
+     id="metadata5294">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs5292" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="2560"
+     inkscape:window-height="1377"
+     id="namedview5290"
+     showgrid="true"
+     inkscape:zoom="22.627417"
+     inkscape:cx="8.4232539"
+     inkscape:cy="5.3953736"
+     inkscape:window-x="1192"
+     inkscape:window-y="1432"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg5288"
+     inkscape:snap-bbox="true">
+    <inkscape:grid
+       originx="0"
+       originy="0"
+       type="xygrid"
+       id="grid8172" />
+  </sodipodi:namedview>
+  <style
+     type="text/css"
+     id="style5282">.icon-canvas-transparent{opacity:0;fill:#F6F6F6;} .icon-vs-out{opacity:0;fill:#F6F6F6;} .icon-vs-bg{fill:#656565;} .icon-vs-fg{fill:#F0EFF1;}</style>
+  <path
+     class="icon-canvas-transparent"
+     d="M 16,22 H 0 V 6 h 16 z"
+     id="canvas"
+     inkscape:connector-curvature="0"
+     style="opacity:0;fill:#f6f6f6" />
+  <path
+     class="icon-vs-out"
+     d="m 2.939,20 c -0.97,0 -2,-0.701 -2,-2 V 8 c 0,-1.299 1.03,-2 2,-2 H 9 l 3.939,3.556 V 18 c 0,0.97 -0.701,2 -2,2 z"
+     id="outline"
+     inkscape:connector-curvature="0"
+     style="opacity:0;fill:#f6f6f6" />
+  <path
+     style="fill:#c5c5c5;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+     d="M 2.7753907,3 C 2.3458795,3 2,3.3467621 2,3.7773438 V 15.222656 C 2,15.653238 2.3458795,16 2.7753907,16 H 4 V 14 6 h 12 v 3 h 2 V 3.7773438 C 18,3.346762 17.654121,3 17.224609,3 Z"
+     id="rect8154"
+     inkscape:connector-curvature="0"
+     sodipodi:nodetypes="ssssccccccsss" />
+  <g
+     id="g3665"
+     transform="translate(-2.65153,1.973829)">
+    <path
+       inkscape:connector-curvature="0"
+       id="rect931"
+       d="m 12.268712,8.0000004 c -0.129219,0 -0.258265,0.041082 -0.357248,0.1396656 l -3.4161779,3.243568 -1.379877,1.304048 c -0.1979645,0.187314 -0.1979645,0.489646 0,0.678603 l 1.379877,1.307992 3.4161779,3.243568 c 0.197965,0.187313 0.516541,0.187313 0.714488,0 l 1.379877,-1.308075 c 0.197965,-0.187314 0.197965,-0.489644 0,-0.678601 l -3.058934,-2.904598 3.058934,-2.900488 c 0.197965,-0.1873132 0.197965,-0.4904664 0,-0.6786009 L 12.625965,8.1390067 C 12.526957,8.0461722 12.397894,7.999341 12.268726,7.999341 Z"
+       style="fill:#c5c5c5;fill-opacity:1;stroke:none;stroke-width:0.20000002;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    <path
+       style="fill:#c5c5c5;fill-opacity:1;stroke:none;stroke-width:0.20000002;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 18.268713,8.0000004 c 0.129219,0 0.258265,0.041082 0.357248,0.1396656 l 3.416178,3.243568 1.379877,1.304048 c 0.197965,0.187314 0.197965,0.489646 0,0.678603 l -1.379877,1.307992 -3.416178,3.243568 c -0.197965,0.187313 -0.516541,0.187313 -0.714488,0 L 16.531595,16.60937 c -0.197965,-0.187314 -0.197965,-0.489644 0,-0.678601 l 3.058935,-2.904598 -3.058935,-2.900488 c -0.197965,-0.1873132 -0.197965,-0.4904664 0,-0.6786009 L 17.91146,8.1390067 C 18.01047,8.0461717 18.139531,7.999341 18.268699,7.999341 Z"
+       id="path8177"
+       inkscape:connector-curvature="0" />
+  </g>
+</svg>

--- a/resources/dark/attach.svg
+++ b/resources/dark/attach.svg
@@ -1,0 +1,81 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   version="1.1"
+   id="svg5288"
+   sodipodi:docname="attach.svg"
+   inkscape:version="0.92.3 (2405546, 2018-03-11)">
+  <metadata
+     id="metadata5294">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs5292" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1920"
+     inkscape:window-height="1017"
+     id="namedview5290"
+     showgrid="false"
+     inkscape:zoom="14.75"
+     inkscape:cx="-28.971391"
+     inkscape:cy="-0.89834203"
+     inkscape:window-x="-8"
+     inkscape:window-y="-8"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg5288" />
+  <style
+     type="text/css"
+     id="style5282">.icon-canvas-transparent{opacity:0;fill:#F6F6F6;} .icon-vs-out{opacity:0;fill:#F6F6F6;} .icon-vs-bg{fill:#656565;} .icon-vs-fg{fill:#F0EFF1;}</style>
+  <path
+     class="icon-canvas-transparent"
+     d="M16 16h-16v-16h16v16z"
+     id="canvas" />
+  <path
+     class="icon-vs-out"
+     d="m 3.2251816,16.355932 c -1.1578935,0 -2.3874092,-0.836787 -2.3874092,-2.387409 V 2.031477 c 0,-1.55062228 1.2295157,-2.3874092 2.3874092,-2.3874092 h 7.2350434 l 4.702003,4.2448136 V 13.968523 c 0,1.157893 -0.836787,2.387409 -2.38741,2.387409 z"
+     id="outline"
+     inkscape:connector-curvature="0"
+     style="opacity:0;fill:#f6f6f6;stroke-width:1" />
+  <path
+     style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#c5c5c5;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+     d="M 2.6586382,2.4254927 A 0.59691199,0.59691199 0 0 0 2.0617859,3.022345 V 13.544198 A 0.59691199,0.59691199 0 0 0 2.6586382,14.14105 H 13.180492 a 0.59691199,0.59691199 0 0 0 0.596852,-0.596852 V 9.4967936 H 12.583639 V 12.947346 H 3.2554905 V 3.6191973 H 6.6244419 V 2.4254927 Z"
+     id="rect5898"
+     inkscape:connector-curvature="0" />
+  <path
+     style="fill:#c5c5c5;fill-opacity:1;stroke:none;stroke-width:0.2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+     d="m 8.1928063,1.8841352 c 0.072582,-0.072582 0.169375,-0.1207764 0.2832891,-0.1180538 l 3.8376846,-2.605e-4 1.546522,-0.00371 c 0.222006,-3.986e-4 0.400848,0.1784434 0.401422,0.4014225 l -0.0014,1.5488543 -2.6e-4,3.8376845 c -3.98e-4,0.2220065 -0.179353,0.400961 -0.401351,0.40135 l -1.549039,0.00118 C 12.087683,7.9529927 11.908841,7.7741506 11.908266,7.5511718 l 1.03e-4,-3.4364926 -3.4340618,0.00253 C 8.2523,4.1176097 8.072972,3.9382819 8.0728845,3.7157887 l 0.00132,-1.548895 C 8.0749093,2.0563614 8.1197076,1.9561607 8.1922657,1.883603 Z"
+     id="path5900"
+     inkscape:connector-curvature="0" />
+  <rect
+     style="fill:#c5c5c5;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+     id="rect5902"
+     width="2.3874097"
+     height="6.676652"
+     x="10.13773"
+     y="-6.1121459"
+     transform="rotate(45)" />
+</svg>

--- a/resources/dark/background_page.svg
+++ b/resources/dark/background_page.svg
@@ -1,0 +1,65 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="22"
+   height="22"
+   version="1.1"
+   id="svg5288"
+   sodipodi:docname="background_page.svg"
+   inkscape:version="0.92.3 (2405546, 2018-03-11)">
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="2560"
+     inkscape:window-height="1377"
+     id="namedview5290"
+     showgrid="true"
+     inkscape:zoom="20.85965"
+     inkscape:cx="15.54776"
+     inkscape:cy="3.0556789"
+     inkscape:window-x="1192"
+     inkscape:window-y="1432"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg5288"
+     inkscape:snap-bbox="true">
+    <inkscape:grid
+       originy="0"
+       originx="0"
+       id="grid8172"
+       type="xygrid" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata5294">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs5292" />
+  <style
+     id="style5282"
+     type="text/css">.icon-canvas-transparent{opacity:0;fill:#F6F6F6;} .icon-vs-out{opacity:0;fill:#F6F6F6;} .icon-vs-bg{fill:#656565;} .icon-vs-fg{fill:#F0EFF1;}</style>
+  <path
+     style="fill:#c5c5c5;fill-opacity:1;stroke:none;stroke-width:0.18897638;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+     d="M 11.666667,0.9941408 A 3.3333334,2.2222222 0 0 0 8.3333336,3.2174482 v 1.110026 H 5.3938804 c -0.2190962,0 -0.3938802,0.174784 -0.3938802,0.3938802 v 2.9394532 h -1.110026 a 2.2222222,3.3333334 0 0 0 -2.2233074,3.3333334 2.2222222,3.3333334 0 0 0 2.2233074,3.333333 h 1.110026 v 2.939454 c 0,0.219096 0.174784,0.39388 0.3938802,0.39388 h 2.9394532 v 1.129556 A 3.3333334,2.2316385 0 0 0 11.666667,21.023438 3.3333334,2.2316385 0 0 0 15,18.790364 v -1.129556 h 2.939454 c 0.219096,0 0.39388,-0.174784 0.39388,-0.39388 V 14.327474 12.660808 H 16.666667 A 1.6666667,1.6666667 0 0 1 15,10.994141 1.6666667,1.6666667 0 0 1 16.666667,9.3274743 h 1.666667 V 7.6608076 4.7213544 c 0,-0.2190962 -0.174784,-0.3938802 -0.39388,-0.3938802 H 15 V 3.2174482 A 3.3333334,2.2222222 0 0 0 11.666667,0.9941408 Z m 0,1.6666667 a 1.6666667,1.6666667 0 0 1 1.666667,1.6666667 v 1.6666667 h 3.05013 c 0.156496,0 0.283203,0.1267062 0.283203,0.2832032 V 7.6608076 H 15.55664 c -1.2273,0 -2.223306,1.4923845 -2.223306,3.3333334 0,1.840948 0.996006,3.333333 2.223306,3.333333 h 1.110027 v 1.383464 c 0,0.156496 -0.126707,0.283203 -0.283203,0.283203 h -3.05013 v 1.666667 A 1.6666667,1.6666667 0 0 1 11.666667,19.327474 1.6666667,1.6666667 0 0 1 10,17.660808 V 15.994141 H 6.9498701 c -0.156497,0 -0.2832032,-0.126707 -0.2832032,-0.283203 v -3.05013 H 5.0000002 A 1.6666667,1.6666667 0 0 1 3.3333335,10.994141 1.6666667,1.6666667 0 0 1 5.0000002,9.3274743 H 6.6666669 V 6.2773441 c 0,-0.156497 0.1267062,-0.2832032 0.2832032,-0.2832032 H 10 V 4.3274742 a 1.6666667,1.6666667 0 0 1 1.666667,-1.6666667 z"
+     id="rect866"
+     inkscape:connector-curvature="0" />
+</svg>

--- a/resources/dark/browser.svg
+++ b/resources/dark/browser.svg
@@ -1,0 +1,92 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="22"
+   height="22"
+   version="1.1"
+   id="svg5288"
+   sodipodi:docname="browser.svg"
+   inkscape:version="0.92.3 (2405546, 2018-03-11)">
+  <metadata
+     id="metadata5294">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs5292" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="2560"
+     inkscape:window-height="1377"
+     id="namedview5290"
+     showgrid="true"
+     inkscape:zoom="22.627417"
+     inkscape:cx="8.4232539"
+     inkscape:cy="5.3953736"
+     inkscape:window-x="1192"
+     inkscape:window-y="1432"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg5288"
+     inkscape:snap-bbox="true">
+    <inkscape:grid
+       originx="0"
+       originy="0"
+       type="xygrid"
+       id="grid8172" />
+  </sodipodi:namedview>
+  <style
+     type="text/css"
+     id="style5282">.icon-canvas-transparent{opacity:0;fill:#F6F6F6;} .icon-vs-out{opacity:0;fill:#F6F6F6;} .icon-vs-bg{fill:#656565;} .icon-vs-fg{fill:#F0EFF1;}</style>
+  <path
+     class="icon-canvas-transparent"
+     d="M 16,22 H 0 V 6 h 16 z"
+     id="canvas"
+     inkscape:connector-curvature="0"
+     style="opacity:0;fill:#f6f6f6" />
+  <path
+     class="icon-vs-out"
+     d="m 2.939,20 c -0.97,0 -2,-0.701 -2,-2 V 8 c 0,-1.299 1.03,-2 2,-2 H 9 l 3.939,3.556 V 18 c 0,0.97 -0.701,2 -2,2 z"
+     id="outline"
+     inkscape:connector-curvature="0"
+     style="opacity:0;fill:#f6f6f6" />
+  <path
+     style="fill:#c5c5c5;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+     d="M 2.7753907,3 C 2.3458795,3 2,3.3467621 2,3.7773438 V 15.222656 C 2,15.653238 2.3458795,16 2.7753907,16 H 4 V 14 6 h 12 v 3 h 2 V 3.7773438 C 18,3.346762 17.654121,3 17.224609,3 Z"
+     id="rect8154"
+     inkscape:connector-curvature="0"
+     sodipodi:nodetypes="ssssccccccsss" />
+  <g
+     id="g3665"
+     transform="translate(-2.65153,1.973829)">
+    <path
+       inkscape:connector-curvature="0"
+       id="rect931"
+       d="m 12.268712,8.0000004 c -0.129219,0 -0.258265,0.041082 -0.357248,0.1396656 l -3.4161779,3.243568 -1.379877,1.304048 c -0.1979645,0.187314 -0.1979645,0.489646 0,0.678603 l 1.379877,1.307992 3.4161779,3.243568 c 0.197965,0.187313 0.516541,0.187313 0.714488,0 l 1.379877,-1.308075 c 0.197965,-0.187314 0.197965,-0.489644 0,-0.678601 l -3.058934,-2.904598 3.058934,-2.900488 c 0.197965,-0.1873132 0.197965,-0.4904664 0,-0.6786009 L 12.625965,8.1390067 C 12.526957,8.0461722 12.397894,7.999341 12.268726,7.999341 Z"
+       style="fill:#c5c5c5;fill-opacity:1;stroke:none;stroke-width:0.20000002;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    <path
+       style="fill:#c5c5c5;fill-opacity:1;stroke:none;stroke-width:0.20000002;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 18.268713,8.0000004 c 0.129219,0 0.258265,0.041082 0.357248,0.1396656 l 3.416178,3.243568 1.379877,1.304048 c 0.197965,0.187314 0.197965,0.489646 0,0.678603 l -1.379877,1.307992 -3.416178,3.243568 c -0.197965,0.187313 -0.516541,0.187313 -0.714488,0 L 16.531595,16.60937 c -0.197965,-0.187314 -0.197965,-0.489644 0,-0.678601 l 3.058935,-2.904598 -3.058935,-2.900488 c -0.197965,-0.1873132 -0.197965,-0.4904664 0,-0.6786009 L 17.91146,8.1390067 C 18.01047,8.0461717 18.139531,7.999341 18.268699,7.999341 Z"
+       id="path8177"
+       inkscape:connector-curvature="0" />
+  </g>
+</svg>

--- a/resources/dark/external.svg
+++ b/resources/dark/external.svg
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="22"
+   height="22"
+   version="1.1"
+   id="svg5288"
+   sodipodi:docname="external.svg"
+   inkscape:version="0.92.3 (2405546, 2018-03-11)">
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="2560"
+     inkscape:window-height="1377"
+     id="namedview5290"
+     showgrid="true"
+     inkscape:zoom="20.85965"
+     inkscape:cx="7.7576005"
+     inkscape:cy="3.0556789"
+     inkscape:window-x="1192"
+     inkscape:window-y="1432"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg5288"
+     inkscape:snap-bbox="true">
+    <inkscape:grid
+       originy="0"
+       originx="0"
+       id="grid8172"
+       type="xygrid" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata5294">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs5292" />
+  <style
+     id="style5282"
+     type="text/css">.icon-canvas-transparent{opacity:0;fill:#F6F6F6;} .icon-vs-out{opacity:0;fill:#F6F6F6;} .icon-vs-bg{fill:#656565;} .icon-vs-fg{fill:#F0EFF1;}</style>
+  <path
+     style="fill:#c5c5c5;fill-opacity:1;stroke:none;stroke-width:0.18897638;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+     d="M 5 3 L 5 19 L 18 19 L 18 8 L 13 3 L 5 3 z M 7 5 L 12 5 L 12 9 L 16 9 L 16 17 L 7 17 L 7 5 z "
+     id="rect814" />
+</svg>

--- a/resources/dark/iframe.svg
+++ b/resources/dark/iframe.svg
@@ -1,0 +1,76 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="22"
+   height="22"
+   version="1.1"
+   id="svg5288"
+   sodipodi:docname="iframe.svg"
+   inkscape:version="0.92.3 (2405546, 2018-03-11)">
+  <metadata
+     id="metadata5294">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs5292" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="2560"
+     inkscape:window-height="1377"
+     id="namedview5290"
+     showgrid="true"
+     inkscape:zoom="41.7193"
+     inkscape:cx="8.0683923"
+     inkscape:cy="7.8702607"
+     inkscape:window-x="1192"
+     inkscape:window-y="1432"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg5288"
+     inkscape:snap-bbox="true">
+    <inkscape:grid
+       originx="0"
+       originy="0"
+       type="xygrid"
+       id="grid8172" />
+  </sodipodi:namedview>
+  <style
+     type="text/css"
+     id="style5282">.icon-canvas-transparent{opacity:0;fill:#F6F6F6;} .icon-vs-out{opacity:0;fill:#F6F6F6;} .icon-vs-bg{fill:#656565;} .icon-vs-fg{fill:#F0EFF1;}</style>
+  <path
+     class="icon-canvas-transparent"
+     d="M 16,22 H 0 V 6 h 16 z"
+     id="canvas"
+     inkscape:connector-curvature="0"
+     style="opacity:0;fill:#f6f6f6" />
+  <path
+     class="icon-vs-out"
+     d="M 4,21 C 3.03,21 2,20.299 2,19 V 9 C 2,7.701 3.03,7 4,7 h 6.061 L 14,10.556 V 19 c 0,0.97 -0.701,2 -2,2 z"
+     id="outline"
+     inkscape:connector-curvature="0"
+     style="opacity:0;fill:#f6f6f6" />
+  <path
+     style="fill:#c5c5c5;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+     d="M 3.7753906 4 C 3.3458795 4 3 4.3467621 3 4.7773438 L 3 16.222656 C 3 16.653238 3.3458795 17 3.7753906 17 L 18.224609 17 C 18.654121 17 19 16.653238 19 16.222656 L 19 4.7773438 C 19 4.3467621 18.654121 4 18.224609 4 L 3.7753906 4 z M 5 7 L 17 7 L 17 15 L 5 15 L 5 7 z "
+     id="rect8154" />
+</svg>

--- a/resources/dark/other.svg
+++ b/resources/dark/other.svg
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="22"
+   height="22"
+   version="1.1"
+   id="svg5288"
+   sodipodi:docname="other.svg"
+   inkscape:version="0.92.3 (2405546, 2018-03-11)">
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="2560"
+     inkscape:window-height="1377"
+     id="namedview5290"
+     showgrid="true"
+     inkscape:zoom="20.85965"
+     inkscape:cx="15.54776"
+     inkscape:cy="3.0556789"
+     inkscape:window-x="1192"
+     inkscape:window-y="1432"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg5288"
+     inkscape:snap-bbox="true">
+    <inkscape:grid
+       originy="0"
+       originx="0"
+       id="grid8172"
+       type="xygrid" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata5294">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs5292" />
+  <style
+     id="style5282"
+     type="text/css">.icon-canvas-transparent{opacity:0;fill:#F6F6F6;} .icon-vs-out{opacity:0;fill:#F6F6F6;} .icon-vs-bg{fill:#656565;} .icon-vs-fg{fill:#F0EFF1;}</style>
+  <path
+     style="fill:#c5c5c5;fill-opacity:1;stroke:none;stroke-width:0.18897638;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+     d="M 5 3 L 5 19 L 18 19 L 18 8 L 13 3 L 5 3 z M 7 5 L 12 5 L 12 9 L 16 9 L 16 17 L 7 17 L 7 5 z "
+     id="rect814" />
+</svg>

--- a/resources/dark/page.svg
+++ b/resources/dark/page.svg
@@ -1,0 +1,79 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="22"
+   height="22"
+   version="1.1"
+   id="svg5288"
+   sodipodi:docname="page.svg"
+   inkscape:version="0.92.3 (2405546, 2018-03-11)">
+  <metadata
+     id="metadata5294">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs5292" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="2560"
+     inkscape:window-height="1377"
+     id="namedview5290"
+     showgrid="true"
+     inkscape:zoom="41.7193"
+     inkscape:cx="4.3841399"
+     inkscape:cy="8.4367158"
+     inkscape:window-x="1192"
+     inkscape:window-y="1432"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg5288">
+    <inkscape:grid
+       type="xygrid"
+       id="grid8175" />
+  </sodipodi:namedview>
+  <style
+     type="text/css"
+     id="style5282">.icon-canvas-transparent{opacity:0;fill:#F6F6F6;} .icon-vs-out{opacity:0;fill:#F6F6F6;} .icon-vs-bg{fill:#656565;} .icon-vs-fg{fill:#F0EFF1;}</style>
+  <path
+     class="icon-canvas-transparent"
+     d="M 16,22 H 0 V 6 h 16 z"
+     id="canvas"
+     inkscape:connector-curvature="0"
+     style="opacity:0;fill:#f6f6f6" />
+  <path
+     class="icon-vs-out"
+     d="M 4,21 C 3.03,21 2,20.299 2,19 V 9 C 2,7.701 3.03,7 4,7 h 6.061 L 14,10.556 V 19 c 0,0.97 -0.701,2 -2,2 z"
+     id="outline"
+     inkscape:connector-curvature="0"
+     style="opacity:0;fill:#f6f6f6" />
+  <path
+     style="fill:#c5c5c5;fill-opacity:1;stroke:none;stroke-width:0.20000002;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+     d="M 8,7 C 7.8707804,7 7.7417342,7.041082 7.6427519,7.1396656 l -3.4161783,3.2435684 -1.379877,1.304048 c -0.1979645,0.187314 -0.1979645,0.489646 0,0.678603 l 1.379877,1.307992 3.4161783,3.243568 c 0.1979645,0.187313 0.5165409,0.187313 0.7144875,0 L 9.7371166,15.60937 c 0.197965,-0.187314 0.197965,-0.489644 0,-0.678601 l -3.058934,-2.904598 3.058934,-2.9004888 c 0.197965,-0.1873128 0.197965,-0.490466 0,-0.6786005 L 8.3572529,7.1390063 C 8.2582443,7.0461718 8.1291815,6.9993406 8.0000135,6.9993406 Z"
+     id="rect931"
+     inkscape:connector-curvature="0" />
+  <path
+     inkscape:connector-curvature="0"
+     id="path8177"
+     d="m 14,7 c 0.129219,0 0.258265,0.041082 0.357248,0.1396656 l 3.416178,3.2435684 1.379877,1.304048 c 0.197965,0.187314 0.197965,0.489646 0,0.678603 l -1.379877,1.307992 -3.416178,3.243568 c -0.197965,0.187313 -0.516541,0.187313 -0.714488,0 L 12.262883,15.60937 c -0.197965,-0.187314 -0.197965,-0.489644 0,-0.678601 l 3.058934,-2.904598 -3.058934,-2.9004888 c -0.197965,-0.1873128 -0.197965,-0.490466 0,-0.6786005 l 1.379864,-1.3080754 c 0.09901,-0.092835 0.228071,-0.1396657 0.357239,-0.1396657 z"
+     style="fill:#c5c5c5;fill-opacity:1;stroke:none;stroke-width:0.20000002;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+</svg>

--- a/resources/dark/refresh.svg
+++ b/resources/dark/refresh.svg
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   version="1.1"
+   id="svg7042"
+   sodipodi:docname="refresh.svg"
+   inkscape:version="0.92.3 (2405546, 2018-03-11)">
+  <metadata
+     id="metadata7048">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs7046" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1920"
+     inkscape:window-height="1017"
+     id="namedview7044"
+     showgrid="false"
+     inkscape:zoom="14.75"
+     inkscape:cx="8"
+     inkscape:cy="8"
+     inkscape:window-x="-8"
+     inkscape:window-y="-8"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg7042" />
+  <path
+     d="M12.6 6.134l-.094.071c-.269.333-.746 1.096-.91 2.375.057.277.092.495.092.545 0 2.206-1.794 4-4 4-1.098 0-2.093-.445-2.817-1.164-.718-.724-1.163-1.718-1.163-2.815 0-2.206 1.794-4 4-4l.351.025v1.85s1.626-1.342 1.631-1.339l1.869-1.577-3.5-2.917v2.218l-.371-.03c-3.176 0-5.75 2.574-5.75 5.75 0 1.593.648 3.034 1.695 4.076 1.042 1.046 2.482 1.694 4.076 1.694 3.176 0 5.75-2.574 5.75-5.75-.001-1.106-.318-2.135-.859-3.012z"
+     fill="#C5C5C5"
+     id="path7040" />
+</svg>

--- a/resources/dark/service_worker.svg
+++ b/resources/dark/service_worker.svg
@@ -1,0 +1,82 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="22"
+   height="22"
+   version="1.1"
+   id="svg5288"
+   sodipodi:docname="service_worker.svg"
+   inkscape:version="0.92.3 (2405546, 2018-03-11)">
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="2560"
+     inkscape:window-height="1377"
+     id="namedview5290"
+     showgrid="true"
+     inkscape:zoom="41.7193"
+     inkscape:cx="8.0683923"
+     inkscape:cy="7.8702607"
+     inkscape:window-x="1192"
+     inkscape:window-y="1432"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg5288"
+     inkscape:snap-bbox="true">
+    <inkscape:grid
+       originy="0"
+       originx="0"
+       id="grid8172"
+       type="xygrid" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata5294">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs5292" />
+  <style
+     id="style5282"
+     type="text/css">.icon-canvas-transparent{opacity:0;fill:#F6F6F6;} .icon-vs-out{opacity:0;fill:#F6F6F6;} .icon-vs-bg{fill:#656565;} .icon-vs-fg{fill:#F0EFF1;}</style>
+  <path
+     style="opacity:0;fill:#f6f6f6"
+     inkscape:connector-curvature="0"
+     id="canvas"
+     d="M 16,22 H 0 V 6 h 16 z"
+     class="icon-canvas-transparent" />
+  <path
+     style="opacity:0;fill:#f6f6f6"
+     inkscape:connector-curvature="0"
+     id="outline"
+     d="M 4,21 C 3.03,21 2,20.299 2,19 V 9 C 2,7.701 3.03,7 4,7 h 6.061 L 14,10.556 V 19 c 0,0.97 -0.701,2 -2,2 z"
+     class="icon-vs-out" />
+  <path
+     style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#c5c5c5;fill-opacity:1;fill-rule:nonzero;stroke:#c5c5c5;stroke-width:0.37795275;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+     d="m 7.1926933,5.992145 -0.5055708,1.5400915 0.00292,0.195799 -0.096438,-0.17242 L 5.389588,6.4772592 3.8115057,7.3890402 4.1417341,8.9700449 4.2469395,9.1424651 4.0745195,9.0372594 2.4905922,8.7070311 1.5788113,10.288036 l 1.0783563,1.204018 0.1724201,0.09643 -0.1957991,-0.003 -1.5371691,0.502649 v 1.826484 l 1.5371691,0.502648 0.1957991,-0.003 -0.1724201,0.09643 -1.0783563,1.204019 0.9117809,1.581006 1.5839273,-0.333152 0.17242,-0.102284 -0.1052048,0.169497 -0.3302284,1.583928 1.5780823,0.911781 1.2040185,-1.078356 0.096438,-0.172421 -0.00292,0.1958 0.5055709,1.537169 h 1.8235618 l 0.505571,-1.537169 -0.00292,-0.1958 0.096438,0.172421 1.2040182,1.078356 1.578083,-0.911781 -0.330229,-1.583928 -0.105201,-0.169497 0.172421,0.102284 1.583926,0.333152 0.911781,-1.581006 -1.078356,-1.204019 -0.17242,-0.09643 0.195799,0.003 1.537169,-0.502648 v -1.826484 l -1.537169,-0.502649 -0.195799,0.003 0.17242,-0.09643 1.078361,-1.204018 -0.911781,-1.5810049 -1.583926,0.3302283 -0.172421,0.1052063 0.105201,-0.1724202 0.330219,-1.5810053 -1.578082,-0.911781 -1.2040189,1.0783563 -0.096438,0.17242 0.00292,-0.195799 -0.505571,-1.5400915 z m 0.9117809,4.278357 A 2.7313908,2.730667 0 0 1 10.836895,13 2.7313908,2.730667 0 0 1 8.1044742,15.729497 2.7313908,2.730667 0 0 1 5.3720539,13 2.7313908,2.730667 0 0 1 8.1044742,10.270502 Z m 3.2730598,0.683835 0.09936,0.09937 0.05845,0.222096 a 3.8590267,3.8375958 0 0 0 -0.157808,-0.321462 z m 0.452969,1.41443 L 12,13 11.476895,14.949224 10.050776,16.375342 8.1044742,16.898447 6.1581727,16.375342 5.553241,15.770411 a 3.8590267,3.8375958 0 0 0 2.4489502,0.873791 3.8590267,3.8375958 0 0 0 3.8604568,-3.837078 3.8590267,3.8375958 0 0 0 -0.03214,-0.438357 z M 4.6794511,14.747579 A 3.8590267,3.8375958 0 0 0 5.0213689,15.23854 L 4.7320538,14.949224 Z"
+     id="path841"
+     inkscape:connector-curvature="0" />
+  <path
+     id="path864"
+     d="m 16.140381,0.81933236 -0.299033,0.91092564 0.0018,0.1158085 -0.05702,-0.101982 -0.712146,-0.6378206 -0.933397,0.5392954 0.195319,0.9351248 0.06223,0.1019838 -0.102018,-0.062228 -0.936854,-0.1953215 -0.539295,0.9351247 0.637822,0.7121463 0.101986,0.057043 -0.115792,-0.00173 -0.909198,0.2973044 v 1.0803195 l 0.909198,0.2973037 0.115792,-0.00173 -0.101986,0.057041 -0.637822,0.7121472 0.539295,0.9351253 0.936854,-0.1970525 0.101985,-0.060489 -0.06225,0.1002554 -0.195319,0.9368541 0.933395,0.5392956 0.712148,-0.6378219 0.05702,-0.1019871 -0.0018,0.115802 0.299032,0.9091983 h 1.07859 l 0.299033,-0.9091983 -0.0018,-0.115802 0.05702,0.1019871 0.712148,0.6378219 0.933398,-0.5393059 -0.195319,-0.9368541 -0.06223,-0.1002554 0.101985,0.060489 0.93687,0.1970525 0.53938,-0.9351278 L 19.90158,5.857928 19.799595,5.800885 19.915403,5.802615 20.824601,5.5053113 V 4.4250074 L 19.91538,4.127703 19.799572,4.1294329 19.901557,4.072392 20.539379,3.3602458 20.000084,2.425121 19.063231,2.6204425 18.961245,2.68267 19.023474,2.5806863 19.218794,1.6455616 18.285397,1.106266 17.573252,1.7440868 17.516229,1.8460705 17.518059,1.7302619 17.219016,0.81933386 Z M 16.679676,3.3498731 A 1.6155491,1.6151211 0 0 1 18.295833,4.964303 1.6155491,1.6151211 0 0 1 16.679676,6.5787318 1.6155491,1.6151211 0 0 1 15.063518,4.964303 1.6155491,1.6151211 0 0 1 16.679676,3.3498731 Z m 1.935933,0.4044716 0.05877,0.058769 0.03458,0.1313667 A 2.2825175,2.2698416 0 0 0 18.615643,3.7543442 Z M 18.883528,4.5909445 18.983783,4.964303 18.674375,6.1172198 17.830867,6.960733 16.679678,7.2701373 15.52849,6.960733 15.17069,6.6029312 a 2.2825175,2.2698416 0 0 0 1.448492,0.5168259 2.2825175,2.2698416 0 0 0 2.283362,-2.2695357 2.2825175,2.2698416 0 0 0 -0.01895,-0.2592769 z M 14.653861,5.9979521 A 2.2825175,2.2698416 0 0 0 14.856102,6.288343 L 14.684987,6.1172203 Z"
+     style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#c5c5c5;fill-opacity:1;fill-rule:nonzero;stroke:#c5c5c5;stroke-width:0.18897636;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+     inkscape:connector-curvature="0" />
+</svg>

--- a/resources/dark/shared_worker.svg
+++ b/resources/dark/shared_worker.svg
@@ -1,0 +1,96 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="22"
+   height="22"
+   version="1.1"
+   id="svg5288"
+   sodipodi:docname="shared_worker.svg"
+   inkscape:version="0.92.3 (2405546, 2018-03-11)">
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="2560"
+     inkscape:window-height="1377"
+     id="namedview5290"
+     showgrid="true"
+     inkscape:zoom="59"
+     inkscape:cx="13.703578"
+     inkscape:cy="12.124373"
+     inkscape:window-x="1192"
+     inkscape:window-y="1432"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg5288"
+     inkscape:snap-bbox="true">
+    <inkscape:grid
+       originy="0"
+       originx="0"
+       id="grid8172"
+       type="xygrid" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata5294">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs5292" />
+  <style
+     id="style5282"
+     type="text/css">.icon-canvas-transparent{opacity:0;fill:#F6F6F6;} .icon-vs-out{opacity:0;fill:#F6F6F6;} .icon-vs-bg{fill:#656565;} .icon-vs-fg{fill:#F0EFF1;}</style>
+  <path
+     style="opacity:0;fill:#f6f6f6"
+     inkscape:connector-curvature="0"
+     id="canvas"
+     d="M 16,22 H 0 V 6 h 16 z"
+     class="icon-canvas-transparent" />
+  <path
+     style="opacity:0;fill:#f6f6f6"
+     inkscape:connector-curvature="0"
+     id="outline"
+     d="M 4,21 C 3.03,21 2,20.299 2,19 V 9 C 2,7.701 3.03,7 4,7 h 6.061 L 14,10.556 V 19 c 0,0.97 -0.701,2 -2,2 z"
+     class="icon-vs-out" />
+  <path
+     style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#c5c5c5;fill-opacity:1;fill-rule:nonzero;stroke:#c5c5c5;stroke-width:0.37795275;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+     d="M 7.1933594 5.9921875 L 6.6875 7.5332031 L 6.6894531 7.7285156 L 6.59375 7.5546875 L 5.3886719 6.4765625 L 3.8105469 7.3886719 L 4.1425781 8.9707031 L 4.2460938 9.1425781 L 4.0742188 9.0371094 L 2.4902344 8.7070312 L 1.578125 10.287109 L 2.65625 11.492188 L 2.8300781 11.587891 L 2.6328125 11.585938 L 1.0957031 12.087891 L 1.0957031 13.914062 L 2.6328125 14.417969 L 2.8300781 14.414062 L 2.65625 14.509766 L 1.578125 15.714844 L 2.4902344 17.294922 L 4.0742188 16.962891 L 4.2460938 16.859375 L 4.1425781 17.029297 L 3.8105469 18.613281 L 5.3886719 19.525391 L 6.59375 18.447266 L 6.6894531 18.275391 L 6.6875 18.470703 L 7.1933594 20.007812 L 9.015625 20.007812 L 9.5214844 18.470703 L 9.5195312 18.275391 L 9.6152344 18.447266 L 10.820312 19.525391 L 12.396484 18.613281 L 12.066406 17.029297 L 11.962891 16.859375 L 12.134766 16.962891 L 13.71875 17.294922 L 14.630859 15.714844 L 13.552734 14.509766 L 13.378906 14.414062 L 13.574219 14.417969 L 15.113281 13.914062 L 15.113281 12.087891 L 13.574219 11.585938 L 13.378906 11.587891 L 13.552734 11.492188 L 14.630859 10.287109 L 13.71875 8.7070312 L 12.134766 9.0371094 L 11.962891 9.1425781 L 12.066406 8.9707031 L 12.396484 7.3886719 L 10.820312 6.4765625 L 9.6152344 7.5546875 L 9.5195312 7.7285156 L 9.5214844 7.5332031 L 9.015625 5.9921875 L 7.1933594 5.9921875 z M 8 8.9707031 A 4.0672188 4.0297809 0 0 1 12.066406 13 A 4.0672188 4.0297809 0 0 1 8 17.029297 A 4.0672188 4.0297809 0 0 1 3.9335938 13 A 4.0672188 4.0297809 0 0 1 8 8.9707031 z "
+     id="path841" />
+  <path
+     id="path864"
+     d="m 16.140381,0.81933236 -0.299033,0.91092564 0.0018,0.1158085 -0.05702,-0.101982 -0.712146,-0.6378206 -0.933397,0.5392954 0.195319,0.9351248 0.06223,0.1019838 -0.102018,-0.062228 -0.936854,-0.1953215 -0.539295,0.9351247 0.637822,0.7121463 0.101986,0.057043 -0.115792,-0.00173 -0.909198,0.2973044 v 1.0803195 l 0.909198,0.2973037 0.115792,-0.00173 -0.101986,0.057041 -0.637822,0.7121472 0.539295,0.9351253 0.936854,-0.1970525 0.101985,-0.060489 -0.06225,0.1002554 -0.195319,0.9368541 0.933395,0.5392956 0.712148,-0.6378219 0.05702,-0.1019871 -0.0018,0.115802 0.299032,0.9091983 h 1.07859 l 0.299033,-0.9091983 -0.0018,-0.115802 0.05702,0.1019871 0.712148,0.6378219 0.933398,-0.5393059 -0.195319,-0.9368541 -0.06223,-0.1002554 0.101985,0.060489 0.93687,0.1970525 0.53938,-0.9351278 L 19.90158,5.857928 19.799595,5.800885 19.915403,5.802615 20.824601,5.5053113 V 4.4250074 L 19.91538,4.127703 19.799572,4.1294329 19.901557,4.072392 20.539379,3.3602458 20.000084,2.425121 19.063231,2.6204425 18.961245,2.68267 19.023474,2.5806863 19.218794,1.6455616 18.285397,1.106266 17.573252,1.7440868 17.516229,1.8460705 17.518059,1.7302619 17.219016,0.81933386 Z M 16.679676,3.3498731 A 1.6155491,1.6151211 0 0 1 18.295833,4.964303 1.6155491,1.6151211 0 0 1 16.679676,6.5787318 1.6155491,1.6151211 0 0 1 15.063518,4.964303 1.6155491,1.6151211 0 0 1 16.679676,3.3498731 Z m 1.935933,0.4044716 0.05877,0.058769 0.03458,0.1313667 A 2.2825175,2.2698416 0 0 0 18.615643,3.7543442 Z M 18.883528,4.5909445 18.983783,4.964303 18.674375,6.1172198 17.830867,6.960733 16.679678,7.2701373 15.52849,6.960733 15.17069,6.6029312 a 2.2825175,2.2698416 0 0 0 1.448492,0.5168259 2.2825175,2.2698416 0 0 0 2.283362,-2.2695357 2.2825175,2.2698416 0 0 0 -0.01895,-0.2592769 z M 14.653861,5.9979521 A 2.2825175,2.2698416 0 0 0 14.856102,6.288343 L 14.684987,6.1172203 Z"
+     style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#c5c5c5;fill-opacity:1;fill-rule:nonzero;stroke:#c5c5c5;stroke-width:0.18897636;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+     inkscape:connector-curvature="0" />
+  <rect
+     style="fill:#c5c5c5;fill-opacity:1;stroke:none;stroke-width:0.18897638;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+     id="rect3073"
+     width="2"
+     height="6"
+     x="7"
+     y="10" />
+  <rect
+     y="-11"
+     x="12"
+     height="6"
+     width="2"
+     id="rect3075"
+     style="fill:#c5c5c5;fill-opacity:1;stroke:none;stroke-width:0.18897638;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+     transform="rotate(90)" />
+</svg>

--- a/resources/dark/webview.svg
+++ b/resources/dark/webview.svg
@@ -1,0 +1,90 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="22"
+   height="22"
+   version="1.1"
+   id="svg5288"
+   sodipodi:docname="webview.svg"
+   inkscape:version="0.92.3 (2405546, 2018-03-11)">
+  <metadata
+     id="metadata5294">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs5292" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="2560"
+     inkscape:window-height="1377"
+     id="namedview5290"
+     showgrid="true"
+     inkscape:zoom="41.7193"
+     inkscape:cx="4.1733126"
+     inkscape:cy="7.8702607"
+     inkscape:window-x="1192"
+     inkscape:window-y="1432"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg5288"
+     inkscape:snap-bbox="true">
+    <inkscape:grid
+       originx="0"
+       originy="0"
+       type="xygrid"
+       id="grid8172" />
+  </sodipodi:namedview>
+  <style
+     type="text/css"
+     id="style5282">.icon-canvas-transparent{opacity:0;fill:#F6F6F6;} .icon-vs-out{opacity:0;fill:#F6F6F6;} .icon-vs-bg{fill:#656565;} .icon-vs-fg{fill:#F0EFF1;}</style>
+  <path
+     class="icon-canvas-transparent"
+     d="M 16,22 H 0 V 6 h 16 z"
+     id="canvas"
+     inkscape:connector-curvature="0"
+     style="opacity:0;fill:#f6f6f6" />
+  <path
+     class="icon-vs-out"
+     d="M 4,21 C 3.03,21 2,20.299 2,19 V 9 C 2,7.701 3.03,7 4,7 h 6.061 L 14,10.556 V 19 c 0,0.97 -0.701,2 -2,2 z"
+     id="outline"
+     inkscape:connector-curvature="0"
+     style="opacity:0;fill:#f6f6f6" />
+  <path
+     style="fill:#c5c5c5;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+     d="M 3.7753906 4 C 3.3458795 4 3 4.3467621 3 4.7773438 L 3 16.222656 C 3 16.653238 3.3458795 17 3.7753906 17 L 18.224609 17 C 18.654121 17 19 16.653238 19 16.222656 L 19 4.7773438 C 19 4.3467621 18.654121 4 18.224609 4 L 3.7753906 4 z M 5 7 L 17 7 L 17 15 L 5 15 L 5 7 z "
+     id="rect8154" />
+  <g
+     id="g4263"
+     transform="translate(0.229641)">
+    <path
+       inkscape:connector-curvature="0"
+       id="rect931"
+       d="m 8.999992,8.0003893 c -0.07625,0 -0.152408,0.024243 -0.21082,0.08242 L 6.7732095,9.9969109 5.9589134,10.766459 c -0.1168232,0.110538 -0.1168232,0.288951 0,0.400458 l 0.8142961,0.771875 2.0159625,1.914101 c 0.116823,0.110538 0.304823,0.110538 0.421635,0 l 0.814297,-0.771924 c 0.116823,-0.110538 0.116823,-0.288949 0,-0.400457 L 8.2199585,10.966445 10.025104,9.2548016 c 0.116823,-0.1105374 0.116823,-0.2894349 0,-0.4004572 L 9.210815,8.08242 C 9.152385,8.027636 9.076225,8 9,8 Z"
+       style="fill:#c5c5c5;fill-opacity:1;stroke:none;stroke-width:0.20000002;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    <path
+       style="fill:#c5c5c5;fill-opacity:1;stroke:none;stroke-width:0.20000002;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 12.540726,8.0003893 c 0.07625,0 0.152408,0.024243 0.21082,0.08242 l 2.015962,1.9141018 0.814296,0.7695479 c 0.116824,0.110538 0.116824,0.288951 0,0.400459 l -0.814296,0.771875 -2.015962,1.9141 c -0.116824,0.110538 -0.304823,0.110538 -0.421636,0 l -0.814296,-0.771924 c -0.116823,-0.110538 -0.116823,-0.288949 0,-0.400457 l 1.805145,-1.714067 -1.805145,-1.7116434 c -0.116823,-0.1105374 -0.116823,-0.2894349 0,-0.4004572 L 12.329903,8.08242 C 12.388333,8.027636 12.464492,8 12.540717,8 Z"
+       id="path8177"
+       inkscape:connector-curvature="0" />
+  </g>
+</svg>

--- a/resources/dark/worker.svg
+++ b/resources/dark/worker.svg
@@ -1,0 +1,83 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="22"
+   height="22"
+   version="1.1"
+   id="svg5288"
+   sodipodi:docname="worker.svg"
+   inkscape:version="0.92.3 (2405546, 2018-03-11)">
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="2560"
+     inkscape:window-height="1377"
+     id="namedview5290"
+     showgrid="true"
+     inkscape:zoom="20.85965"
+     inkscape:cx="1.7430031"
+     inkscape:cy="16.161259"
+     inkscape:window-x="1192"
+     inkscape:window-y="1432"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg5288"
+     inkscape:snap-bbox="true">
+    <inkscape:grid
+       originy="0"
+       originx="0"
+       id="grid8172"
+       type="xygrid" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata5294">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs5292" />
+  <style
+     id="style5282"
+     type="text/css">.icon-canvas-transparent{opacity:0;fill:#F6F6F6;} .icon-vs-out{opacity:0;fill:#F6F6F6;} .icon-vs-bg{fill:#656565;} .icon-vs-fg{fill:#F0EFF1;}</style>
+  <path
+     style="opacity:0;fill:#f6f6f6"
+     inkscape:connector-curvature="0"
+     id="canvas"
+     d="M 16,22 H 0 V 6 h 16 z"
+     class="icon-canvas-transparent" />
+  <path
+     style="opacity:0;fill:#f6f6f6"
+     inkscape:connector-curvature="0"
+     id="outline"
+     d="M 4,21 C 3.03,21 2,20.299 2,19 V 9 C 2,7.701 3.03,7 4,7 h 6.061 L 14,10.556 V 19 c 0,0.97 -0.701,2 -2,2 z"
+     class="icon-vs-out" />
+  <path
+     style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#c5c5c5;fill-opacity:1;fill-rule:nonzero;stroke:#c5c5c5;stroke-width:0.37795275;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+     d="m 10.080333,4.077528 -0.5055705,1.5400915 0.00292,0.195799 -0.096438,-0.17242 L 8.277228,4.5626422 6.6991457,5.4744232 7.0293741,7.0554279 7.1345795,7.2278481 6.9621595,7.1226424 5.3782322,6.7924141 4.4664513,8.373419 5.5448076,9.577437 5.7172277,9.673867 5.5214286,9.670867 3.9842595,10.173516 V 12 l 1.5371691,0.502648 0.1957991,-0.003 -0.1724201,0.09643 -1.0783563,1.204019 0.9117809,1.581006 1.5839273,-0.333152 0.17242,-0.102284 -0.1052048,0.169497 -0.3302284,1.583928 1.5780823,0.911781 1.2040185,-1.078356 0.096438,-0.172421 -0.00292,0.1958 0.5055709,1.537169 h 1.823562 l 0.505571,-1.537169 -0.0029,-0.1958 0.09644,0.172421 1.204018,1.078356 1.578083,-0.911781 -0.330229,-1.583928 -0.105201,-0.169497 0.172421,0.102284 1.583926,0.333152 0.911781,-1.581006 -1.078356,-1.204019 -0.17242,-0.09643 0.195799,0.003 L 18,12 v -1.826484 l -1.537169,-0.502649 -0.195799,0.003 0.17242,-0.09643 1.078361,-1.204018 -0.911781,-1.5810049 -1.583926,0.3302283 -0.172421,0.1052063 0.105201,-0.1724202 0.330219,-1.5810053 -1.578082,-0.911781 -1.204019,1.0783563 -0.09644,0.17242 0.0029,-0.195799 -0.505571,-1.5400915 z m 0.911781,4.278357 a 2.7313908,2.730667 0 0 1 2.732421,2.729498 2.7313908,2.730667 0 0 1 -2.732421,2.729497 2.7313908,2.730667 0 0 1 -2.7324201,-2.729497 2.7313908,2.730667 0 0 1 2.7324201,-2.729498 z m 3.27306,0.683835 0.09936,0.09937 0.05845,0.222096 A 3.8590267,3.8375958 0 0 0 14.265176,9.039724 Z m 0.452969,1.41443 0.169497,0.631233 -0.523105,1.949224 -1.426119,1.426118 L 10.992114,14.98383 9.0458127,14.460725 8.440881,13.855794 a 3.8590267,3.8375958 0 0 0 2.44895,0.873791 3.8590267,3.8375958 0 0 0 3.860457,-3.837078 3.8590267,3.8375958 0 0 0 -0.03214,-0.438357 z m -7.1510519,2.378812 a 3.8590267,3.8375958 0 0 0 0.3419178,0.490961 L 7.6196938,13.034607 Z"
+     id="path841"
+     inkscape:connector-curvature="0" />
+  <circle
+     style="fill:#c5c5c5;fill-opacity:1;stroke:none;stroke-width:0.18897638;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+     id="path3643"
+     cx="10.992129"
+     cy="11.085297"
+     r="1" />
+</svg>

--- a/resources/light/app.svg
+++ b/resources/light/app.svg
@@ -1,0 +1,93 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="22"
+   height="22"
+   version="1.1"
+   id="svg5288"
+   sodipodi:docname="app.svg"
+   inkscape:version="0.92.3 (2405546, 2018-03-11)">
+  <metadata
+     id="metadata5294">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs5292" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="2560"
+     inkscape:window-height="1377"
+     id="namedview5290"
+     showgrid="true"
+     inkscape:zoom="22.627417"
+     inkscape:cx="8.4232539"
+     inkscape:cy="5.3953736"
+     inkscape:window-x="1192"
+     inkscape:window-y="1432"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg5288"
+     inkscape:snap-bbox="true">
+    <inkscape:grid
+       originx="0"
+       originy="0"
+       type="xygrid"
+       id="grid8172" />
+  </sodipodi:namedview>
+  <style
+     type="text/css"
+     id="style5282">.icon-canvas-transparent{opacity:0;fill:#F6F6F6;} .icon-vs-out{opacity:0;fill:#F6F6F6;} .icon-vs-bg{fill:#656565;} .icon-vs-fg{fill:#F0EFF1;}</style>
+  <path
+     class="icon-canvas-transparent"
+     d="M 16,22 H 0 V 6 h 16 z"
+     id="canvas"
+     inkscape:connector-curvature="0"
+     style="opacity:0;fill:#808080;fill-opacity:1" />
+  <path
+     class="icon-vs-out"
+     d="m 2.939,20 c -0.97,0 -2,-0.701 -2,-2 V 8 c 0,-1.299 1.03,-2 2,-2 H 9 l 3.939,3.556 V 18 c 0,0.97 -0.701,2 -2,2 z"
+     id="outline"
+     inkscape:connector-curvature="0"
+     style="opacity:0;fill:#808080;fill-opacity:1" />
+  <path
+     style="fill:#808080;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+     d="M 2.7753907,3 C 2.3458795,3 2,3.3467621 2,3.7773438 V 15.222656 C 2,15.653238 2.3458795,16 2.7753907,16 H 4 V 14 6 h 12 v 3 h 2 V 3.7773438 C 18,3.346762 17.654121,3 17.224609,3 Z"
+     id="rect8154"
+     inkscape:connector-curvature="0"
+     sodipodi:nodetypes="ssssccccccsss" />
+  <g
+     id="g3665"
+     transform="translate(-2.65153,1.973829)"
+     style="fill:#808080;fill-opacity:1">
+    <path
+       inkscape:connector-curvature="0"
+       id="rect931"
+       d="m 12.268712,8.0000004 c -0.129219,0 -0.258265,0.041082 -0.357248,0.1396656 l -3.4161779,3.243568 -1.379877,1.304048 c -0.1979645,0.187314 -0.1979645,0.489646 0,0.678603 l 1.379877,1.307992 3.4161779,3.243568 c 0.197965,0.187313 0.516541,0.187313 0.714488,0 l 1.379877,-1.308075 c 0.197965,-0.187314 0.197965,-0.489644 0,-0.678601 l -3.058934,-2.904598 3.058934,-2.900488 c 0.197965,-0.1873132 0.197965,-0.4904664 0,-0.6786009 L 12.625965,8.1390067 C 12.526957,8.0461722 12.397894,7.999341 12.268726,7.999341 Z"
+       style="fill:#808080;fill-opacity:1;stroke:none;stroke-width:0.20000002;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    <path
+       style="fill:#808080;fill-opacity:1;stroke:none;stroke-width:0.20000002;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 18.268713,8.0000004 c 0.129219,0 0.258265,0.041082 0.357248,0.1396656 l 3.416178,3.243568 1.379877,1.304048 c 0.197965,0.187314 0.197965,0.489646 0,0.678603 l -1.379877,1.307992 -3.416178,3.243568 c -0.197965,0.187313 -0.516541,0.187313 -0.714488,0 L 16.531595,16.60937 c -0.197965,-0.187314 -0.197965,-0.489644 0,-0.678601 l 3.058935,-2.904598 -3.058935,-2.900488 c -0.197965,-0.1873132 -0.197965,-0.4904664 0,-0.6786009 L 17.91146,8.1390067 C 18.01047,8.0461717 18.139531,7.999341 18.268699,7.999341 Z"
+       id="path8177"
+       inkscape:connector-curvature="0" />
+  </g>
+</svg>

--- a/resources/light/attach.svg
+++ b/resources/light/attach.svg
@@ -1,0 +1,82 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   version="1.1"
+   id="svg5288"
+   sodipodi:docname="attach.svg"
+   inkscape:version="0.92.3 (2405546, 2018-03-11)">
+  <metadata
+     id="metadata5294">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs5292" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="2560"
+     inkscape:window-height="1377"
+     id="namedview5290"
+     showgrid="false"
+     inkscape:zoom="14.75"
+     inkscape:cx="-39.98834"
+     inkscape:cy="-0.89834203"
+     inkscape:window-x="1192"
+     inkscape:window-y="1432"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg5288" />
+  <style
+     type="text/css"
+     id="style5282">.icon-canvas-transparent{opacity:0;fill:#F6F6F6;} .icon-vs-out{opacity:0;fill:#F6F6F6;} .icon-vs-bg{fill:#656565;} .icon-vs-fg{fill:#F0EFF1;}</style>
+  <path
+     class="icon-canvas-transparent"
+     d="M16 16h-16v-16h16v16z"
+     id="canvas"
+     style="fill:#808080;fill-opacity:1" />
+  <path
+     class="icon-vs-out"
+     d="m 3.2251816,16.355932 c -1.1578935,0 -2.3874092,-0.836787 -2.3874092,-2.387409 V 2.031477 c 0,-1.55062228 1.2295157,-2.3874092 2.3874092,-2.3874092 h 7.2350434 l 4.702003,4.2448136 V 13.968523 c 0,1.157893 -0.836787,2.387409 -2.38741,2.387409 z"
+     id="outline"
+     inkscape:connector-curvature="0"
+     style="opacity:0;fill:#808080;stroke-width:1;fill-opacity:1" />
+  <path
+     style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#808080;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+     d="M 2.6586382,2.4254927 A 0.59691199,0.59691199 0 0 0 2.0617859,3.022345 V 13.544198 A 0.59691199,0.59691199 0 0 0 2.6586382,14.14105 H 13.180492 a 0.59691199,0.59691199 0 0 0 0.596852,-0.596852 V 9.4967936 H 12.583639 V 12.947346 H 3.2554905 V 3.6191973 H 6.6244419 V 2.4254927 Z"
+     id="rect5898"
+     inkscape:connector-curvature="0" />
+  <path
+     style="fill:#808080;fill-opacity:1;stroke:none;stroke-width:0.2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+     d="m 8.1928063,1.8841352 c 0.072582,-0.072582 0.169375,-0.1207764 0.2832891,-0.1180538 l 3.8376846,-2.605e-4 1.546522,-0.00371 c 0.222006,-3.986e-4 0.400848,0.1784434 0.401422,0.4014225 l -0.0014,1.5488543 -2.6e-4,3.8376845 c -3.98e-4,0.2220065 -0.179353,0.400961 -0.401351,0.40135 l -1.549039,0.00118 C 12.087683,7.9529927 11.908841,7.7741506 11.908266,7.5511718 l 1.03e-4,-3.4364926 -3.4340618,0.00253 C 8.2523,4.1176097 8.072972,3.9382819 8.0728845,3.7157887 l 0.00132,-1.548895 C 8.0749093,2.0563614 8.1197076,1.9561607 8.1922657,1.883603 Z"
+     id="path5900"
+     inkscape:connector-curvature="0" />
+  <rect
+     style="fill:#808080;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+     id="rect5902"
+     width="2.3874097"
+     height="6.676652"
+     x="10.13773"
+     y="-6.1121459"
+     transform="rotate(45)" />
+</svg>

--- a/resources/light/background_page.svg
+++ b/resources/light/background_page.svg
@@ -1,0 +1,65 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="22"
+   height="22"
+   version="1.1"
+   id="svg5288"
+   sodipodi:docname="background_page.svg"
+   inkscape:version="0.92.3 (2405546, 2018-03-11)">
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="2560"
+     inkscape:window-height="1377"
+     id="namedview5290"
+     showgrid="true"
+     inkscape:zoom="20.85965"
+     inkscape:cx="7.7576005"
+     inkscape:cy="3.0556789"
+     inkscape:window-x="1192"
+     inkscape:window-y="1432"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg5288"
+     inkscape:snap-bbox="true">
+    <inkscape:grid
+       originy="0"
+       originx="0"
+       id="grid8172"
+       type="xygrid" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata5294">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs5292" />
+  <style
+     id="style5282"
+     type="text/css">.icon-canvas-transparent{opacity:0;fill:#F6F6F6;} .icon-vs-out{opacity:0;fill:#F6F6F6;} .icon-vs-bg{fill:#656565;} .icon-vs-fg{fill:#F0EFF1;}</style>
+  <path
+     style="fill:#808080;fill-opacity:1;stroke:none;stroke-width:0.18897638;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+     d="M 11.666667,0.9941408 A 3.3333334,2.2222222 0 0 0 8.3333336,3.2174482 v 1.110026 H 5.3938804 c -0.2190962,0 -0.3938802,0.174784 -0.3938802,0.3938802 v 2.9394532 h -1.110026 a 2.2222222,3.3333334 0 0 0 -2.2233074,3.3333334 2.2222222,3.3333334 0 0 0 2.2233074,3.333333 h 1.110026 v 2.939454 c 0,0.219096 0.174784,0.39388 0.3938802,0.39388 h 2.9394532 v 1.129556 A 3.3333334,2.2316385 0 0 0 11.666667,21.023438 3.3333334,2.2316385 0 0 0 15,18.790364 v -1.129556 h 2.939454 c 0.219096,0 0.39388,-0.174784 0.39388,-0.39388 V 14.327474 12.660808 H 16.666667 A 1.6666667,1.6666667 0 0 1 15,10.994141 1.6666667,1.6666667 0 0 1 16.666667,9.3274743 h 1.666667 V 7.6608076 4.7213544 c 0,-0.2190962 -0.174784,-0.3938802 -0.39388,-0.3938802 H 15 V 3.2174482 A 3.3333334,2.2222222 0 0 0 11.666667,0.9941408 Z m 0,1.6666667 a 1.6666667,1.6666667 0 0 1 1.666667,1.6666667 v 1.6666667 h 3.05013 c 0.156496,0 0.283203,0.1267062 0.283203,0.2832032 V 7.6608076 H 15.55664 c -1.2273,0 -2.223306,1.4923845 -2.223306,3.3333334 0,1.840948 0.996006,3.333333 2.223306,3.333333 h 1.110027 v 1.383464 c 0,0.156496 -0.126707,0.283203 -0.283203,0.283203 h -3.05013 v 1.666667 A 1.6666667,1.6666667 0 0 1 11.666667,19.327474 1.6666667,1.6666667 0 0 1 10,17.660808 V 15.994141 H 6.9498701 c -0.156497,0 -0.2832032,-0.126707 -0.2832032,-0.283203 v -3.05013 H 5.0000002 A 1.6666667,1.6666667 0 0 1 3.3333335,10.994141 1.6666667,1.6666667 0 0 1 5.0000002,9.3274743 H 6.6666669 V 6.2773441 c 0,-0.156497 0.1267062,-0.2832032 0.2832032,-0.2832032 H 10 V 4.3274742 a 1.6666667,1.6666667 0 0 1 1.666667,-1.6666667 z"
+     id="rect866"
+     inkscape:connector-curvature="0" />
+</svg>

--- a/resources/light/browser.svg
+++ b/resources/light/browser.svg
@@ -1,0 +1,93 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="22"
+   height="22"
+   version="1.1"
+   id="svg5288"
+   sodipodi:docname="browser.svg"
+   inkscape:version="0.92.3 (2405546, 2018-03-11)">
+  <metadata
+     id="metadata5294">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs5292" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="2560"
+     inkscape:window-height="1377"
+     id="namedview5290"
+     showgrid="true"
+     inkscape:zoom="22.627417"
+     inkscape:cx="1.2417007"
+     inkscape:cy="5.3953736"
+     inkscape:window-x="1192"
+     inkscape:window-y="1432"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg5288"
+     inkscape:snap-bbox="true">
+    <inkscape:grid
+       originx="0"
+       originy="0"
+       type="xygrid"
+       id="grid8172" />
+  </sodipodi:namedview>
+  <style
+     type="text/css"
+     id="style5282">.icon-canvas-transparent{opacity:0;fill:#F6F6F6;} .icon-vs-out{opacity:0;fill:#F6F6F6;} .icon-vs-bg{fill:#656565;} .icon-vs-fg{fill:#F0EFF1;}</style>
+  <path
+     class="icon-canvas-transparent"
+     d="M 16,22 H 0 V 6 h 16 z"
+     id="canvas"
+     inkscape:connector-curvature="0"
+     style="opacity:0;fill:#808080;fill-opacity:1" />
+  <path
+     class="icon-vs-out"
+     d="m 2.939,20 c -0.97,0 -2,-0.701 -2,-2 V 8 c 0,-1.299 1.03,-2 2,-2 H 9 l 3.939,3.556 V 18 c 0,0.97 -0.701,2 -2,2 z"
+     id="outline"
+     inkscape:connector-curvature="0"
+     style="opacity:0;fill:#808080;fill-opacity:1" />
+  <path
+     style="fill:#808080;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+     d="M 2.7753907,3 C 2.3458795,3 2,3.3467621 2,3.7773438 V 15.222656 C 2,15.653238 2.3458795,16 2.7753907,16 H 4 V 14 6 h 12 v 3 h 2 V 3.7773438 C 18,3.346762 17.654121,3 17.224609,3 Z"
+     id="rect8154"
+     inkscape:connector-curvature="0"
+     sodipodi:nodetypes="ssssccccccsss" />
+  <g
+     id="g3665"
+     transform="translate(-2.65153,1.973829)"
+     style="fill:#808080;fill-opacity:1">
+    <path
+       inkscape:connector-curvature="0"
+       id="rect931"
+       d="m 12.268712,8.0000004 c -0.129219,0 -0.258265,0.041082 -0.357248,0.1396656 l -3.4161779,3.243568 -1.379877,1.304048 c -0.1979645,0.187314 -0.1979645,0.489646 0,0.678603 l 1.379877,1.307992 3.4161779,3.243568 c 0.197965,0.187313 0.516541,0.187313 0.714488,0 l 1.379877,-1.308075 c 0.197965,-0.187314 0.197965,-0.489644 0,-0.678601 l -3.058934,-2.904598 3.058934,-2.900488 c 0.197965,-0.1873132 0.197965,-0.4904664 0,-0.6786009 L 12.625965,8.1390067 C 12.526957,8.0461722 12.397894,7.999341 12.268726,7.999341 Z"
+       style="fill:#808080;fill-opacity:1;stroke:none;stroke-width:0.20000002;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    <path
+       style="fill:#808080;fill-opacity:1;stroke:none;stroke-width:0.20000002;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 18.268713,8.0000004 c 0.129219,0 0.258265,0.041082 0.357248,0.1396656 l 3.416178,3.243568 1.379877,1.304048 c 0.197965,0.187314 0.197965,0.489646 0,0.678603 l -1.379877,1.307992 -3.416178,3.243568 c -0.197965,0.187313 -0.516541,0.187313 -0.714488,0 L 16.531595,16.60937 c -0.197965,-0.187314 -0.197965,-0.489644 0,-0.678601 l 3.058935,-2.904598 -3.058935,-2.900488 c -0.197965,-0.1873132 -0.197965,-0.4904664 0,-0.6786009 L 17.91146,8.1390067 C 18.01047,8.0461717 18.139531,7.999341 18.268699,7.999341 Z"
+       id="path8177"
+       inkscape:connector-curvature="0" />
+  </g>
+</svg>

--- a/resources/light/external.svg
+++ b/resources/light/external.svg
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="22"
+   height="22"
+   version="1.1"
+   id="svg5288"
+   sodipodi:docname="external.svg"
+   inkscape:version="0.92.3 (2405546, 2018-03-11)">
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="2560"
+     inkscape:window-height="1377"
+     id="namedview5290"
+     showgrid="true"
+     inkscape:zoom="20.85965"
+     inkscape:cx="-0.032558971"
+     inkscape:cy="3.0556789"
+     inkscape:window-x="1192"
+     inkscape:window-y="1432"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg5288"
+     inkscape:snap-bbox="true">
+    <inkscape:grid
+       originy="0"
+       originx="0"
+       id="grid8172"
+       type="xygrid" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata5294">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs5292" />
+  <style
+     id="style5282"
+     type="text/css">.icon-canvas-transparent{opacity:0;fill:#F6F6F6;} .icon-vs-out{opacity:0;fill:#F6F6F6;} .icon-vs-bg{fill:#656565;} .icon-vs-fg{fill:#F0EFF1;}</style>
+  <path
+     style="fill:#808080;fill-opacity:1;stroke:none;stroke-width:0.18897638;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+     d="M 5 3 L 5 19 L 18 19 L 18 8 L 13 3 L 5 3 z M 7 5 L 12 5 L 12 9 L 16 9 L 16 17 L 7 17 L 7 5 z "
+     id="rect814" />
+</svg>

--- a/resources/light/iframe.svg
+++ b/resources/light/iframe.svg
@@ -1,0 +1,76 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="22"
+   height="22"
+   version="1.1"
+   id="svg5288"
+   sodipodi:docname="iframe.svg"
+   inkscape:version="0.92.3 (2405546, 2018-03-11)">
+  <metadata
+     id="metadata5294">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs5292" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="2560"
+     inkscape:window-height="1377"
+     id="namedview5290"
+     showgrid="true"
+     inkscape:zoom="41.7193"
+     inkscape:cx="4.2145887"
+     inkscape:cy="7.8702607"
+     inkscape:window-x="1192"
+     inkscape:window-y="1432"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg5288"
+     inkscape:snap-bbox="true">
+    <inkscape:grid
+       originx="0"
+       originy="0"
+       type="xygrid"
+       id="grid8172" />
+  </sodipodi:namedview>
+  <style
+     type="text/css"
+     id="style5282">.icon-canvas-transparent{opacity:0;fill:#F6F6F6;} .icon-vs-out{opacity:0;fill:#F6F6F6;} .icon-vs-bg{fill:#656565;} .icon-vs-fg{fill:#F0EFF1;}</style>
+  <path
+     class="icon-canvas-transparent"
+     d="M 16,22 H 0 V 6 h 16 z"
+     id="canvas"
+     inkscape:connector-curvature="0"
+     style="opacity:0;fill:#808080;fill-opacity:1" />
+  <path
+     class="icon-vs-out"
+     d="M 4,21 C 3.03,21 2,20.299 2,19 V 9 C 2,7.701 3.03,7 4,7 h 6.061 L 14,10.556 V 19 c 0,0.97 -0.701,2 -2,2 z"
+     id="outline"
+     inkscape:connector-curvature="0"
+     style="opacity:0;fill:#808080;fill-opacity:1" />
+  <path
+     style="fill:#808080;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+     d="M 3.7753906 4 C 3.3458795 4 3 4.3467621 3 4.7773438 L 3 16.222656 C 3 16.653238 3.3458795 17 3.7753906 17 L 18.224609 17 C 18.654121 17 19 16.653238 19 16.222656 L 19 4.7773438 C 19 4.3467621 18.654121 4 18.224609 4 L 3.7753906 4 z M 5 7 L 17 7 L 17 15 L 5 15 L 5 7 z "
+     id="rect8154" />
+</svg>

--- a/resources/light/other.svg
+++ b/resources/light/other.svg
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="22"
+   height="22"
+   version="1.1"
+   id="svg5288"
+   sodipodi:docname="other.svg"
+   inkscape:version="0.92.3 (2405546, 2018-03-11)">
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="2560"
+     inkscape:window-height="1377"
+     id="namedview5290"
+     showgrid="true"
+     inkscape:zoom="20.85965"
+     inkscape:cx="7.7576005"
+     inkscape:cy="3.0556789"
+     inkscape:window-x="1192"
+     inkscape:window-y="1432"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg5288"
+     inkscape:snap-bbox="true">
+    <inkscape:grid
+       originy="0"
+       originx="0"
+       id="grid8172"
+       type="xygrid" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata5294">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs5292" />
+  <style
+     id="style5282"
+     type="text/css">.icon-canvas-transparent{opacity:0;fill:#F6F6F6;} .icon-vs-out{opacity:0;fill:#F6F6F6;} .icon-vs-bg{fill:#656565;} .icon-vs-fg{fill:#F0EFF1;}</style>
+  <path
+     style="fill:#808080;fill-opacity:1;stroke:none;stroke-width:0.18897638;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+     d="M 5 3 L 5 19 L 18 19 L 18 8 L 13 3 L 5 3 z M 7 5 L 12 5 L 12 9 L 16 9 L 16 17 L 7 17 L 7 5 z "
+     id="rect814" />
+</svg>

--- a/resources/light/page.svg
+++ b/resources/light/page.svg
@@ -1,0 +1,79 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="22"
+   height="22"
+   version="1.1"
+   id="svg5288"
+   sodipodi:docname="page.svg"
+   inkscape:version="0.92.3 (2405546, 2018-03-11)">
+  <metadata
+     id="metadata5294">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs5292" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="2560"
+     inkscape:window-height="1377"
+     id="namedview5290"
+     showgrid="true"
+     inkscape:zoom="41.7193"
+     inkscape:cx="2.333563"
+     inkscape:cy="8.4367158"
+     inkscape:window-x="1192"
+     inkscape:window-y="1432"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg5288">
+    <inkscape:grid
+       type="xygrid"
+       id="grid8175" />
+  </sodipodi:namedview>
+  <style
+     type="text/css"
+     id="style5282">.icon-canvas-transparent{opacity:0;fill:#F6F6F6;} .icon-vs-out{opacity:0;fill:#F6F6F6;} .icon-vs-bg{fill:#656565;} .icon-vs-fg{fill:#F0EFF1;}</style>
+  <path
+     class="icon-canvas-transparent"
+     d="M 16,22 H 0 V 6 h 16 z"
+     id="canvas"
+     inkscape:connector-curvature="0"
+     style="opacity:0;fill:#808080;fill-opacity:1" />
+  <path
+     class="icon-vs-out"
+     d="M 4,21 C 3.03,21 2,20.299 2,19 V 9 C 2,7.701 3.03,7 4,7 h 6.061 L 14,10.556 V 19 c 0,0.97 -0.701,2 -2,2 z"
+     id="outline"
+     inkscape:connector-curvature="0"
+     style="opacity:0;fill:#808080;fill-opacity:1" />
+  <path
+     style="fill:#808080;fill-opacity:1;stroke:none;stroke-width:0.20000002;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+     d="M 8,7 C 7.8707804,7 7.7417342,7.041082 7.6427519,7.1396656 l -3.4161783,3.2435684 -1.379877,1.304048 c -0.1979645,0.187314 -0.1979645,0.489646 0,0.678603 l 1.379877,1.307992 3.4161783,3.243568 c 0.1979645,0.187313 0.5165409,0.187313 0.7144875,0 L 9.7371166,15.60937 c 0.197965,-0.187314 0.197965,-0.489644 0,-0.678601 l -3.058934,-2.904598 3.058934,-2.9004888 c 0.197965,-0.1873128 0.197965,-0.490466 0,-0.6786005 L 8.3572529,7.1390063 C 8.2582443,7.0461718 8.1291815,6.9993406 8.0000135,6.9993406 Z"
+     id="rect931"
+     inkscape:connector-curvature="0" />
+  <path
+     inkscape:connector-curvature="0"
+     id="path8177"
+     d="m 14,7 c 0.129219,0 0.258265,0.041082 0.357248,0.1396656 l 3.416178,3.2435684 1.379877,1.304048 c 0.197965,0.187314 0.197965,0.489646 0,0.678603 l -1.379877,1.307992 -3.416178,3.243568 c -0.197965,0.187313 -0.516541,0.187313 -0.714488,0 L 12.262883,15.60937 c -0.197965,-0.187314 -0.197965,-0.489644 0,-0.678601 l 3.058934,-2.904598 -3.058934,-2.9004888 c -0.197965,-0.1873128 -0.197965,-0.490466 0,-0.6786005 l 1.379864,-1.3080754 c 0.09901,-0.092835 0.228071,-0.1396657 0.357239,-0.1396657 z"
+     style="fill:#808080;fill-opacity:1;stroke:none;stroke-width:0.20000002;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+</svg>

--- a/resources/light/refresh.svg
+++ b/resources/light/refresh.svg
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   version="1.1"
+   id="svg7042"
+   sodipodi:docname="refresh.svg"
+   inkscape:version="0.92.3 (2405546, 2018-03-11)">
+  <metadata
+     id="metadata7048">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs7046" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="2560"
+     inkscape:window-height="1377"
+     id="namedview7044"
+     showgrid="false"
+     inkscape:zoom="14.75"
+     inkscape:cx="-3.0169492"
+     inkscape:cy="8"
+     inkscape:window-x="1192"
+     inkscape:window-y="1432"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg7042" />
+  <path
+     d="M12.6 6.134l-.094.071c-.269.333-.746 1.096-.91 2.375.057.277.092.495.092.545 0 2.206-1.794 4-4 4-1.098 0-2.093-.445-2.817-1.164-.718-.724-1.163-1.718-1.163-2.815 0-2.206 1.794-4 4-4l.351.025v1.85s1.626-1.342 1.631-1.339l1.869-1.577-3.5-2.917v2.218l-.371-.03c-3.176 0-5.75 2.574-5.75 5.75 0 1.593.648 3.034 1.695 4.076 1.042 1.046 2.482 1.694 4.076 1.694 3.176 0 5.75-2.574 5.75-5.75-.001-1.106-.318-2.135-.859-3.012z"
+     fill="#C5C5C5"
+     id="path7040"
+     style="fill:#808080;fill-opacity:1" />
+</svg>

--- a/resources/light/service_worker.svg
+++ b/resources/light/service_worker.svg
@@ -1,0 +1,82 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="22"
+   height="22"
+   version="1.1"
+   id="svg5288"
+   sodipodi:docname="service_worker.svg"
+   inkscape:version="0.92.3 (2405546, 2018-03-11)">
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="2560"
+     inkscape:window-height="1377"
+     id="namedview5290"
+     showgrid="true"
+     inkscape:zoom="41.7193"
+     inkscape:cx="4.1733126"
+     inkscape:cy="7.8702607"
+     inkscape:window-x="1192"
+     inkscape:window-y="1432"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg5288"
+     inkscape:snap-bbox="true">
+    <inkscape:grid
+       originy="0"
+       originx="0"
+       id="grid8172"
+       type="xygrid" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata5294">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs5292" />
+  <style
+     id="style5282"
+     type="text/css">.icon-canvas-transparent{opacity:0;fill:#F6F6F6;} .icon-vs-out{opacity:0;fill:#F6F6F6;} .icon-vs-bg{fill:#656565;} .icon-vs-fg{fill:#F0EFF1;}</style>
+  <path
+     style="opacity:0;fill:#808080;fill-opacity:1;stroke:#808080;stroke-opacity:1"
+     inkscape:connector-curvature="0"
+     id="canvas"
+     d="M 16,22 H 0 V 6 h 16 z"
+     class="icon-canvas-transparent" />
+  <path
+     style="opacity:0;fill:#808080;fill-opacity:1;stroke:#808080;stroke-opacity:1"
+     inkscape:connector-curvature="0"
+     id="outline"
+     d="M 4,21 C 3.03,21 2,20.299 2,19 V 9 C 2,7.701 3.03,7 4,7 h 6.061 L 14,10.556 V 19 c 0,0.97 -0.701,2 -2,2 z"
+     class="icon-vs-out" />
+  <path
+     style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#808080;fill-opacity:1;fill-rule:nonzero;stroke:#808080;stroke-width:0.37795275;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+     d="m 7.1926933,5.992145 -0.5055708,1.5400915 0.00292,0.195799 -0.096438,-0.17242 L 5.389588,6.4772592 3.8115057,7.3890402 4.1417341,8.9700449 4.2469395,9.1424651 4.0745195,9.0372594 2.4905922,8.7070311 1.5788113,10.288036 l 1.0783563,1.204018 0.1724201,0.09643 -0.1957991,-0.003 -1.5371691,0.502649 v 1.826484 l 1.5371691,0.502648 0.1957991,-0.003 -0.1724201,0.09643 -1.0783563,1.204019 0.9117809,1.581006 1.5839273,-0.333152 0.17242,-0.102284 -0.1052048,0.169497 -0.3302284,1.583928 1.5780823,0.911781 1.2040185,-1.078356 0.096438,-0.172421 -0.00292,0.1958 0.5055709,1.537169 h 1.8235618 l 0.505571,-1.537169 -0.00292,-0.1958 0.096438,0.172421 1.2040182,1.078356 1.578083,-0.911781 -0.330229,-1.583928 -0.105201,-0.169497 0.172421,0.102284 1.583926,0.333152 0.911781,-1.581006 -1.078356,-1.204019 -0.17242,-0.09643 0.195799,0.003 1.537169,-0.502648 v -1.826484 l -1.537169,-0.502649 -0.195799,0.003 0.17242,-0.09643 1.078361,-1.204018 -0.911781,-1.5810049 -1.583926,0.3302283 -0.172421,0.1052063 0.105201,-0.1724202 0.330219,-1.5810053 -1.578082,-0.911781 -1.2040189,1.0783563 -0.096438,0.17242 0.00292,-0.195799 -0.505571,-1.5400915 z m 0.9117809,4.278357 A 2.7313908,2.730667 0 0 1 10.836895,13 2.7313908,2.730667 0 0 1 8.1044742,15.729497 2.7313908,2.730667 0 0 1 5.3720539,13 2.7313908,2.730667 0 0 1 8.1044742,10.270502 Z m 3.2730598,0.683835 0.09936,0.09937 0.05845,0.222096 a 3.8590267,3.8375958 0 0 0 -0.157808,-0.321462 z m 0.452969,1.41443 L 12,13 11.476895,14.949224 10.050776,16.375342 8.1044742,16.898447 6.1581727,16.375342 5.553241,15.770411 a 3.8590267,3.8375958 0 0 0 2.4489502,0.873791 3.8590267,3.8375958 0 0 0 3.8604568,-3.837078 3.8590267,3.8375958 0 0 0 -0.03214,-0.438357 z M 4.6794511,14.747579 A 3.8590267,3.8375958 0 0 0 5.0213689,15.23854 L 4.7320538,14.949224 Z"
+     id="path841"
+     inkscape:connector-curvature="0" />
+  <path
+     id="path864"
+     d="m 16.140381,0.81933236 -0.299033,0.91092564 0.0018,0.1158085 -0.05702,-0.101982 -0.712146,-0.6378206 -0.933397,0.5392954 0.195319,0.9351248 0.06223,0.1019838 -0.102018,-0.062228 -0.936854,-0.1953215 -0.539295,0.9351247 0.637822,0.7121463 0.101986,0.057043 -0.115792,-0.00173 -0.909198,0.2973044 v 1.0803195 l 0.909198,0.2973037 0.115792,-0.00173 -0.101986,0.057041 -0.637822,0.7121472 0.539295,0.9351253 0.936854,-0.1970525 0.101985,-0.060489 -0.06225,0.1002554 -0.195319,0.9368541 0.933395,0.5392956 0.712148,-0.6378219 0.05702,-0.1019871 -0.0018,0.115802 0.299032,0.9091983 h 1.07859 l 0.299033,-0.9091983 -0.0018,-0.115802 0.05702,0.1019871 0.712148,0.6378219 0.933398,-0.5393059 -0.195319,-0.9368541 -0.06223,-0.1002554 0.101985,0.060489 0.93687,0.1970525 0.53938,-0.9351278 L 19.90158,5.857928 19.799595,5.800885 19.915403,5.802615 20.824601,5.5053113 V 4.4250074 L 19.91538,4.127703 19.799572,4.1294329 19.901557,4.072392 20.539379,3.3602458 20.000084,2.425121 19.063231,2.6204425 18.961245,2.68267 19.023474,2.5806863 19.218794,1.6455616 18.285397,1.106266 17.573252,1.7440868 17.516229,1.8460705 17.518059,1.7302619 17.219016,0.81933386 Z M 16.679676,3.3498731 A 1.6155491,1.6151211 0 0 1 18.295833,4.964303 1.6155491,1.6151211 0 0 1 16.679676,6.5787318 1.6155491,1.6151211 0 0 1 15.063518,4.964303 1.6155491,1.6151211 0 0 1 16.679676,3.3498731 Z m 1.935933,0.4044716 0.05877,0.058769 0.03458,0.1313667 A 2.2825175,2.2698416 0 0 0 18.615643,3.7543442 Z M 18.883528,4.5909445 18.983783,4.964303 18.674375,6.1172198 17.830867,6.960733 16.679678,7.2701373 15.52849,6.960733 15.17069,6.6029312 a 2.2825175,2.2698416 0 0 0 1.448492,0.5168259 2.2825175,2.2698416 0 0 0 2.283362,-2.2695357 2.2825175,2.2698416 0 0 0 -0.01895,-0.2592769 z M 14.653861,5.9979521 A 2.2825175,2.2698416 0 0 0 14.856102,6.288343 L 14.684987,6.1172203 Z"
+     style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#808080;fill-opacity:1;fill-rule:nonzero;stroke:#808080;stroke-width:0.18897636;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+     inkscape:connector-curvature="0" />
+</svg>

--- a/resources/light/shared_worker.svg
+++ b/resources/light/shared_worker.svg
@@ -1,0 +1,96 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="22"
+   height="22"
+   version="1.1"
+   id="svg5288"
+   sodipodi:docname="shared_worker.svg"
+   inkscape:version="0.92.3 (2405546, 2018-03-11)">
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="2560"
+     inkscape:window-height="1377"
+     id="namedview5290"
+     showgrid="true"
+     inkscape:zoom="20.85965"
+     inkscape:cx="-8.6406372"
+     inkscape:cy="24.945641"
+     inkscape:window-x="1192"
+     inkscape:window-y="1432"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg5288"
+     inkscape:snap-bbox="true">
+    <inkscape:grid
+       originy="0"
+       originx="0"
+       id="grid8172"
+       type="xygrid" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata5294">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs5292" />
+  <style
+     id="style5282"
+     type="text/css">.icon-canvas-transparent{opacity:0;fill:#F6F6F6;} .icon-vs-out{opacity:0;fill:#F6F6F6;} .icon-vs-bg{fill:#656565;} .icon-vs-fg{fill:#F0EFF1;}</style>
+  <path
+     style="opacity:0;fill:#808080;fill-opacity:1;stroke:#808080;stroke-opacity:1"
+     inkscape:connector-curvature="0"
+     id="canvas"
+     d="M 16,22 H 0 V 6 h 16 z"
+     class="icon-canvas-transparent" />
+  <path
+     style="opacity:0;fill:#808080;fill-opacity:1;stroke:#808080;stroke-opacity:1"
+     inkscape:connector-curvature="0"
+     id="outline"
+     d="M 4,21 C 3.03,21 2,20.299 2,19 V 9 C 2,7.701 3.03,7 4,7 h 6.061 L 14,10.556 V 19 c 0,0.97 -0.701,2 -2,2 z"
+     class="icon-vs-out" />
+  <path
+     style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#808080;fill-opacity:1;fill-rule:nonzero;stroke:#808080;stroke-width:0.37795275;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+     d="M 7.1933594 5.9921875 L 6.6875 7.5332031 L 6.6894531 7.7285156 L 6.59375 7.5546875 L 5.3886719 6.4765625 L 3.8105469 7.3886719 L 4.1425781 8.9707031 L 4.2460938 9.1425781 L 4.0742188 9.0371094 L 2.4902344 8.7070312 L 1.578125 10.287109 L 2.65625 11.492188 L 2.8300781 11.587891 L 2.6328125 11.585938 L 1.0957031 12.087891 L 1.0957031 13.914062 L 2.6328125 14.417969 L 2.8300781 14.414062 L 2.65625 14.509766 L 1.578125 15.714844 L 2.4902344 17.294922 L 4.0742188 16.962891 L 4.2460938 16.859375 L 4.1425781 17.029297 L 3.8105469 18.613281 L 5.3886719 19.525391 L 6.59375 18.447266 L 6.6894531 18.275391 L 6.6875 18.470703 L 7.1933594 20.007812 L 9.015625 20.007812 L 9.5214844 18.470703 L 9.5195312 18.275391 L 9.6152344 18.447266 L 10.820312 19.525391 L 12.396484 18.613281 L 12.066406 17.029297 L 11.962891 16.859375 L 12.134766 16.962891 L 13.71875 17.294922 L 14.630859 15.714844 L 13.552734 14.509766 L 13.378906 14.414062 L 13.574219 14.417969 L 15.113281 13.914062 L 15.113281 12.087891 L 13.574219 11.585938 L 13.378906 11.587891 L 13.552734 11.492188 L 14.630859 10.287109 L 13.71875 8.7070312 L 12.134766 9.0371094 L 11.962891 9.1425781 L 12.066406 8.9707031 L 12.396484 7.3886719 L 10.820312 6.4765625 L 9.6152344 7.5546875 L 9.5195312 7.7285156 L 9.5214844 7.5332031 L 9.015625 5.9921875 L 7.1933594 5.9921875 z M 8 8.9707031 A 4.0672188 4.0297809 0 0 1 12.066406 13 A 4.0672188 4.0297809 0 0 1 8 17.029297 A 4.0672188 4.0297809 0 0 1 3.9335938 13 A 4.0672188 4.0297809 0 0 1 8 8.9707031 z "
+     id="path841" />
+  <path
+     id="path864"
+     d="m 16.140381,0.81933236 -0.299033,0.91092564 0.0018,0.1158085 -0.05702,-0.101982 -0.712146,-0.6378206 -0.933397,0.5392954 0.195319,0.9351248 0.06223,0.1019838 -0.102018,-0.062228 -0.936854,-0.1953215 -0.539295,0.9351247 0.637822,0.7121463 0.101986,0.057043 -0.115792,-0.00173 -0.909198,0.2973044 v 1.0803195 l 0.909198,0.2973037 0.115792,-0.00173 -0.101986,0.057041 -0.637822,0.7121472 0.539295,0.9351253 0.936854,-0.1970525 0.101985,-0.060489 -0.06225,0.1002554 -0.195319,0.9368541 0.933395,0.5392956 0.712148,-0.6378219 0.05702,-0.1019871 -0.0018,0.115802 0.299032,0.9091983 h 1.07859 l 0.299033,-0.9091983 -0.0018,-0.115802 0.05702,0.1019871 0.712148,0.6378219 0.933398,-0.5393059 -0.195319,-0.9368541 -0.06223,-0.1002554 0.101985,0.060489 0.93687,0.1970525 0.53938,-0.9351278 L 19.90158,5.857928 19.799595,5.800885 19.915403,5.802615 20.824601,5.5053113 V 4.4250074 L 19.91538,4.127703 19.799572,4.1294329 19.901557,4.072392 20.539379,3.3602458 20.000084,2.425121 19.063231,2.6204425 18.961245,2.68267 19.023474,2.5806863 19.218794,1.6455616 18.285397,1.106266 17.573252,1.7440868 17.516229,1.8460705 17.518059,1.7302619 17.219016,0.81933386 Z M 16.679676,3.3498731 A 1.6155491,1.6151211 0 0 1 18.295833,4.964303 1.6155491,1.6151211 0 0 1 16.679676,6.5787318 1.6155491,1.6151211 0 0 1 15.063518,4.964303 1.6155491,1.6151211 0 0 1 16.679676,3.3498731 Z m 1.935933,0.4044716 0.05877,0.058769 0.03458,0.1313667 A 2.2825175,2.2698416 0 0 0 18.615643,3.7543442 Z M 18.883528,4.5909445 18.983783,4.964303 18.674375,6.1172198 17.830867,6.960733 16.679678,7.2701373 15.52849,6.960733 15.17069,6.6029312 a 2.2825175,2.2698416 0 0 0 1.448492,0.5168259 2.2825175,2.2698416 0 0 0 2.283362,-2.2695357 2.2825175,2.2698416 0 0 0 -0.01895,-0.2592769 z M 14.653861,5.9979521 A 2.2825175,2.2698416 0 0 0 14.856102,6.288343 L 14.684987,6.1172203 Z"
+     style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#808080;fill-opacity:1;fill-rule:nonzero;stroke:#808080;stroke-width:0.18897636;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+     inkscape:connector-curvature="0" />
+  <rect
+     style="fill:#808080;fill-opacity:1;stroke:#808080;stroke-width:0.18897638;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+     id="rect3073"
+     width="2"
+     height="6"
+     x="7"
+     y="10" />
+  <rect
+     y="-11"
+     x="12"
+     height="6"
+     width="2"
+     id="rect3075"
+     style="fill:#808080;fill-opacity:1;stroke:#808080;stroke-width:0.18897638;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+     transform="rotate(90)" />
+</svg>

--- a/resources/light/webview.svg
+++ b/resources/light/webview.svg
@@ -1,0 +1,91 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="22"
+   height="22"
+   version="1.1"
+   id="svg5288"
+   sodipodi:docname="webview.svg"
+   inkscape:version="0.92.3 (2405546, 2018-03-11)">
+  <metadata
+     id="metadata5294">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs5292" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="2560"
+     inkscape:window-height="1377"
+     id="namedview5290"
+     showgrid="true"
+     inkscape:zoom="41.7193"
+     inkscape:cx="0.27823286"
+     inkscape:cy="7.8702607"
+     inkscape:window-x="1192"
+     inkscape:window-y="1432"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg5288"
+     inkscape:snap-bbox="true">
+    <inkscape:grid
+       originx="0"
+       originy="0"
+       type="xygrid"
+       id="grid8172" />
+  </sodipodi:namedview>
+  <style
+     type="text/css"
+     id="style5282">.icon-canvas-transparent{opacity:0;fill:#F6F6F6;} .icon-vs-out{opacity:0;fill:#F6F6F6;} .icon-vs-bg{fill:#656565;} .icon-vs-fg{fill:#F0EFF1;}</style>
+  <path
+     class="icon-canvas-transparent"
+     d="M 16,22 H 0 V 6 h 16 z"
+     id="canvas"
+     inkscape:connector-curvature="0"
+     style="opacity:0;fill:#808080;fill-opacity:1" />
+  <path
+     class="icon-vs-out"
+     d="M 4,21 C 3.03,21 2,20.299 2,19 V 9 C 2,7.701 3.03,7 4,7 h 6.061 L 14,10.556 V 19 c 0,0.97 -0.701,2 -2,2 z"
+     id="outline"
+     inkscape:connector-curvature="0"
+     style="opacity:0;fill:#808080;fill-opacity:1" />
+  <path
+     style="fill:#808080;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+     d="M 3.7753906 4 C 3.3458795 4 3 4.3467621 3 4.7773438 L 3 16.222656 C 3 16.653238 3.3458795 17 3.7753906 17 L 18.224609 17 C 18.654121 17 19 16.653238 19 16.222656 L 19 4.7773438 C 19 4.3467621 18.654121 4 18.224609 4 L 3.7753906 4 z M 5 7 L 17 7 L 17 15 L 5 15 L 5 7 z "
+     id="rect8154" />
+  <g
+     id="g4263"
+     transform="translate(0.229641)"
+     style="fill:#808080;fill-opacity:1">
+    <path
+       inkscape:connector-curvature="0"
+       id="rect931"
+       d="m 8.999992,8.0003893 c -0.07625,0 -0.152408,0.024243 -0.21082,0.08242 L 6.7732095,9.9969109 5.9589134,10.766459 c -0.1168232,0.110538 -0.1168232,0.288951 0,0.400458 l 0.8142961,0.771875 2.0159625,1.914101 c 0.116823,0.110538 0.304823,0.110538 0.421635,0 l 0.814297,-0.771924 c 0.116823,-0.110538 0.116823,-0.288949 0,-0.400457 L 8.2199585,10.966445 10.025104,9.2548016 c 0.116823,-0.1105374 0.116823,-0.2894349 0,-0.4004572 L 9.210815,8.08242 C 9.152385,8.027636 9.076225,8 9,8 Z"
+       style="fill:#808080;fill-opacity:1;stroke:none;stroke-width:0.20000002;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    <path
+       style="fill:#808080;fill-opacity:1;stroke:none;stroke-width:0.20000002;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 12.540726,8.0003893 c 0.07625,0 0.152408,0.024243 0.21082,0.08242 l 2.015962,1.9141018 0.814296,0.7695479 c 0.116824,0.110538 0.116824,0.288951 0,0.400459 l -0.814296,0.771875 -2.015962,1.9141 c -0.116824,0.110538 -0.304823,0.110538 -0.421636,0 l -0.814296,-0.771924 c -0.116823,-0.110538 -0.116823,-0.288949 0,-0.400457 l 1.805145,-1.714067 -1.805145,-1.7116434 c -0.116823,-0.1105374 -0.116823,-0.2894349 0,-0.4004572 L 12.329903,8.08242 C 12.388333,8.027636 12.464492,8 12.540717,8 Z"
+       id="path8177"
+       inkscape:connector-curvature="0" />
+  </g>
+</svg>

--- a/resources/light/worker.svg
+++ b/resources/light/worker.svg
@@ -1,0 +1,83 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="22"
+   height="22"
+   version="1.1"
+   id="svg5288"
+   sodipodi:docname="worker.svg"
+   inkscape:version="0.92.3 (2405546, 2018-03-11)">
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="2560"
+     inkscape:window-height="1377"
+     id="namedview5290"
+     showgrid="true"
+     inkscape:zoom="20.85965"
+     inkscape:cx="-6.0471564"
+     inkscape:cy="16.161259"
+     inkscape:window-x="1192"
+     inkscape:window-y="1432"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg5288"
+     inkscape:snap-bbox="true">
+    <inkscape:grid
+       originy="0"
+       originx="0"
+       id="grid8172"
+       type="xygrid" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata5294">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs5292" />
+  <style
+     id="style5282"
+     type="text/css">.icon-canvas-transparent{opacity:0;fill:#F6F6F6;} .icon-vs-out{opacity:0;fill:#F6F6F6;} .icon-vs-bg{fill:#656565;} .icon-vs-fg{fill:#F0EFF1;}</style>
+  <path
+     style="opacity:0;fill:#808080;fill-opacity:1;stroke:#808080;stroke-opacity:1"
+     inkscape:connector-curvature="0"
+     id="canvas"
+     d="M 16,22 H 0 V 6 h 16 z"
+     class="icon-canvas-transparent" />
+  <path
+     style="opacity:0;fill:#808080;fill-opacity:1;stroke:#808080;stroke-opacity:1"
+     inkscape:connector-curvature="0"
+     id="outline"
+     d="M 4,21 C 3.03,21 2,20.299 2,19 V 9 C 2,7.701 3.03,7 4,7 h 6.061 L 14,10.556 V 19 c 0,0.97 -0.701,2 -2,2 z"
+     class="icon-vs-out" />
+  <path
+     style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#808080;fill-opacity:1;fill-rule:nonzero;stroke:#808080;stroke-width:0.37795275;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+     d="m 10.080333,4.077528 -0.5055705,1.5400915 0.00292,0.195799 -0.096438,-0.17242 L 8.277228,4.5626422 6.6991457,5.4744232 7.0293741,7.0554279 7.1345795,7.2278481 6.9621595,7.1226424 5.3782322,6.7924141 4.4664513,8.373419 5.5448076,9.577437 5.7172277,9.673867 5.5214286,9.670867 3.9842595,10.173516 V 12 l 1.5371691,0.502648 0.1957991,-0.003 -0.1724201,0.09643 -1.0783563,1.204019 0.9117809,1.581006 1.5839273,-0.333152 0.17242,-0.102284 -0.1052048,0.169497 -0.3302284,1.583928 1.5780823,0.911781 1.2040185,-1.078356 0.096438,-0.172421 -0.00292,0.1958 0.5055709,1.537169 h 1.823562 l 0.505571,-1.537169 -0.0029,-0.1958 0.09644,0.172421 1.204018,1.078356 1.578083,-0.911781 -0.330229,-1.583928 -0.105201,-0.169497 0.172421,0.102284 1.583926,0.333152 0.911781,-1.581006 -1.078356,-1.204019 -0.17242,-0.09643 0.195799,0.003 L 18,12 v -1.826484 l -1.537169,-0.502649 -0.195799,0.003 0.17242,-0.09643 1.078361,-1.204018 -0.911781,-1.5810049 -1.583926,0.3302283 -0.172421,0.1052063 0.105201,-0.1724202 0.330219,-1.5810053 -1.578082,-0.911781 -1.204019,1.0783563 -0.09644,0.17242 0.0029,-0.195799 -0.505571,-1.5400915 z m 0.911781,4.278357 a 2.7313908,2.730667 0 0 1 2.732421,2.729498 2.7313908,2.730667 0 0 1 -2.732421,2.729497 2.7313908,2.730667 0 0 1 -2.7324201,-2.729497 2.7313908,2.730667 0 0 1 2.7324201,-2.729498 z m 3.27306,0.683835 0.09936,0.09937 0.05845,0.222096 A 3.8590267,3.8375958 0 0 0 14.265176,9.039724 Z m 0.452969,1.41443 0.169497,0.631233 -0.523105,1.949224 -1.426119,1.426118 L 10.992114,14.98383 9.0458127,14.460725 8.440881,13.855794 a 3.8590267,3.8375958 0 0 0 2.44895,0.873791 3.8590267,3.8375958 0 0 0 3.860457,-3.837078 3.8590267,3.8375958 0 0 0 -0.03214,-0.438357 z m -7.1510519,2.378812 a 3.8590267,3.8375958 0 0 0 0.3419178,0.490961 L 7.6196938,13.034607 Z"
+     id="path841"
+     inkscape:connector-curvature="0" />
+  <circle
+     style="fill:#808080;fill-opacity:1;stroke:#808080;stroke-width:0.18897638;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+     id="path3643"
+     cx="10.992129"
+     cy="11.085297"
+     r="1" />
+</svg>

--- a/resources/viewIcon.svg
+++ b/resources/viewIcon.svg
@@ -1,0 +1,88 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="28"
+   height="28"
+   viewBox="0 0 7.4083337 7.4083337"
+   version="1.1"
+   id="svg8"
+   inkscape:version="0.92.3 (2405546, 2018-03-11)"
+   sodipodi:docname="viewIcon.svg">
+  <defs
+     id="defs2">
+	</defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="31.678384"
+     inkscape:cx="13.037404"
+     inkscape:cy="12.894057"
+     inkscape:document-units="mm"
+     inkscape:current-layer="layer1"
+     showgrid="false"
+     units="px"
+     inkscape:window-width="1920"
+     inkscape:window-height="1017"
+     inkscape:window-x="-8"
+     inkscape:window-y="-8"
+     inkscape:window-maximized="1" />
+  <metadata
+     id="metadata5">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(0,-289.59167)">
+    <path
+       style="fill:#000000;fill-opacity:1;stroke-width:0.26458338"
+       d="m 3.2288571,289.7732 c -0.3684428,0 -0.7131285,0.0495 -1.0334773,0.14847 -0.3203489,0.0989 -0.5991372,0.23428 -0.8358441,0.40587 -0.2367068,0.17158 -0.4454934,0.37404 -0.62615995,0.60784 -0.18066675,0.23381 -0.32368378,0.4833 -0.42949086,0.74956 -0.10507527,0.26442 -0.17796572,0.54058 -0.21787864,0.82862 0.15069935,-0.2002 0.32181732,-0.38651 0.51143634,-0.55868 0.19154016,-0.1739 0.41074821,-0.33585 0.65749211,-0.48541 0.2467439,-0.14955 0.5250502,-0.26983 0.8353621,-0.36104 0.3103117,-0.0912 0.6340904,-0.14217 0.9703312,-0.15377 l 0.081945,0.005 c 0.055203,0.002 0.1247237,0.0124 0.209202,0.0294 0.084478,0.017 0.1784998,0.0406 0.2805429,0.0704 0.1024615,0.0298 0.2025088,0.0771 0.3007882,0.14172 0.098279,0.0642 0.1863029,0.14096 0.2636716,0.22945 0.077369,0.0885 0.13573,0.20552 0.1754599,0.35044 0.040148,0.14491 0.050442,0.3061 0.030368,0.48347 h -2.374009 c 0.03973,-0.2164 0.097226,-0.40025 0.1720856,-0.55096 0.074859,-0.15072 0.1720216,-0.29548 0.2916295,-0.43383 -0.5256898,0.22569 -0.931239,0.53451 -1.2152035,0.92599 -0.2839647,0.39147 -0.42207565,0.8657 -0.41454785,1.42296 0.00502,0.45137 0.15986795,0.8801 0.46516125,1.28509 0.2526135,0.33512 0.5628746,0.58817 0.9288763,0.76113 v -1.65096 C 2.1271741,293.83683 2.0609775,293.6166 2.0584826,293.36261 h 4.2057323 v -0.64929 c 0,-0.58741 -0.1292277,-1.09658 -0.3885179,-1.52708 -0.2768552,-0.45601 -0.6427667,-0.80535 -1.0990338,-1.04842 -0.4562671,-0.24308 -0.9719307,-0.36442 -1.5478061,-0.36442 z"
+       id="path850"
+       inkscape:connector-curvature="0" />
+    <path
+       style="stroke-width:0.26458338;fill:#000000;fill-opacity:1"
+       inkscape:connector-curvature="0"
+       d="m 0.16536457,292.92543 h 0.004035 c 2.9423e-4,-0.002 6.3049e-4,-0.004 9.3872e-4,-0.006 -0.001639,0.002 -0.003335,0.004 -0.004974,0.006 z"
+       id="path856" />
+    <path
+       style="fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.05291665;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 2.9580031,293.90477 c -0.076787,0 -0.1386418,0.0619 -0.1386418,0.13869 v 2.57226 c 0,0.0768 0.061855,0.13869 0.1386418,0.13869 h 3.9810637 c 0.076787,0 0.1386418,-0.0619 0.1386418,-0.13869 v -2.57226 c 0,-0.0768 -0.061855,-0.13869 -0.1386418,-0.13869 z m 0.1772324,0.58554 h 3.6270752 v 1.96338 H 3.1352355 Z"
+       id="rect926"
+       inkscape:connector-curvature="0" />
+    <g
+       id="g991"
+       transform="translate(0.00888425)">
+      <path
+         inkscape:connector-curvature="0"
+         id="rect931"
+         d="m 4.4497393,294.81909 c -0.014936,0 -0.029852,0.005 -0.041293,0.017 l -0.3948637,0.39481 -0.159495,0.15873 c -0.022882,0.0228 -0.022882,0.0596 0,0.0826 l 0.159495,0.15921 0.3948637,0.39481 c 0.022882,0.0228 0.059705,0.0228 0.082585,0 l 0.159495,-0.15922 c 0.022882,-0.0228 0.022882,-0.0596 0,-0.0826 l -0.3535711,-0.35355 0.3535711,-0.35305 c 0.022882,-0.0228 0.022882,-0.0597 0,-0.0826 l -0.1594934,-0.15922 c -0.011444,-0.0113 -0.026362,-0.017 -0.041292,-0.017 z"
+         style="fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.05291667;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+      <path
+         style="fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.05291667;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         d="m 5.4295632,294.81909 c 0.014935,0 0.029852,0.005 0.041292,0.017 l 0.3948636,0.39481 0.159495,0.15873 c 0.022882,0.0228 0.022882,0.0596 0,0.0826 l -0.159495,0.15921 -0.3948636,0.39481 c -0.022882,0.0228 -0.059705,0.0228 -0.082585,0 L 5.2287773,295.867 c -0.022882,-0.0228 -0.022882,-0.0596 0,-0.0826 l 0.3535709,-0.35355 -0.3535709,-0.35305 c -0.022882,-0.0228 -0.022882,-0.0597 0,-0.0826 l 0.1594934,-0.15922 c 0.011444,-0.0113 0.026362,-0.017 0.041292,-0.017 z"
+         id="path938"
+         inkscape:connector-curvature="0" />
+    </g>
+  </g>
+</svg>


### PR DESCRIPTION
This PR just adds a bunch of svg icons that we will use in the tree view contribution point in a future PR. Each one represents a type of target that you can connect to (page, webworker, iframe, etc).

* Added dark and light icons for treeview target types
* Added icon for vscode sidepanel view

Quick screen grab of each one (sorry for the mixed snip sizes):
![image](https://user-images.githubusercontent.com/10660853/57491832-4242f280-7273-11e9-97e8-fe72ae1840ef.png)
