### PR TITLE
Adding sourcemap related settings ready for opening links in the editor

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ To add a new debug configuration, in your `launch.json` add a new debug config w
 * `useHttps`: By default the extension will search for attachable instances using the `http` protocol. Set this to true if you are hosting your web app over `https` instead.
 * `sourceMaps`: By default, the extension will use sourcemaps and your original sources whenever possible. You can disable this by setting `sourceMaps` to false.
 * `pathMapping`: This property takes a mapping of URL paths to local paths, to give you more flexibility in how URLs are resolved to local files. `"webRoot": "${workspaceFolder}"` is just shorthand for a pathMapping like `{ "/": "${workspaceFolder}" }`.
-* `sourceMapPathOverrides`: A mapping of source paths from the sourcemap, to the locations of these sources on disk. See [Sourcemps](#sourcemaps) for more information
+* `sourceMapPathOverrides`: A mapping of source paths from the sourcemap, to the locations of these sources on disk. See [Sourcemaps](#sourcemaps) for more information
 
 #### Sourcemaps
 The elements tool uses sourcemaps to correctly open original source files when you click links in the UI, but sometimes the sourcemaps aren't generated properly and overrides are needed. In the config we support `sourceMapPathOverrides`, a mapping of source paths from the sourcemap, to the locations of these sources on disk. Useful when the sourcemap isn't accurate or can't be fixed in the build process.

--- a/README.md
+++ b/README.md
@@ -79,18 +79,38 @@ The elements tool uses sourcemaps to correctly open original source files when y
 The left hand side of the mapping is a pattern that can contain a wildcard, and will be tested against the `sourceRoot` + `sources` entry in the source map. If it matches, the source file will be resolved to the path on the right hand side, which should be an absolute path to the source file on disk.
 
 A few mappings are applied by default, corresponding to some common default configs for Webpack and Meteor:
+Note: These are the mappings that are included by default out of the box, with examples of how they could be resolved in different scenarios. These are not mappings that would make sense together in one project.
+
 ```json
-// Note: These are the mappings that are included by default out of the box, with examples of how they could be resolved in different scenarios. These are not mappings that would make sense together in one project.
-// webRoot = /Users/me/project
 "sourceMapPathOverrides": {
-    "webpack:///./~/*": "${webRoot}/node_modules/*",       // Example: "webpack:///./~/querystring/index.js" -> "/Users/me/project/node_modules/querystring/index.js"
-    "webpack:///./*":   "${webRoot}/*",                    // Example: "webpack:///./src/app.js" -> "/Users/me/project/src/app.js",
-    "webpack:///*":     "*",                               // Example: "webpack:///project/app.ts" -> "/project/app.ts"
-    "webpack:///src/*": "${webRoot}/*",                    // Example: "webpack:///src/app.js" -> "/Users/me/project/app.js"
-    "meteor://💻app/*": "${webRoot}/*"                    // Example: "meteor://💻app/main.ts" -> "/Users/me/project/main.ts"
+    "webpack:///./~/*": "${webRoot}/node_modules/*",
+    "webpack:///./*": "${webRoot}/*",
+    "webpack:///*": "*",
+    "webpack:///src/*": "${webRoot}/*",
+    "meteor://💻app/*": "${webRoot}/*"
 }
 ```
-If you set `sourceMapPathOverrides` in your launch config, that will override these defaults. `${workspaceFolder}` and `${webRoot}` can be used here.
+If you set `sourceMapPathOverrides` in your launch config, that will override these defaults. `${workspaceFolder}` and `${webRoot}` can be used there.
+
+See the following examples for each entry in the default mappings (`webRoot = /Users/me/project`):
+
+`"webpack:///./~/*": "${webRoot}/node_modules/*"` Example:<br/>
+`"webpack:///./~/querystring/index.js"`
+-> `"/Users/me/project/node_modules/querystring/index.js"`
+
+`"webpack:///./*":   "${webRoot}/*"` Example:<br/>
+`"webpack:///./src/app.js"` -> `"/Users/me/project/src/app.js"`
+
+`"webpack:///*": "*"` Example <br/>
+`"webpack:///project/app.ts"` -> `"/project/app.ts"`
+
+`"webpack:///src/*": "${webRoot}/*"` Example <br/>
+`"webpack:///src/app.js"` -> `"/Users/me/project/app.js"`
+
+`"meteor://💻app/*": "${webRoot}/*"` Example <br/>
+`"meteor://💻app/main.ts"` -> `"/Users/me/project/main.ts"`
+
+
 
 ### Ionic/gulp-sourcemaps note
 Ionic and gulp-sourcemaps output a sourceRoot of `"/source/"` by default. If you can't fix this via your build config, try this setting:

--- a/package.json
+++ b/package.json
@@ -123,6 +123,34 @@
                     ],
                     "default": true,
                     "description": "By default, Microsoft Edge is launched with a separate user profile in a temp folder. Use this option to override the path. You can also set to false to launch with your default user profile instead."
+                },
+                "vscode-edge-devtools.webRoot": {
+                    "type": "string",
+                    "description": "The absolute path to the webserver root. Used to resolve paths like `/app.js` to files on disk",
+                    "default": "${workspaceFolder}"
+                },
+                "vscode-edge-devtools.pathMapping": {
+                    "type": "object",
+                    "default": {
+                        "/": "${workspaceFolder}"
+                    },
+                    "description": "A set of mappings for rewriting the locations of source files from what the sourcemap says, to their locations on disk"
+                },
+                "vscode-edge-devtools.sourceMapPathOverrides": {
+                    "type": "object",
+                    "description": "A set of mappings for rewriting the locations of source files from what the sourcemap says, to their locations on disk",
+                    "default": {
+                        "webpack:///./*": "${webRoot}/*",
+                        "webpack:///src/*": "${webRoot}/*",
+                        "webpack:///*": "*",
+                        "webpack:///./~/*": "${webRoot}/node_modules/*",
+                        "meteor://💻app/*": "${webRoot}/*"
+                    }
+                },
+                "vscode-edge-devtools.sourceMaps": {
+                  "type": "boolean",
+                  "description": "Use JavaScript source maps (if they exist)",
+                  "default": true
                 }
             }
         },
@@ -138,7 +166,8 @@
                             "type": "vscode-edge-devtools.debug",
                             "request": "launch",
                             "name": "Launch Microsoft Edge and open the Elements tool",
-                            "url": "http://localhost:8080"
+                            "url": "http://localhost:8080",
+                            "webRoot": "^\"${2:\\${workspaceFolder\\}}\""
                         }
                     },
                     {
@@ -148,7 +177,8 @@
                             "type": "vscode-edge-devtools.debug",
                             "request": "attach",
                             "name": "Attach to Microsoft Edge and open the Elements tool",
-                            "url": "http://localhost:8080"
+                            "url": "http://localhost:8080",
+                            "webRoot": "^\"${2:\\${workspaceFolder\\}}\""
                         }
                     }
                 ],
@@ -192,6 +222,34 @@
                                 "type": "boolean",
                                 "default": false,
                                 "description": "Should we request the remote target list using https rather than http"
+                            },
+                            "webRoot": {
+                                "type": "string",
+                                "description": "The absolute path to the webserver root. Used to resolve paths like `/app.js` to files on disk",
+                                "default": "${workspaceFolder}"
+                            },
+                            "pathMapping": {
+                                "type": "object",
+                                "description": "A mapping of URLs/paths to local folders, to resolve scripts in Microsoft Edge to scripts on disk",
+                                "default": {
+                                    "/": "${workspaceFolder}"
+                                }
+                            },
+                            "sourceMapPathOverrides": {
+                                "type": "object",
+                                "description": "A set of mappings for rewriting the locations of source files from what the sourcemap says, to their locations on disk",
+                                "default": {
+                                    "webpack:///./*": "${webRoot}/*",
+                                    "webpack:///src/*": "${webRoot}/*",
+                                    "webpack:///*": "*",
+                                    "webpack:///./~/*": "${webRoot}/node_modules/*",
+                                    "meteor://💻app/*": "${webRoot}/*"
+                                }
+                            },
+                            "sourceMaps": {
+                              "type": "boolean",
+                              "description": "Use JavaScript source maps (if they exist)",
+                              "default": true
                             }
                         }
                     },
@@ -234,6 +292,34 @@
                                 "type": "boolean",
                                 "default": false,
                                 "description": "Should we request the remote target list using https rather than http"
+                            },
+                            "webRoot": {
+                                "type": "string",
+                                "description": "The absolute path to the webserver root. Used to resolve paths like `/app.js` to files on disk",
+                                "default": "${workspaceFolder}"
+                            },
+                            "pathMapping": {
+                                "type": "object",
+                                "description": "A mapping of URLs/paths to local folders, to resolve scripts in Microsoft Edge to scripts on disk",
+                                "default": {
+                                    "/": "${workspaceFolder}"
+                                }
+                            },
+                            "sourceMapPathOverrides": {
+                                "type": "object",
+                                "description": "A set of mappings for rewriting the locations of source files from what the sourcemap says, to their locations on disk",
+                                "default": {
+                                    "webpack:///./*": "${webRoot}/*",
+                                    "webpack:///src/*": "${webRoot}/*",
+                                    "webpack:///*": "*",
+                                    "webpack:///./~/*": "${webRoot}/node_modules/*",
+                                    "meteor://💻app/*": "${webRoot}/*"
+                                }
+                            },
+                            "sourceMaps": {
+                              "type": "boolean",
+                              "description": "Use JavaScript source maps (if they exist)",
+                              "default": true
                             }
                         }
                     }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -28,6 +28,20 @@ export interface IUserConfig {
     port: number;
     useHttps: boolean;
     userDataDir: string | boolean;
+    webRoot: string;
+    pathMapping: IStringDictionary<string>;
+    sourceMapPathOverrides: IStringDictionary<string>;
+    sourceMaps: boolean;
+}
+
+export interface IRuntimeConfig {
+    pathMapping: IStringDictionary<string>;
+    sourceMapPathOverrides: IStringDictionary<string>;
+    sourceMaps: boolean;
+    webRoot: string;
+}
+export interface IStringDictionary<T> {
+    [name: string]: T;
 }
 
 export type Platform = "Windows" | "OSX" | "Linux";
@@ -44,6 +58,18 @@ export const SETTINGS_PREF_DEFAULTS = {
     uiTheme: '"dark"',
 };
 export const SETTINGS_VIEW_NAME = "vscode-edge-devtools-view";
+export const SETTINGS_DEFAULT_PATH_MAPPING: IStringDictionary<string> = {
+    "/": "${workspaceFolder}",
+};
+export const SETTINGS_DEFAULT_PATH_OVERRIDES: IStringDictionary<string> = {
+    "meteor://💻app/*": "${webRoot}/*",
+    "webpack:///*": "*",
+    "webpack:///./*": "${webRoot}/*",
+    "webpack:///./~/*": "${webRoot}/node_modules/*",
+    "webpack:///src/*": "${webRoot}/*",
+};
+export const SETTINGS_DEFAULT_WEB_ROOT: string = "${workspaceFolder}";
+export const SETTINGS_DEFAULT_SOURCE_MAPS: boolean = true;
 
 const WIN_APP_DATA = process.env.LOCALAPPDATA || "/";
 const WIN_MSEDGE_PATHS = [
@@ -303,4 +329,34 @@ export async function openNewTab(hostname: string, port: number, tabUrl?: string
  */
 export function removeTrailingSlash(uri: string) {
     return (uri.endsWith("/") ? uri.slice(0, -1) : uri);
+}
+
+/**
+ * Get the configuration settings that should be used at runtime.
+ * The order of precedence is launch.json > extension settings > default values.
+ * @param config A user specified config from launch.json
+ */
+export function getRuntimeConfig(config: Partial<IUserConfig> = {}): IRuntimeConfig {
+    const settings = vscode.workspace.getConfiguration(SETTINGS_STORE_NAME);
+    const pathMapping = config.pathMapping || settings.get("pathMapping") || SETTINGS_DEFAULT_PATH_MAPPING;
+    const sourceMapPathOverrides =
+        config.sourceMapPathOverrides || settings.get("sourceMapPathOverrides") || SETTINGS_DEFAULT_PATH_OVERRIDES;
+    const webRoot = config.webRoot || settings.get("webRoot") || SETTINGS_DEFAULT_WEB_ROOT;
+
+    let sourceMaps = SETTINGS_DEFAULT_SOURCE_MAPS;
+    if (typeof config.sourceMaps !== "undefined") {
+        sourceMaps = config.sourceMaps;
+    } else {
+        const settingsSourceMaps: boolean | undefined = settings.get("sourceMaps");
+        if (typeof settingsSourceMaps !== "undefined") {
+            sourceMaps = settingsSourceMaps;
+        }
+    }
+
+    return {
+        pathMapping,
+        sourceMapPathOverrides,
+        sourceMaps,
+        webRoot,
+    };
 }


### PR DESCRIPTION
This PR is the second step in the feature to open links from the Elements tool in the VS Code editor (see #55). It adds a number of settings that can be specified by the user in either their `launch.json` or in the extension settings (for when attach/launch is done using the side panel). The actual opening of the files in the Editor will be done in a follow up PR.

The source map settings match those used by the debugger for Edge extension and will be used to map the runtime source locations reported by the browser, such as `http://localhost:8080/app/file.js` to files that exist on disk, such as `build/out/app/file.ts`.

A new function has been added to get the various runtime settings based on the order of presidence:
launch.json > extension settings > default values

* Added new sourcemap settings to `package.json`
* Updated readme
* Added new getRuntimeConfig() function
* Added unit tests
