### PR TITLE
Fix spacing in regex for retail

### DIFF
--- a/src/host/polyfills/simpleView.test.ts
+++ b/src/host/polyfills/simpleView.test.ts
@@ -16,8 +16,12 @@ describe("simpleView", () => {
         expect(result).toEqual("handleAction(context, actionId) { return false; // code");
 
         const result2 = apply.applyInspectorViewPatch(
+            "handleAction(context,actionId) { // code");
+        expect(result2).toEqual("handleAction(context, actionId) { return false; // code");
+
+        const result3 = apply.applyInspectorViewPatch(
             "_showDrawer(focus) { // code");
-        expect(result2).toEqual("_showDrawer(focus) { return false; // code");
+        expect(result3).toEqual("_showDrawer(focus) { return false; // code");
     });
 
     it("applyMainViewPatch correctly changes text", async () => {
@@ -30,6 +34,9 @@ describe("simpleView", () => {
         const apply = await import("./simpleView");
         const result = apply.applySelectTabPatch("selectTab(id, userGesture) { // code");
         expect(result).toEqual(expect.stringContaining("selectTab(id, userGesture) { if ("));
+
+        const result2 = apply.applySelectTabPatch("selectTab(id,userGesture) { // code");
+        expect(result2).toEqual(expect.stringContaining("selectTab(id, userGesture) { if ("));
     });
 
     it("applyInspectorCommonCssPatch correctly changes text", async () => {

--- a/src/host/polyfills/simpleView.ts
+++ b/src/host/polyfills/simpleView.ts
@@ -10,7 +10,7 @@ export function applyCommonRevealerPatch(content: string) {
 export function applyInspectorViewPatch(content: string) {
     return content
         .replace(
-            /handleAction\(context, actionId\)\s*{/g,
+            /handleAction\(context,\s*actionId\)\s*{/g,
             "handleAction(context, actionId) { return false;")
         .replace(
             /_showDrawer\(focus\)\s*{/g,
@@ -47,7 +47,7 @@ export function applySelectTabPatch(content: string) {
     }).join(" && ");
 
     return content.replace(
-        /selectTab\(id, userGesture\)\s*{/g,
+        /selectTab\(id,\s*userGesture\)\s*{/g,
         `selectTab(id, userGesture) { if (${condition}) return false;`);
 }
 


### PR DESCRIPTION
This PR fixes a spacing issue in the regex for the polyfills in simpleView.ts. 
Previously the regex's would not match the retail code since it was minified and removed the space between the parameters to the function, so `selectTab(id, userGesture)` would become `selectTab(id,userGesture)`.
The fix is to add \s* to the regex to ensure that this optional space is taken into account

* Fix regex for applyInspectorViewPatch and applySelectTabPatch
* Add tests for this case