### PR TITLE
Fix trailing slashes

### DIFF
--- a/src/extension.test.ts
+++ b/src/extension.test.ts
@@ -4,7 +4,7 @@
 import { ExtensionContext } from "vscode";
 import TelemetryReporter from "vscode-extension-telemetry";
 import { createFakeExtensionContext, createFakeTelemetryReporter, createFakeVSCode, Mocked } from "./test/helpers";
-import { IRemoteTargetJson, SETTINGS_STORE_NAME, SETTINGS_VIEW_NAME } from "./utils";
+import { IRemoteTargetJson, removeTrailingSlash, SETTINGS_STORE_NAME, SETTINGS_VIEW_NAME } from "./utils";
 
 jest.mock("vscode", () => createFakeVSCode(), { virtual: true });
 
@@ -28,6 +28,7 @@ describe("extension", () => {
                 createTelemetryReporter: jest.fn((_: ExtensionContext) => createFakeTelemetryReporter()),
                 getListOfTargets: jest.fn(),
                 getRemoteEndpointSettings: jest.fn(),
+                removeTrailingSlash: jest.fn(removeTrailingSlash),
             };
             jest.doMock("./utils", () => mockUtils);
             jest.doMock("./launchDebugProvider");
@@ -170,6 +171,7 @@ describe("extension", () => {
                         port: "port",
                         useHttps: false,
                     }),
+                    removeTrailingSlash: jest.fn(removeTrailingSlash),
                 },
                 vscode: createFakeVSCode(),
             };
@@ -320,6 +322,7 @@ describe("extension", () => {
                 }),
                 launchBrowser: jest.fn(),
                 openNewTab: jest.fn().mockResolvedValue(null),
+                removeTrailingSlash: jest.fn(removeTrailingSlash),
             };
 
             mockPanel = {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -16,6 +16,7 @@ import {
     IRemoteTargetJson,
     launchBrowser,
     openNewTab,
+    removeTrailingSlash,
     SETTINGS_STORE_NAME,
     SETTINGS_VIEW_NAME,
 } from "./utils";
@@ -94,10 +95,10 @@ export async function attach(context: vscode.ExtensionContext, viaConfig: boolea
         // Try to match the given target with the list of targets we received from the endpoint
         let targetWebsocketUrl = "";
         if (targetUrl) {
-            const noTrailingSlashTarget = (targetUrl.endsWith("/") ? targetUrl.slice(0, -1) : targetUrl);
+            const noTrailingSlashTarget = removeTrailingSlash(targetUrl);
             const matches = items.filter((i) => {
                 if (i.description) {
-                    const noTrailingSlash = (i.description.endsWith("/") ? i.description.slice(0, -1) : i.description);
+                    const noTrailingSlash = removeTrailingSlash(i.description);
                     return noTrailingSlashTarget.localeCompare(noTrailingSlash, "en", { sensitivity: "base" }) === 0;
                 }
                 return false;

--- a/src/utils.test.ts
+++ b/src/utils.test.ts
@@ -508,4 +508,18 @@ describe("utils", () => {
             expect(target).toBeUndefined();
         });
     });
+
+    describe("removeTrailingSlash", () => {
+        it("returns a string without a trailing slash", async () => {
+            expect(utils.removeTrailingSlash("hello/")).toEqual("hello");
+            expect(utils.removeTrailingSlash("hello//")).toEqual("hello/");
+            expect(utils.removeTrailingSlash("/")).toEqual("");
+        });
+
+        it("does nothing to strings without a trailing slash", async () => {
+            expect(utils.removeTrailingSlash("hello")).toEqual("hello");
+            expect(utils.removeTrailingSlash("hello\\")).toEqual("hello\\");
+            expect(utils.removeTrailingSlash("")).toEqual("");
+        });
+    });
 });

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -263,3 +263,11 @@ export async function openNewTab(hostname: string, port: number, tabUrl?: string
         return undefined;
     }
 }
+
+/**
+ * Remove a '/' from the end of the specified string if it exists
+ * @param uri The string from which to remove the trailing slash (if any)
+ */
+export function removeTrailingSlash(uri: string) {
+    return (uri.endsWith("/") ? uri.slice(0, -1) : uri);
+}


### PR DESCRIPTION
This PR fixes #32
The issue is caused by mis-matched trailing slashes between the url given for the tab to open, and the url that Edge actually displays once it navigates there.

In this case using `https://www.bing.com` will actually end up navigating to `https://www.bing.com/` which is pretty common for index pages on sites. To fix this I added code to strip a trailing slash from the target url and json targets and compare those strings instead.

* Added trailing slash removal code
* Updated unit tests