### PR TITLE
Moving to new vscode package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -499,6 +499,12 @@
             "integrity": "sha512-l42BggppR6zLmpfU6fq9HEa2oGPEI8yrSPL3GITjfRInppYFahObbIQOQK3UGxEnyQpltZLaPe75046NOZQikw==",
             "dev": true
         },
+        "@types/vscode": {
+            "version": "1.36.0",
+            "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.36.0.tgz",
+            "integrity": "sha512-SbHR3Q5g/C3N+Ila3KrRf1rSZiyHxWdOZ7X3yFHXzw6HrvRLuVZrxnwEX0lTBMRpH9LkwZdqRTgXW+D075jxkg==",
+            "dev": true
+        },
         "@types/ws": {
             "version": "6.0.1",
             "resolved": "https://registry.npmjs.org/@types/ws/-/ws-6.0.1.tgz",
@@ -1194,12 +1200,6 @@
                     "dev": true
                 }
             }
-        },
-        "browser-stdout": {
-            "version": "1.3.1",
-            "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz",
-            "integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==",
-            "dev": true
         },
         "browserify-aes": {
             "version": "1.2.0",
@@ -3263,12 +3263,6 @@
             "integrity": "sha512-jpSvDPV4Cq/bgtpndIWbI5hmYxhQGHPC4d4cqBPb4DLniCfhJokdXhwhaDuLBGLQdvvRum/UiX6ECVIPvDXqdg==",
             "dev": true
         },
-        "growl": {
-            "version": "1.10.5",
-            "resolved": "https://registry.npmjs.org/growl/-/growl-1.10.5.tgz",
-            "integrity": "sha512-qBr4OuELkhPenW6goKVXiv47US3clb3/IbuWF9KNKEijAy9oeHxU9IgzjvJhHkUzhaj7rOUD7+YGWqUjLp5oSA==",
-            "dev": true
-        },
         "growly": {
             "version": "1.3.0",
             "resolved": "https://registry.npmjs.org/growly/-/growly-1.3.0.tgz",
@@ -3375,12 +3369,6 @@
                 "inherits": "^2.0.3",
                 "minimalistic-assert": "^1.0.1"
             }
-        },
-        "he": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/he/-/he-1.1.1.tgz",
-            "integrity": "sha1-k0EP0hsAlzUVH4howvJx80J+I/0=",
-            "dev": true
         },
         "hmac-drbg": {
             "version": "1.0.1",
@@ -4833,62 +4821,6 @@
                 "minimist": "0.0.8"
             }
         },
-        "mocha": {
-            "version": "5.2.0",
-            "resolved": "https://registry.npmjs.org/mocha/-/mocha-5.2.0.tgz",
-            "integrity": "sha512-2IUgKDhc3J7Uug+FxMXuqIyYzH7gJjXECKe/w43IGgQHTSj3InJi+yAA7T24L9bQMRKiUEHxEX37G5JpVUGLcQ==",
-            "dev": true,
-            "requires": {
-                "browser-stdout": "1.3.1",
-                "commander": "2.15.1",
-                "debug": "3.1.0",
-                "diff": "3.5.0",
-                "escape-string-regexp": "1.0.5",
-                "glob": "7.1.2",
-                "growl": "1.10.5",
-                "he": "1.1.1",
-                "minimatch": "3.0.4",
-                "mkdirp": "0.5.1",
-                "supports-color": "5.4.0"
-            },
-            "dependencies": {
-                "commander": {
-                    "version": "2.15.1",
-                    "resolved": "https://registry.npmjs.org/commander/-/commander-2.15.1.tgz",
-                    "integrity": "sha512-VlfT9F3V0v+jr4yxPc5gg9s62/fIVWsd2Bk2iD435um1NlGMYdVCq+MjcXnhYq2icNOizHr1kK+5TI6H0Hy0ag==",
-                    "dev": true
-                },
-                "diff": {
-                    "version": "3.5.0",
-                    "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
-                    "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==",
-                    "dev": true
-                },
-                "glob": {
-                    "version": "7.1.2",
-                    "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
-                    "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
-                    "dev": true,
-                    "requires": {
-                        "fs.realpath": "^1.0.0",
-                        "inflight": "^1.0.4",
-                        "inherits": "2",
-                        "minimatch": "^3.0.4",
-                        "once": "^1.3.0",
-                        "path-is-absolute": "^1.0.0"
-                    }
-                },
-                "supports-color": {
-                    "version": "5.4.0",
-                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
-                    "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
-                    "dev": true,
-                    "requires": {
-                        "has-flag": "^3.0.0"
-                    }
-                }
-            }
-        },
         "move-concurrently": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/move-concurrently/-/move-concurrently-1.0.1.tgz",
@@ -5603,12 +5535,6 @@
             "integrity": "sha1-nsYfeQSYdXB9aUFFlv2Qek1xHnM=",
             "dev": true
         },
-        "querystringify": {
-            "version": "2.1.1",
-            "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.1.1.tgz",
-            "integrity": "sha512-w7fLxIRCRT7U8Qu53jQnJyPkYZIaR4n5151KMfcJlO/A9397Wxb1amJvROTK6TOnp7PfoAmg/qXiNHI+08jRfA==",
-            "dev": true
-        },
         "randombytes": {
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
@@ -5785,12 +5711,6 @@
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
             "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
-            "dev": true
-        },
-        "requires-port": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
-            "integrity": "sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8=",
             "dev": true
         },
         "resolve": {
@@ -6994,16 +6914,6 @@
             "integrity": "sha1-dBxsL0WWxIMNZxhGCSDQySIC3Hg=",
             "dev": true
         },
-        "url-parse": {
-            "version": "1.4.7",
-            "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.4.7.tgz",
-            "integrity": "sha512-d3uaVyzDB9tQoSXFvuSUNFibTd9zxd2bkVrDRvF5TmvWWQwqE4lgYJ5m+x1DbecWkw+LK4RNl2CU1hHuOKPVlg==",
-            "dev": true,
-            "requires": {
-                "querystringify": "^2.1.1",
-                "requires-port": "^1.0.0"
-            }
-        },
         "use": {
             "version": "3.1.1",
             "resolved": "https://registry.npmjs.org/use/-/use-3.1.1.tgz",
@@ -7102,21 +7012,6 @@
                 "yazl": "^2.2.2"
             }
         },
-        "vscode": {
-            "version": "1.1.35",
-            "resolved": "https://registry.npmjs.org/vscode/-/vscode-1.1.35.tgz",
-            "integrity": "sha512-xPnxzQU40LOS2yPyzWW+WKpTV6qA3z16TcgpZ9O38UWLA157Zz4GxUx5H7Gd07pxzw0GqvusbF4D+5GBgNxvEQ==",
-            "dev": true,
-            "requires": {
-                "glob": "^7.1.2",
-                "mocha": "^5.2.0",
-                "request": "^2.88.0",
-                "semver": "^5.4.1",
-                "source-map-support": "^0.5.0",
-                "url-parse": "^1.4.4",
-                "vscode-test": "^0.4.1"
-            }
-        },
         "vscode-extension-telemetry": {
             "version": "0.1.1",
             "resolved": "https://registry.npmjs.org/vscode-extension-telemetry/-/vscode-extension-telemetry-0.1.1.tgz",
@@ -7126,9 +7021,9 @@
             }
         },
         "vscode-test": {
-            "version": "0.4.3",
-            "resolved": "https://registry.npmjs.org/vscode-test/-/vscode-test-0.4.3.tgz",
-            "integrity": "sha512-EkMGqBSefZH2MgW65nY05rdRSko15uvzq4VAPM5jVmwYuFQKE7eikKXNJDRxL+OITXHB6pI+a3XqqD32Y3KC5w==",
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/vscode-test/-/vscode-test-1.0.2.tgz",
+            "integrity": "sha512-lBvwzJWl/uVfsa2buouUwIaN10MIaiZMlTXP+rESGrHLa12Nt8nP2xroZYdbnSv1DrTCFjnQAsGXbCJnQC585A==",
             "dev": true,
             "requires": {
                 "http-proxy-agent": "^2.1.0",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
         "dom"
     ],
     "engines": {
-        "vscode": "^1.33.1"
+        "vscode": "^1.36.0"
     },
     "categories": [
         "Debuggers"
@@ -413,7 +413,6 @@
         "watch": "npm run watch-wp",
         "watch-wp": "webpack --watch",
         "lint": "tslint -c tslint.json -p tsconfig.json",
-        "postinstall": "node ./node_modules/vscode/bin/install",
         "test": "npm run lint && jest --coverage"
     },
     "dependencies": {
@@ -425,7 +424,7 @@
         "@types/jest": "24.0.15",
         "@types/node": "12.6.8",
         "@types/ws": "6.0.1",
-        "diff": "3.5.0",
+        "@types/vscode": "1.36.0",
         "fs-extra": "8.1.0",
         "jest": "24.8.0",
         "ts-jest": "24.0.2",
@@ -434,7 +433,7 @@
         "tslint": "5.18.0",
         "typescript": "3.5.3",
         "vsce": "1.65.0",
-        "vscode": "1.1.35",
+        "vscode-test": "1.0.2",
         "webpack": "4.36.1",
         "webpack-cli": "3.3.6"
     }


### PR DESCRIPTION
This PR updates the package.json file to use the new format for VS Code extensions from the 1.36.0 update. You can read more about the package changes here:
https://code.visualstudio.com/updates/v1_36#_splitting-vscode-package-into-typesvscode-and-vscodetest

The PR follows the migration guidance from here: https://code.visualstudio.com/api/working-with-extensions/testing-extension#migrating-from-vscode

* Updated to use the new @types/vscode and vscode-test packages
* Updated to 1.36 VS Code engine version
* Removed diff dev dependency
