### PR TITLE
Pass the runtime config to DevToolsPanel

### DIFF
--- a/src/devtoolsPanel.ts
+++ b/src/devtoolsPanel.ts
@@ -14,6 +14,7 @@ import {
 import { PanelSocket } from "./panelSocket";
 import {
     fetchUri,
+    IRuntimeConfig,
     SETTINGS_PREF_DEFAULTS,
     SETTINGS_PREF_NAME,
     SETTINGS_STORE_NAME,
@@ -22,6 +23,7 @@ import {
 
 export class DevToolsPanel {
     private static instance: DevToolsPanel | undefined;
+    private readonly config: IRuntimeConfig;
     private readonly context: vscode.ExtensionContext;
     private readonly disposables: vscode.Disposable[] = [];
     private readonly extensionPath: string;
@@ -34,12 +36,14 @@ export class DevToolsPanel {
         panel: vscode.WebviewPanel,
         context: vscode.ExtensionContext,
         telemetryReporter: Readonly<TelemetryReporter>,
-        targetUrl: string) {
+        targetUrl: string,
+        config: IRuntimeConfig) {
         this.panel = panel;
         this.context = context;
         this.telemetryReporter = telemetryReporter;
         this.extensionPath = this.context.extensionPath;
         this.targetUrl = targetUrl;
+        this.config = config;
 
         // Hook up the socket events
         this.panelSocket = new PanelSocket(this.targetUrl, (e, msg) => this.postToDevTools(e, msg));
@@ -170,6 +174,11 @@ export class DevToolsPanel {
     }
 
     private async onSocketOpenInEditor(message: string) {
+        // Report usage telemetry
+        this.telemetryReporter.sendTelemetryEvent("extension/openInEditor", {
+            sourceMaps: `${this.config.sourceMaps}`,
+        });
+
         // TODO: Parse message and open the requested file
     }
 
@@ -209,7 +218,8 @@ export class DevToolsPanel {
     public static createOrShow(
         context: vscode.ExtensionContext,
         telemetryReporter: Readonly<TelemetryReporter>,
-        targetUrl: string) {
+        targetUrl: string,
+        config: IRuntimeConfig) {
         const column = vscode.ViewColumn.Beside;
 
         if (DevToolsPanel.instance) {
@@ -221,7 +231,7 @@ export class DevToolsPanel {
                 retainContextWhenHidden: true,
             });
 
-            DevToolsPanel.instance = new DevToolsPanel(panel, context, telemetryReporter, targetUrl);
+            DevToolsPanel.instance = new DevToolsPanel(panel, context, telemetryReporter, targetUrl, config);
         }
     }
 }

--- a/src/extension.test.ts
+++ b/src/extension.test.ts
@@ -4,11 +4,19 @@
 import { ExtensionContext } from "vscode";
 import TelemetryReporter from "vscode-extension-telemetry";
 import { createFakeExtensionContext, createFakeTelemetryReporter, createFakeVSCode, Mocked } from "./test/helpers";
-import { IRemoteTargetJson, removeTrailingSlash, SETTINGS_STORE_NAME, SETTINGS_VIEW_NAME } from "./utils";
+import {
+    IRemoteTargetJson,
+    IRuntimeConfig,
+    removeTrailingSlash,
+    SETTINGS_STORE_NAME,
+    SETTINGS_VIEW_NAME,
+} from "./utils";
 
 jest.mock("vscode", () => createFakeVSCode(), { virtual: true });
 
 describe("extension", () => {
+    const fakeRuntimeConfig: Partial<IRuntimeConfig> = {};
+
     describe("activate", () => {
         let context: ExtensionContext;
         let commandMock: jest.Mock;
@@ -28,6 +36,7 @@ describe("extension", () => {
                 createTelemetryReporter: jest.fn((_: ExtensionContext) => createFakeTelemetryReporter()),
                 getListOfTargets: jest.fn(),
                 getRemoteEndpointSettings: jest.fn(),
+                getRuntimeConfig: jest.fn(),
                 removeTrailingSlash: jest.fn(removeTrailingSlash),
             };
             jest.doMock("./utils", () => mockUtils);
@@ -171,6 +180,7 @@ describe("extension", () => {
                         port: "port",
                         useHttps: false,
                     }),
+                    getRuntimeConfig: jest.fn().mockReturnValue(fakeRuntimeConfig),
                     removeTrailingSlash: jest.fn(removeTrailingSlash),
                 },
                 vscode: createFakeVSCode(),
@@ -235,6 +245,7 @@ describe("extension", () => {
                 expectedContext,
                 mockTelemetry,
                 expectedPick.detail,
+                fakeRuntimeConfig,
             );
         });
 
@@ -256,6 +267,7 @@ describe("extension", () => {
                 expectedContext,
                 mockTelemetry,
                 expectedWS,
+                fakeRuntimeConfig,
             );
         });
 
@@ -277,6 +289,7 @@ describe("extension", () => {
                 expectedContext,
                 mockTelemetry,
                 expectedWS,
+                fakeRuntimeConfig,
             );
 
             // Reverse the mismatched slashes
@@ -286,6 +299,7 @@ describe("extension", () => {
                 expectedContext,
                 mockTelemetry,
                 expectedWS,
+                fakeRuntimeConfig,
             );
         });
 
@@ -332,6 +346,7 @@ describe("extension", () => {
                     port: "port",
                     useHttps: false,
                 }),
+                getRuntimeConfig: jest.fn().mockReturnValue(fakeRuntimeConfig),
                 launchBrowser: jest.fn(),
                 openNewTab: jest.fn().mockResolvedValue(null),
                 removeTrailingSlash: jest.fn(removeTrailingSlash),
@@ -417,6 +432,7 @@ describe("extension", () => {
                 expect.any(Object),
                 expect.any(Object),
                 target.webSocketDebuggerUrl,
+                fakeRuntimeConfig,
             );
         });
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -13,6 +13,7 @@ import {
     getBrowserPath,
     getListOfTargets,
     getRemoteEndpointSettings,
+    getRuntimeConfig,
     IRemoteTargetJson,
     IUserConfig,
     launchBrowser,
@@ -59,7 +60,8 @@ export function activate(context: vscode.ExtensionContext) {
         `${SETTINGS_VIEW_NAME}.attach`,
         (target: CDPTarget) => {
             telemetryReporter.sendTelemetryEvent("view/devtools");
-            DevToolsPanel.createOrShow(context, telemetryReporter, target.websocketUrl);
+            const runtimeConfig = getRuntimeConfig();
+            DevToolsPanel.createOrShow(context, telemetryReporter, target.websocketUrl, runtimeConfig);
         }));
     context.subscriptions.push(vscode.commands.registerCommand(
         `${SETTINGS_VIEW_NAME}.copyItem`,
@@ -114,13 +116,15 @@ export async function attach(context: vscode.ExtensionContext, attachUrl?: strin
         if (targetWebsocketUrl) {
             // Auto connect to found target
             telemetryReporter.sendTelemetryEvent("command/attach/devtools", telemetryProps);
-            DevToolsPanel.createOrShow(context, telemetryReporter, targetWebsocketUrl);
+            const runtimeConfig = getRuntimeConfig(config);
+            DevToolsPanel.createOrShow(context, telemetryReporter, targetWebsocketUrl, runtimeConfig);
         } else {
             // Show the target list and allow the user to select one
             const selection = await vscode.window.showQuickPick(items);
             if (selection && selection.detail) {
                 telemetryReporter.sendTelemetryEvent("command/attach/devtools", telemetryProps);
-                DevToolsPanel.createOrShow(context, telemetryReporter, selection.detail);
+                const runtimeConfig = getRuntimeConfig(config);
+                DevToolsPanel.createOrShow(context, telemetryReporter, selection.detail, runtimeConfig);
             }
         }
     } else {
@@ -142,7 +146,8 @@ export async function launch(context: vscode.ExtensionContext, launchUrl?: strin
     if (target && target.webSocketDebuggerUrl) {
         // Show the devtools
         telemetryReporter.sendTelemetryEvent("command/launch/devtools", telemetryProps);
-        DevToolsPanel.createOrShow(context, telemetryReporter, target.webSocketDebuggerUrl);
+        const runtimeConfig = getRuntimeConfig(config);
+        DevToolsPanel.createOrShow(context, telemetryReporter, target.webSocketDebuggerUrl, runtimeConfig);
     } else {
         // Launch a new instance
         const browserPath = await getBrowserPath(config);


### PR DESCRIPTION
This PR is the third step in the feature to open links from the Elements tool in the VS Code editor (see #55). It plumbs through the runtime config from the PR #75 to the DevToolsPanel where it will be used to map the devtools link to the editor file on disk so that it can be opened.

* Added new param to DevToolsPanel constructor
* Passing runtimeConfig to the DevToolsPanel via extension.ts
* Added a new telemetry call to record usage for the open in editor feature
* Updated tests to use a mock config and added a new test for the telemetry
