### PR TITLE
Adding a default userDataDir setting to match Edge/Chrome debugger behavior

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,12 +1,12 @@
 {
     "cSpell.words": [
-        "activitybar",
         "Backend",
-        "blackbox",
-        "edgedevtools",
         "LOCALAPPDATA",
         "MSEDGE",
+        "activitybar",
+        "blackbox",
         "devtool",
+        "edgedevtools",
         "finalhandler",
         "geolocations",
         "monospace",
@@ -17,6 +17,7 @@
         "screencast",
         "undocked",
         "unhandledrejection",
+        "userdatadir",
         "vsce",
         "vsix"
     ]

--- a/README.md
+++ b/README.md
@@ -61,6 +61,14 @@ To add a new debug configuration, in your `launch.json` add a new debug config w
 }
 ```
 
+#### Other optional launch config fields
+* `browserPath`: The full path to the browser executable that will be launched. If not specified the most stable channel of Microsoft Edge (Chromium) will be launched from the default install location instead.
+* `hostname`: By default the extension searches for debuggable instances using `localhost`. If you are hosting your web app on a remote machine you can specify the hostname using this setting.
+* `port`: By default the extension will set the remote-debugging-port to `9222`. Use this option to specify a different port on which to connect.
+* `userDataDir`: Normally, if Microsoft Edge is already running when you start debugging with a launch config, then the new instance won't start in remote debugging mode. So by default, the extension launches Microsoft Edge with a separate user profile in a temp folder. Use this option to set a different path to use, or set to false to launch with your default user profile instead.
+* `useHttps`: By default the extension will search for attachable instances using the `http` protocol. Set this to true if you are hosting your web app over `https` instead.
+
+
 ### Launching the browser via the side bar view
 * Start Microsoft Edge via the side bar
   * Click the `Elements for Microsoft Edge` view in the side bar.

--- a/package.json
+++ b/package.json
@@ -116,10 +116,13 @@
                     "default": "about:blank",
                     "description": "The default url to open when launching the browser without a target"
                 },
-                "vscode-edge-devtools.userDataDirectory": {
-                    "type": "string",
-                    "default": "",
-                    "description": "A custom user data directory to use when launching the browser"
+                "vscode-edge-devtools.userDataDir": {
+                    "type": [
+                        "string",
+                        "boolean"
+                    ],
+                    "default": true,
+                    "description": "By default, Microsoft Edge is launched with a separate user profile in a temp folder. Use this option to override the path. You can also set to false to launch with your default user profile instead."
                 }
             }
         },
@@ -177,10 +180,13 @@
                                 "default": 9222,
                                 "description": "The port on which to search for remote debuggable instances"
                             },
-                            "userDataDirectory": {
-                                "type": "string",
-                                "default": "",
-                                "description": "A custom user data directory to use when launching the browser"
+                            "userDataDir": {
+                                "type": [
+                                  "string",
+                                  "boolean"
+                                ],
+                                "description": "By default, Microsoft Edge is launched with a separate user profile in a temp folder. Use this option to override the path. You can also set to false to launch with your default user profile instead.",
+                                "default": true
                             },
                             "useHttps": {
                                 "type": "boolean",
@@ -216,10 +222,13 @@
                                 "default": 9222,
                                 "description": "The port on which to search for remote debuggable instances"
                             },
-                            "userDataDirectory": {
-                                "type": "string",
-                                "default": "",
-                                "description": "A custom user data directory to use when launching the browser"
+                            "userDataDir": {
+                                "type": [
+                                  "string",
+                                  "boolean"
+                                ],
+                                "description": "By default, Microsoft Edge is launched with a separate user profile in a temp folder. Use this option to override the path. You can also set to false to launch with your default user profile instead.",
+                                "default": true
                             },
                             "useHttps": {
                                 "type": "boolean",


### PR DESCRIPTION
There have been several reported issues of the extension not working which after investigation have boiled down to the fact that Edge is already open without remote debugging enabled. The issue with this is that when we launch a new instance with the `--remote-debugging-port` flag set it doesn't actually enable remote debugging so the extension fails to attach.

The way the other Chromium debug extensions get around this is by changing their default behavior to use the `--user-data-dir` flag set to a temporary folder. This will force the browser to spin up a new manager process (which will look like a new window) that *does* have remote debugging enabled, and then they can connect to that instance.

This PR replaces the `userDataDirectory` setting with a newer `userDataDir` version that matches the behavior of the debugger extensions. The setting can be specified in the launch.json config file as either `true` (generate a temp folder), `false` (use your default profile folder), or a custom path. By default it will be `true` which will auto generate a data directory for the browser to use.

* Replaced `userDataDirectory` setting with a newer `userDataDir` version to match [vscode-edge-debug2](https://github.com/microsoft/vscode-edge-debug2)
* Added default behavior to use a temp directory
* Updated readme with information on the new flag (and other missing ones)
* Updated tests

Fixes #57 #58 #59 