### PR TITLE
Updating vsce npm package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "vscode-edge-devtools",
-    "version": "0.1.0",
+    "version": "1.0.0",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {
@@ -831,24 +831,6 @@
             "integrity": "sha1-jCpe8kcv2ep0KwTHenUJO6J1fJM=",
             "dev": true
         },
-        "array-filter": {
-            "version": "0.0.1",
-            "resolved": "https://registry.npmjs.org/array-filter/-/array-filter-0.0.1.tgz",
-            "integrity": "sha1-fajPLiZijtcygDWB/SH2fKzS7uw=",
-            "dev": true
-        },
-        "array-map": {
-            "version": "0.0.0",
-            "resolved": "https://registry.npmjs.org/array-map/-/array-map-0.0.0.tgz",
-            "integrity": "sha1-iKK6tz0c97zVwbEYoAP2b2ZfpmI=",
-            "dev": true
-        },
-        "array-reduce": {
-            "version": "0.0.0",
-            "resolved": "https://registry.npmjs.org/array-reduce/-/array-reduce-0.0.0.tgz",
-            "integrity": "sha1-FziZ0//Rx9k4PkR5Ul2+J4yrXys=",
-            "dev": true
-        },
         "array-unique": {
             "version": "0.3.2",
             "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
@@ -1083,16 +1065,6 @@
             "requires": {
                 "@babel/plugin-syntax-object-rest-spread": "^7.0.0",
                 "babel-plugin-jest-hoist": "^24.3.0"
-            }
-        },
-        "babel-runtime": {
-            "version": "6.26.0",
-            "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
-            "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
-            "dev": true,
-            "requires": {
-                "core-js": "^2.4.0",
-                "regenerator-runtime": "^0.11.0"
             }
         },
         "balanced-match": {
@@ -1785,163 +1757,11 @@
             "integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=",
             "dev": true
         },
-        "core-js": {
-            "version": "2.6.5",
-            "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.5.tgz",
-            "integrity": "sha512-klh/kDpwX8hryYL14M9w/xei6vrv6sE8gTHDG7/T/+SEovB/G4ejwcfE/CBzO6Edsu+OETZMZ3wcX/EjUkrl5A==",
-            "dev": true
-        },
         "core-util-is": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
             "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
             "dev": true
-        },
-        "cpx": {
-            "version": "1.5.0",
-            "resolved": "https://registry.npmjs.org/cpx/-/cpx-1.5.0.tgz",
-            "integrity": "sha1-GFvgGFEdhycN7czCkxceN2VauI8=",
-            "dev": true,
-            "requires": {
-                "babel-runtime": "^6.9.2",
-                "chokidar": "^1.6.0",
-                "duplexer": "^0.1.1",
-                "glob": "^7.0.5",
-                "glob2base": "^0.0.12",
-                "minimatch": "^3.0.2",
-                "mkdirp": "^0.5.1",
-                "resolve": "^1.1.7",
-                "safe-buffer": "^5.0.1",
-                "shell-quote": "^1.6.1",
-                "subarg": "^1.0.0"
-            },
-            "dependencies": {
-                "anymatch": {
-                    "version": "1.3.2",
-                    "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-1.3.2.tgz",
-                    "integrity": "sha512-0XNayC8lTHQ2OI8aljNCN3sSx6hsr/1+rlcDAotXJR7C1oZZHCNsfpbKwMjRA3Uqb5tF1Rae2oloTr4xpq+WjA==",
-                    "dev": true,
-                    "requires": {
-                        "micromatch": "^2.1.5",
-                        "normalize-path": "^2.0.0"
-                    }
-                },
-                "arr-diff": {
-                    "version": "2.0.0",
-                    "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
-                    "integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
-                    "dev": true,
-                    "requires": {
-                        "arr-flatten": "^1.0.1"
-                    }
-                },
-                "array-unique": {
-                    "version": "0.2.1",
-                    "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
-                    "integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM=",
-                    "dev": true
-                },
-                "braces": {
-                    "version": "1.8.5",
-                    "resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
-                    "integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
-                    "dev": true,
-                    "requires": {
-                        "expand-range": "^1.8.1",
-                        "preserve": "^0.2.0",
-                        "repeat-element": "^1.1.2"
-                    }
-                },
-                "chokidar": {
-                    "version": "1.7.0",
-                    "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-1.7.0.tgz",
-                    "integrity": "sha1-eY5ol3gVHIB2tLNg5e3SjNortGg=",
-                    "dev": true,
-                    "requires": {
-                        "anymatch": "^1.3.0",
-                        "async-each": "^1.0.0",
-                        "fsevents": "^1.0.0",
-                        "glob-parent": "^2.0.0",
-                        "inherits": "^2.0.1",
-                        "is-binary-path": "^1.0.0",
-                        "is-glob": "^2.0.0",
-                        "path-is-absolute": "^1.0.0",
-                        "readdirp": "^2.0.0"
-                    }
-                },
-                "expand-brackets": {
-                    "version": "0.1.5",
-                    "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
-                    "integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
-                    "dev": true,
-                    "requires": {
-                        "is-posix-bracket": "^0.1.0"
-                    }
-                },
-                "extglob": {
-                    "version": "0.3.2",
-                    "resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
-                    "integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
-                    "dev": true,
-                    "requires": {
-                        "is-extglob": "^1.0.0"
-                    }
-                },
-                "glob-parent": {
-                    "version": "2.0.0",
-                    "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
-                    "integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
-                    "dev": true,
-                    "requires": {
-                        "is-glob": "^2.0.0"
-                    }
-                },
-                "is-extglob": {
-                    "version": "1.0.0",
-                    "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
-                    "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
-                    "dev": true
-                },
-                "is-glob": {
-                    "version": "2.0.1",
-                    "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
-                    "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
-                    "dev": true,
-                    "requires": {
-                        "is-extglob": "^1.0.0"
-                    }
-                },
-                "kind-of": {
-                    "version": "3.2.2",
-                    "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-                    "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-                    "dev": true,
-                    "requires": {
-                        "is-buffer": "^1.1.5"
-                    }
-                },
-                "micromatch": {
-                    "version": "2.3.11",
-                    "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
-                    "integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
-                    "dev": true,
-                    "requires": {
-                        "arr-diff": "^2.0.0",
-                        "array-unique": "^0.2.1",
-                        "braces": "^1.8.2",
-                        "expand-brackets": "^0.1.4",
-                        "extglob": "^0.3.1",
-                        "filename-regex": "^2.0.0",
-                        "is-extglob": "^1.0.0",
-                        "is-glob": "^2.0.1",
-                        "kind-of": "^3.0.2",
-                        "normalize-path": "^2.0.1",
-                        "object.omit": "^2.0.0",
-                        "parse-glob": "^3.0.4",
-                        "regex-cache": "^0.4.2"
-                    }
-                }
-            }
         },
         "create-ecdh": {
             "version": "4.0.3",
@@ -2229,6 +2049,12 @@
             "resolved": "https://registry.npmjs.org/diagnostic-channel-publishers/-/diagnostic-channel-publishers-0.2.1.tgz",
             "integrity": "sha1-ji1geottef6IC1SLxYzGvrKIxPM="
         },
+        "didyoumean": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/didyoumean/-/didyoumean-1.2.1.tgz",
+            "integrity": "sha1-6S7f2tplN9SE1zwBcv0eugxJdv8=",
+            "dev": true
+        },
         "diff": {
             "version": "3.3.1",
             "resolved": "https://registry.npmjs.org/diff/-/diff-3.3.1.tgz",
@@ -2301,12 +2127,6 @@
                 "dom-serializer": "0",
                 "domelementtype": "1"
             }
-        },
-        "duplexer": {
-            "version": "0.1.1",
-            "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz",
-            "integrity": "sha1-rOb/gIwc5mtX0ev5eXessCM0z8E=",
-            "dev": true
         },
         "duplexify": {
             "version": "3.7.1",
@@ -2612,57 +2432,6 @@
                 }
             }
         },
-        "expand-range": {
-            "version": "1.8.2",
-            "resolved": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
-            "integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
-            "dev": true,
-            "requires": {
-                "fill-range": "^2.1.0"
-            },
-            "dependencies": {
-                "fill-range": {
-                    "version": "2.2.4",
-                    "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.4.tgz",
-                    "integrity": "sha512-cnrcCbj01+j2gTG921VZPnHbjmdAf8oQV/iGeV2kZxGSyfYjjTyY79ErsK1WJWMpw6DaApEX72binqJE+/d+5Q==",
-                    "dev": true,
-                    "requires": {
-                        "is-number": "^2.1.0",
-                        "isobject": "^2.0.0",
-                        "randomatic": "^3.0.0",
-                        "repeat-element": "^1.1.2",
-                        "repeat-string": "^1.5.2"
-                    }
-                },
-                "is-number": {
-                    "version": "2.1.0",
-                    "resolved": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
-                    "integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
-                    "dev": true,
-                    "requires": {
-                        "kind-of": "^3.0.2"
-                    }
-                },
-                "isobject": {
-                    "version": "2.1.0",
-                    "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
-                    "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
-                    "dev": true,
-                    "requires": {
-                        "isarray": "1.0.0"
-                    }
-                },
-                "kind-of": {
-                    "version": "3.2.2",
-                    "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-                    "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-                    "dev": true,
-                    "requires": {
-                        "is-buffer": "^1.1.5"
-                    }
-                }
-            }
-        },
         "expand-tilde": {
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/expand-tilde/-/expand-tilde-2.0.2.tgz",
@@ -2811,12 +2580,6 @@
             "integrity": "sha512-vNKxJHTEKNThjfrdJwHc7brvM6eVevuO5nTj6ez8ZQ1qbXTvGthucRF7S4vf2cr71QVnT70V34v0S1DyQsti0w==",
             "dev": true
         },
-        "filename-regex": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.1.tgz",
-            "integrity": "sha1-wcS5vuPglyXdsQa3XB4wH+LxiyY=",
-            "dev": true
-        },
         "fileset": {
             "version": "2.0.3",
             "resolved": "https://registry.npmjs.org/fileset/-/fileset-2.0.3.tgz",
@@ -2878,12 +2641,6 @@
                     "dev": true
                 }
             }
-        },
-        "find-index": {
-            "version": "0.1.1",
-            "resolved": "https://registry.npmjs.org/find-index/-/find-index-0.1.1.tgz",
-            "integrity": "sha1-Z101iyyjiS15Whq0cjL4tuLg3eQ=",
-            "dev": true
         },
         "find-up": {
             "version": "3.0.0",
@@ -2947,15 +2704,6 @@
             "resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
             "integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA=",
             "dev": true
-        },
-        "for-own": {
-            "version": "0.1.5",
-            "resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.5.tgz",
-            "integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=",
-            "dev": true,
-            "requires": {
-                "for-in": "^1.0.1"
-            }
         },
         "forever-agent": {
             "version": "0.6.1",
@@ -3665,42 +3413,6 @@
                 "path-is-absolute": "^1.0.0"
             }
         },
-        "glob-base": {
-            "version": "0.3.0",
-            "resolved": "https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz",
-            "integrity": "sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=",
-            "dev": true,
-            "requires": {
-                "glob-parent": "^2.0.0",
-                "is-glob": "^2.0.0"
-            },
-            "dependencies": {
-                "glob-parent": {
-                    "version": "2.0.0",
-                    "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
-                    "integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
-                    "dev": true,
-                    "requires": {
-                        "is-glob": "^2.0.0"
-                    }
-                },
-                "is-extglob": {
-                    "version": "1.0.0",
-                    "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
-                    "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
-                    "dev": true
-                },
-                "is-glob": {
-                    "version": "2.0.1",
-                    "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
-                    "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
-                    "dev": true,
-                    "requires": {
-                        "is-extglob": "^1.0.0"
-                    }
-                }
-            }
-        },
         "glob-parent": {
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-3.1.0.tgz",
@@ -3709,15 +3421,6 @@
             "requires": {
                 "is-glob": "^3.1.0",
                 "path-dirname": "^1.0.0"
-            }
-        },
-        "glob2base": {
-            "version": "0.0.12",
-            "resolved": "https://registry.npmjs.org/glob2base/-/glob2base-0.0.12.tgz",
-            "integrity": "sha1-nUGbPijxLoOjYhZKJ3BVkiycDVY=",
-            "dev": true,
-            "requires": {
-                "find-index": "^0.1.1"
             }
         },
         "global-modules": {
@@ -4153,21 +3856,6 @@
                 }
             }
         },
-        "is-dotfile": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.3.tgz",
-            "integrity": "sha1-pqLzL/0t+wT1yiXs0Pa4PPeYoeE=",
-            "dev": true
-        },
-        "is-equal-shallow": {
-            "version": "0.1.3",
-            "resolved": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz",
-            "integrity": "sha1-IjgJj8Ih3gvPpdnqxMRdY4qhxTQ=",
-            "dev": true,
-            "requires": {
-                "is-primitive": "^2.0.0"
-            }
-        },
         "is-extendable": {
             "version": "0.1.1",
             "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
@@ -4229,18 +3917,6 @@
             "requires": {
                 "isobject": "^3.0.1"
             }
-        },
-        "is-posix-bracket": {
-            "version": "0.1.1",
-            "resolved": "https://registry.npmjs.org/is-posix-bracket/-/is-posix-bracket-0.1.1.tgz",
-            "integrity": "sha1-MzTceXdDaOkvAW5vvAqI9c1ua8Q=",
-            "dev": true
-        },
-        "is-primitive": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz",
-            "integrity": "sha1-IHurkWOEmcB7Kt8kCkGochADRXU=",
-            "dev": true
         },
         "is-regex": {
             "version": "1.0.4",
@@ -5144,12 +4820,6 @@
                 "graceful-fs": "^4.1.6"
             }
         },
-        "jsonify": {
-            "version": "0.0.0",
-            "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
-            "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM=",
-            "dev": true
-        },
         "jsprim": {
             "version": "1.4.1",
             "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
@@ -5360,12 +5030,6 @@
                 "mdurl": "^1.0.1",
                 "uc.micro": "^1.0.5"
             }
-        },
-        "math-random": {
-            "version": "1.0.4",
-            "resolved": "https://registry.npmjs.org/math-random/-/math-random-1.0.4.tgz",
-            "integrity": "sha512-rUxjysqif/BZQH2yhd5Aaq7vXMSx9NdEsQcyA07uEzIvxgI7zIr33gGsh+RU0/XjmQpCW7RsVof1vlkvQVCK5A==",
-            "dev": true
         },
         "md5.js": {
             "version": "1.3.5",
@@ -6005,16 +5669,6 @@
                 "es-abstract": "^1.5.1"
             }
         },
-        "object.omit": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.1.tgz",
-            "integrity": "sha1-Gpx0SCnznbuFjHbKNXmuKlTr0fo=",
-            "dev": true,
-            "requires": {
-                "for-own": "^0.1.4",
-                "is-extendable": "^0.1.1"
-            }
-        },
         "object.pick": {
             "version": "1.3.0",
             "resolved": "https://registry.npmjs.org/object.pick/-/object.pick-1.3.0.tgz",
@@ -6224,35 +5878,6 @@
                 "safe-buffer": "^5.1.1"
             }
         },
-        "parse-glob": {
-            "version": "3.0.4",
-            "resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
-            "integrity": "sha1-ssN2z7EfNVE7rdFz7wu246OIORw=",
-            "dev": true,
-            "requires": {
-                "glob-base": "^0.3.0",
-                "is-dotfile": "^1.0.0",
-                "is-extglob": "^1.0.0",
-                "is-glob": "^2.0.0"
-            },
-            "dependencies": {
-                "is-extglob": {
-                    "version": "1.0.0",
-                    "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
-                    "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
-                    "dev": true
-                },
-                "is-glob": {
-                    "version": "2.0.1",
-                    "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
-                    "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
-                    "dev": true,
-                    "requires": {
-                        "is-extglob": "^1.0.0"
-                    }
-                }
-            }
-        },
         "parse-json": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
@@ -6405,12 +6030,6 @@
             "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
             "dev": true
         },
-        "preserve": {
-            "version": "0.2.0",
-            "resolved": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz",
-            "integrity": "sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks=",
-            "dev": true
-        },
         "pretty-format": {
             "version": "24.5.0",
             "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-24.5.0.tgz",
@@ -6528,31 +6147,6 @@
             "integrity": "sha512-w7fLxIRCRT7U8Qu53jQnJyPkYZIaR4n5151KMfcJlO/A9397Wxb1amJvROTK6TOnp7PfoAmg/qXiNHI+08jRfA==",
             "dev": true
         },
-        "randomatic": {
-            "version": "3.1.1",
-            "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-3.1.1.tgz",
-            "integrity": "sha512-TuDE5KxZ0J461RVjrJZCJc+J+zCkTb1MbH9AQUq68sMhOMcy9jLcb3BrZKgp9q9Ncltdg4QVqWrH02W2EFFVYw==",
-            "dev": true,
-            "requires": {
-                "is-number": "^4.0.0",
-                "kind-of": "^6.0.0",
-                "math-random": "^1.0.1"
-            },
-            "dependencies": {
-                "is-number": {
-                    "version": "4.0.0",
-                    "resolved": "https://registry.npmjs.org/is-number/-/is-number-4.0.0.tgz",
-                    "integrity": "sha512-rSklcAIlf1OmFdyAqbnWTLVelsQ58uvZ66S/ZyawjWqIviTWCjg2PzVGw8WUA+nNuPTqb4wgA+NszrJ+08LlgQ==",
-                    "dev": true
-                },
-                "kind-of": {
-                    "version": "6.0.2",
-                    "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-                    "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
-                    "dev": true
-                }
-            }
-        },
         "randombytes": {
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
@@ -6609,9 +6203,9 @@
             }
         },
         "readable-stream": {
-            "version": "3.3.0",
-            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.3.0.tgz",
-            "integrity": "sha512-EsI+s3k3XsW+fU8fQACLN59ky34AZ14LoeVZpYwmZvldCFo0r0gnelwF2TcMjLor/BTL5aDJVBMkss0dthToPw==",
+            "version": "3.4.0",
+            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.4.0.tgz",
+            "integrity": "sha512-jItXPLmrSR8jmTRmRWJXCnGJsfy85mB3Wd/uINMXA65yrnFo0cPClFIUWzo2najVNSl+mx7/4W8ttlLWJe99pQ==",
             "dev": true,
             "requires": {
                 "inherits": "^2.0.3",
@@ -6663,21 +6257,6 @@
             "dev": true,
             "requires": {
                 "util.promisify": "^1.0.0"
-            }
-        },
-        "regenerator-runtime": {
-            "version": "0.11.1",
-            "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
-            "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg==",
-            "dev": true
-        },
-        "regex-cache": {
-            "version": "0.4.4",
-            "resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.4.tgz",
-            "integrity": "sha512-nVIZwtCjkC9YgvWkpM55B5rBhBYRZhAaJbgcFYXXsHnbZ9UZI9nnVWYZpBlCqv9ho2eZryPnWrZGsOdPwVWXWQ==",
-            "dev": true,
-            "requires": {
-                "is-equal-shallow": "^0.1.3"
             }
         },
         "regex-not": {
@@ -7008,18 +6587,6 @@
             "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
             "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
             "dev": true
-        },
-        "shell-quote": {
-            "version": "1.6.1",
-            "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.6.1.tgz",
-            "integrity": "sha1-9HgZSczkAmlxJ0MOo7PFR29IF2c=",
-            "dev": true,
-            "requires": {
-                "array-filter": "~0.0.0",
-                "array-map": "~0.0.0",
-                "array-reduce": "~0.0.0",
-                "jsonify": "~0.0.0"
-            }
         },
         "shellwords": {
             "version": "0.1.1",
@@ -7515,23 +7082,6 @@
             "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
             "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=",
             "dev": true
-        },
-        "subarg": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/subarg/-/subarg-1.0.0.tgz",
-            "integrity": "sha1-9izxdYHplrSPyWVpn1TAauJouNI=",
-            "dev": true,
-            "requires": {
-                "minimist": "^1.1.0"
-            },
-            "dependencies": {
-                "minimist": {
-                    "version": "1.2.0",
-                    "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-                    "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
-                    "dev": true
-                }
-            }
         },
         "supports-color": {
             "version": "5.5.0",
@@ -8187,17 +7737,17 @@
             }
         },
         "vsce": {
-            "version": "1.61.0",
-            "resolved": "https://registry.npmjs.org/vsce/-/vsce-1.61.0.tgz",
-            "integrity": "sha512-JmVxAO0HtdMjGcdiFPeTbddS//PvO2xVcE7/kq3H1ix3Q4bDyH6j1tSnDDl3OLQkxT/Cgyyqvv/wRohfy6v+lg==",
+            "version": "1.64.0",
+            "resolved": "https://registry.npmjs.org/vsce/-/vsce-1.64.0.tgz",
+            "integrity": "sha512-t3R7QTe2nAXQZs2kD+nA8GjdlX8pAQlnzxaNTG2976i5cyQ8r+ZsMNa/f9PDt7bhjcQM+u/fL+LkNuw+hwoy2A==",
             "dev": true,
             "requires": {
                 "azure-devops-node-api": "^7.2.0",
                 "chalk": "^2.4.2",
                 "cheerio": "^1.0.0-rc.1",
                 "commander": "^2.8.1",
-                "cpx": "^1.5.0",
                 "denodeify": "^1.2.1",
+                "didyoumean": "^1.2.1",
                 "glob": "^7.0.6",
                 "lodash": "^4.17.10",
                 "markdown-it": "^8.3.1",

--- a/package.json
+++ b/package.json
@@ -337,7 +337,7 @@
         "ts-node": "8.0.3",
         "tslint": "5.14.0",
         "typescript": "3.3.3",
-        "vsce": "1.61.0",
+        "vsce": "1.64.0",
         "vscode": "1.1.34",
         "webpack": "4.29.6",
         "webpack-cli": "3.2.3"


### PR DESCRIPTION
This PR updates the vsce package to the latest (1.64.0) to fix the npm audit issue https://nodesecurity.io/advisories/786 .

* Rolling vsce to version 1.64.0