### PR TITLE
Bumping version to 1.0.1 for next preview release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,2 +1,6 @@
+## 1.0.1
+* Fixed launch procedure so that remote debugging will be enabled correctly - [PR #67](https://github.com/microsoft/vscode-edge-devtools/pull/67)
+* Updated readme
+
 ## 1.0.0
 * Initial preview release

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "vscode-edge-devtools",
     "displayName": "Elements for Microsoft Edge (Chromium)",
     "description": "Use the Microsoft Edge (Chromium) Elements tool from within VS Code to see your site's runtime HTML structure, alter its layout, and fix styling issues.",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "license": "SEE LICENSE IN LICENSE",
     "publisher": "ms-edgedevtools",
     "preview": true,


### PR DESCRIPTION
This PR updates the version number to 1.0.1 and adds information to the change log about the most relevant changes that are going into this update. The change log can be seen from the extension marketplace page or from inside VS Code itself.

* Bumped version to 1.0.1
* Updated change log