### PR TITLE
Add flags for cleaner edge launch

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -264,6 +264,8 @@ export async function getBrowserPath(config: Partial<IUserConfig> = {}) {
  */
 export function launchBrowser(browserPath: string, port: number, targetUrl: string, userDataDir?: string) {
     const args = [
+        "--no-first-run",
+        "--no-default-browser-check",
         `--remote-debugging-port=${port}`,
         targetUrl,
     ];


### PR DESCRIPTION
Adding 2 new flags to the launch of the browser. These will disable the first launch experience and the check for the default browser. This matches the behavior of the chrome and edge debug extensions and provides a cleaner launch experience for the user.

* Added `--no-first-run` and `--no-default-browser-check` flags to launch