### PR TITLE
Replacing padding-inline-start with -webkit-padding-start

### DIFF
--- a/postBuildStep.ts
+++ b/postBuildStep.ts
@@ -3,6 +3,7 @@
 
 import * as fse from "fs-extra";
 import path from "path";
+import applyPaddingInlineCssPatch from "./src/host/polyfills/cssPaddingInline";
 import { applyCreateElementPatch, applyUIUtilsPatch } from "./src/host/polyfills/customElements";
 import {
     applyCommonRevealerPatch,
@@ -83,7 +84,10 @@ async function patchFilesForWebView(toolsOutDir: string) {
         applyInspectorViewPatch,
         applySelectTabPatch,
     ]);
-    await patchFileForWebView("elements/elements_module.js", toolsOutDir, true, [applySetupTextSelectionPatch]);
+    await patchFileForWebView("elements/elements_module.js", toolsOutDir, true, [
+        applySetupTextSelectionPatch,
+        applyPaddingInlineCssPatch,
+    ]);
 
     // Debug file versions
     await patchFileForWebView("ui/UIUtils.js", toolsOutDir, false, [applyUIUtilsPatch]);
@@ -94,6 +98,8 @@ async function patchFilesForWebView(toolsOutDir: string) {
     await patchFileForWebView("main/Main.js", toolsOutDir, false, [applyMainViewPatch]);
     await patchFileForWebView("ui/InspectorView.js", toolsOutDir, false, [applyInspectorViewPatch]);
     await patchFileForWebView("ui/TabbedPane.js", toolsOutDir, false, [applySelectTabPatch]);
+    await patchFileForWebView("elements/elementsTreeOutline.js", toolsOutDir, false, [applyPaddingInlineCssPatch]);
+    await patchFileForWebView("elements/stylesSectionTree.js", toolsOutDir, false, [applyPaddingInlineCssPatch]);
 }
 
 async function patchFileForWebView(

--- a/src/host/polyfills/cssPaddingInline.test.ts
+++ b/src/host/polyfills/cssPaddingInline.test.ts
@@ -1,0 +1,17 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+describe("cssPaddingInline", () => {
+    it("applyPaddingInlineCssPatch correctly changes text", async () => {
+        const apply = await import("./cssPaddingInline");
+        const result = apply.default("body { padding-inline-start: 10px; }");
+        expect(result).toEqual("body { -webkit-padding-start: 10px; }");
+    });
+
+    it("applyPaddingInlineCssPatch ignores other text", async () => {
+        const apply = await import("./cssPaddingInline");
+        const expectedText = "body { scroll-padding-inline-start: 10px; }";
+        const result = apply.default(expectedText);
+        expect(result).toEqual(expectedText);
+    });
+});

--- a/src/host/polyfills/cssPaddingInline.ts
+++ b/src/host/polyfills/cssPaddingInline.ts
@@ -1,0 +1,9 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+export default function applyPaddingInlineCssPatch(content: string, isRelease?: boolean) {
+    return content.replace(
+        /([^-])padding-inline-start:/g,
+        "$1-webkit-padding-start:",
+    );
+}


### PR DESCRIPTION
This PR fixes an issue with the older VS Code electron version where the css property padding-inline-start is not supported. The fix is to replace the property with the older -webkit-padding-start version.

* Adds new patch to convert padding-inline-start to -webkit-padding-start
* Adds unit tests

Before:
![vscode-edge-devtools-padding-before](https://user-images.githubusercontent.com/10660853/57946080-58167000-7890-11e9-99dd-189339ed8388.gif)

After:
![vscode-edge-devtools-padding-after](https://user-images.githubusercontent.com/10660853/57946087-5ba9f700-7890-11e9-9521-dd758c03742e.gif)
