### PR TITLE
Actually opening files in editor from links in the elements tool

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -493,6 +493,11 @@
             "integrity": "sha512-aX+gFgA5GHcDi89KG5keey2zf0WfZk/HAQotEamsK2kbey+8yGKcson0hbK8E+v0NArlCJQCqMP161YhV6ZXLg==",
             "dev": true
         },
+        "@types/source-map": {
+            "version": "0.1.29",
+            "resolved": "https://registry.npmjs.org/@types/source-map/-/source-map-0.1.29.tgz",
+            "integrity": "sha1-1wSKYBgLCfiqbVO9oxHGtRy9cBg="
+        },
         "@types/stack-utils": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-1.0.1.tgz",
@@ -1024,8 +1029,7 @@
         "balanced-match": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-            "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
-            "dev": true
+            "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
         },
         "base": {
             "version": "0.11.2",
@@ -1131,7 +1135,6 @@
             "version": "1.1.11",
             "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
             "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-            "dev": true,
             "requires": {
                 "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
@@ -1581,11 +1584,19 @@
                 "object-visit": "^1.0.0"
             }
         },
+        "color": {
+            "version": "3.1.2",
+            "resolved": "https://registry.npmjs.org/color/-/color-3.1.2.tgz",
+            "integrity": "sha512-vXTJhHebByxZn3lDvDJYw4lR5+uB3vuoHsuYA5AKuxRVn5wzzIfQKGLBmgdVRHKTJYeK5rvJcHnrd0Li49CFpg==",
+            "requires": {
+                "color-convert": "^1.9.1",
+                "color-string": "^1.5.2"
+            }
+        },
         "color-convert": {
             "version": "1.9.3",
             "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
             "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-            "dev": true,
             "requires": {
                 "color-name": "1.1.3"
             }
@@ -1593,8 +1604,16 @@
         "color-name": {
             "version": "1.1.3",
             "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-            "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
-            "dev": true
+            "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
+        },
+        "color-string": {
+            "version": "1.5.3",
+            "resolved": "https://registry.npmjs.org/color-string/-/color-string-1.5.3.tgz",
+            "integrity": "sha512-dC2C5qeWoYkxki5UAXapdjqO672AM4vZuPGRQfO8b5HKuKGBbKWpITyDYN7TOFKvRW7kOgAn3746clDBMDJyQw==",
+            "requires": {
+                "color-name": "^1.0.0",
+                "simple-swizzle": "^0.2.2"
+            }
         },
         "combined-stream": {
             "version": "1.0.7",
@@ -1626,8 +1645,7 @@
         "concat-map": {
             "version": "0.0.1",
             "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-            "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-            "dev": true
+            "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
         },
         "concat-stream": {
             "version": "1.6.2",
@@ -1948,6 +1966,11 @@
             "resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-2.1.0.tgz",
             "integrity": "sha1-9B8cEL5LAOh7XxPaaAdZ8sW/0+I=",
             "dev": true
+        },
+        "devtools-protocol": {
+            "version": "0.0.588169",
+            "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.588169.tgz",
+            "integrity": "sha512-DDGCT3YFiamX4jRPqg4galOrQS8DsU0j+xM5iaR0YB5TM1fjCZejQ7MSe9ByIMIq4IsnULY/4Qp3TBWAUjMgXw=="
         },
         "diagnostic-channel": {
             "version": "0.2.0",
@@ -2613,8 +2636,7 @@
         "fs.realpath": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-            "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
-            "dev": true
+            "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
         },
         "fsevents": {
             "version": "1.2.9",
@@ -3185,7 +3207,6 @@
             "version": "7.1.3",
             "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
             "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
-            "dev": true,
             "requires": {
                 "fs.realpath": "^1.0.0",
                 "inflight": "^1.0.4",
@@ -3522,7 +3543,6 @@
             "version": "1.0.6",
             "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
             "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
-            "dev": true,
             "requires": {
                 "once": "^1.3.0",
                 "wrappy": "1"
@@ -3531,8 +3551,7 @@
         "inherits": {
             "version": "2.0.3",
             "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-            "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
-            "dev": true
+            "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
         },
         "ini": {
             "version": "1.3.5",
@@ -4774,7 +4793,6 @@
             "version": "3.0.4",
             "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
             "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
-            "dev": true,
             "requires": {
                 "brace-expansion": "^1.1.7"
             }
@@ -4782,8 +4800,7 @@
         "minimist": {
             "version": "0.0.8",
             "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-            "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
-            "dev": true
+            "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
         },
         "mississippi": {
             "version": "3.0.0",
@@ -4828,7 +4845,6 @@
             "version": "0.5.1",
             "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
             "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
-            "dev": true,
             "requires": {
                 "minimist": "0.0.8"
             }
@@ -5023,6 +5039,11 @@
                 "which": "^1.3.0"
             }
         },
+        "noice-json-rpc": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/noice-json-rpc/-/noice-json-rpc-1.2.0.tgz",
+            "integrity": "sha512-Wm+otW+drKzdqlSPoSwj34tUEq/Xj1gX6Cr2avrykvTW4IY7d3ngLmP+PErALzS0s9nYRokXvYDM54sbFvLlDA=="
+        },
         "normalize-package-data": {
             "version": "2.5.0",
             "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
@@ -5155,7 +5176,6 @@
             "version": "1.4.0",
             "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
             "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-            "dev": true,
             "requires": {
                 "wrappy": "1"
             }
@@ -5383,8 +5403,7 @@
         "path-is-absolute": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-            "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
-            "dev": true
+            "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
         },
         "path-key": {
             "version": "2.0.1",
@@ -6032,6 +6051,21 @@
             "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
             "dev": true
         },
+        "simple-swizzle": {
+            "version": "0.2.2",
+            "resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.2.tgz",
+            "integrity": "sha1-pNprY1/8zMoz9w0Xy5JZLeleVXo=",
+            "requires": {
+                "is-arrayish": "^0.3.1"
+            },
+            "dependencies": {
+                "is-arrayish": {
+                    "version": "0.3.2",
+                    "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.2.tgz",
+                    "integrity": "sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ=="
+                }
+            }
+        },
         "sisteransi": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.2.tgz",
@@ -6175,8 +6209,7 @@
         "source-map": {
             "version": "0.6.1",
             "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-            "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-            "dev": true
+            "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
         },
         "source-map-resolve": {
             "version": "0.5.2",
@@ -7117,6 +7150,48 @@
                 "vscode-test": "^0.4.1"
             }
         },
+        "vscode-chrome-debug-core": {
+            "version": "6.7.51",
+            "resolved": "https://registry.npmjs.org/vscode-chrome-debug-core/-/vscode-chrome-debug-core-6.7.51.tgz",
+            "integrity": "sha512-7mJs+1POJ307jIX2XhNq9765atTqXEIUXRRVynGr5QGrDrBwS82Yrq4eYlwoAXqDqnLXAOY12lDPurvjF/gD9A==",
+            "requires": {
+                "@types/source-map": "^0.1.27",
+                "color": "^3.0.0",
+                "devtools-protocol": "0.0.588169",
+                "glob": "^7.1.3",
+                "noice-json-rpc": "^1.2.0",
+                "source-map": "^0.6.1",
+                "vscode-debugadapter": "^1.34.0",
+                "vscode-debugprotocol": "^1.34.0",
+                "vscode-nls": "^4.0.0",
+                "vscode-uri": "^2.0.2",
+                "ws": "^6.0.0"
+            },
+            "dependencies": {
+                "ws": {
+                    "version": "6.2.1",
+                    "resolved": "https://registry.npmjs.org/ws/-/ws-6.2.1.tgz",
+                    "integrity": "sha512-GIyAXC2cB7LjvpgMt9EKS2ldqr0MTrORaleiOno6TweZ6r3TKtoFQWay/2PceJ3RuBasOHzXNn5Lrw1X0bEjqA==",
+                    "requires": {
+                        "async-limiter": "~1.0.0"
+                    }
+                }
+            }
+        },
+        "vscode-debugadapter": {
+            "version": "1.35.0",
+            "resolved": "https://registry.npmjs.org/vscode-debugadapter/-/vscode-debugadapter-1.35.0.tgz",
+            "integrity": "sha512-Au90Iowj6TuD5uDMaTnxOjl/9hQN0Yoky1TV1Cjjr7jPdxTQpALBRW09Y2LzkIXUVICXlAqxWL9zL8BpzI30jg==",
+            "requires": {
+                "mkdirp": "^0.5.1",
+                "vscode-debugprotocol": "1.35.0"
+            }
+        },
+        "vscode-debugprotocol": {
+            "version": "1.35.0",
+            "resolved": "https://registry.npmjs.org/vscode-debugprotocol/-/vscode-debugprotocol-1.35.0.tgz",
+            "integrity": "sha512-+OMm11R1bGYbpIJ5eQIkwoDGFF4GvBz3Ztl6/VM+/RNNb2Gjk2c0Ku+oMmfhlTmTlPCpgHBsH4JqVCbUYhu5bA=="
+        },
         "vscode-extension-telemetry": {
             "version": "0.1.1",
             "resolved": "https://registry.npmjs.org/vscode-extension-telemetry/-/vscode-extension-telemetry-0.1.1.tgz",
@@ -7124,6 +7199,11 @@
             "requires": {
                 "applicationinsights": "1.0.8"
             }
+        },
+        "vscode-nls": {
+            "version": "4.1.1",
+            "resolved": "https://registry.npmjs.org/vscode-nls/-/vscode-nls-4.1.1.tgz",
+            "integrity": "sha512-4R+2UoUUU/LdnMnFjePxfLqNhBS8lrAFyX7pjb2ud/lqDkrUavFUTcG7wR0HBZFakae0Q6KLBFjMS6W93F403A=="
         },
         "vscode-test": {
             "version": "0.4.3",
@@ -7134,6 +7214,11 @@
                 "http-proxy-agent": "^2.1.0",
                 "https-proxy-agent": "^2.2.1"
             }
+        },
+        "vscode-uri": {
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/vscode-uri/-/vscode-uri-2.0.3.tgz",
+            "integrity": "sha512-4D3DI3F4uRy09WNtDGD93H9q034OHImxiIcSq664Hq1Y1AScehlP3qqZyTkX/RWxeu0MRMHGkrxYqm2qlDF/aw=="
         },
         "w3c-hr-time": {
             "version": "1.0.1",
@@ -7423,8 +7508,7 @@
         "wrappy": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-            "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-            "dev": true
+            "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
         },
         "write-file-atomic": {
             "version": "2.4.1",

--- a/package.json
+++ b/package.json
@@ -417,6 +417,7 @@
         "test": "npm run lint && jest --coverage"
     },
     "dependencies": {
+        "vscode-chrome-debug-core": "6.7.51",
         "vscode-extension-telemetry": "0.1.1",
         "ws": "7.1.0"
     },

--- a/src/common/webviewEvents.ts
+++ b/src/common/webviewEvents.ts
@@ -37,6 +37,13 @@ export interface ITelemetryDataObject {
 }
 export type TelemetryData = ITelemetryDataNumber | ITelemetryDataObject;
 
+export interface IOpenEditorData {
+    url: string;
+    line: number;
+    column: number;
+    ignoreTabChanges: boolean;
+}
+
 /**
  * Parse out the WebviewEvents type from a message and call the appropriate emit event
  * @param message The message to parse

--- a/src/devtoolsPanel.test.ts
+++ b/src/devtoolsPanel.test.ts
@@ -419,6 +419,7 @@ describe("devtoolsPanel", () => {
                 };
 
                 const mockUtils = {
+                    applyPathMapping: jest.fn().mockImplementation((x) => x),
                     fetchUri: jest.fn().mockRejectedValue(null),
                 };
                 jest.doMock("./utils", () => mockUtils);
@@ -431,6 +432,29 @@ describe("devtoolsPanel", () => {
                     `extension/openInEditor`,
                     expect.objectContaining({ sourceMaps: "true" }),
                 );
+            });
+
+            it("calls show document for open in editor", async () => {
+                const expectedRequest = {
+                    column: 5,
+                    line: 1,
+                    url: "app.js",
+                };
+
+                const mockUtils = {
+                    applyPathMapping: jest.fn().mockImplementation((x) => x),
+                    fetchUri: jest.fn().mockRejectedValue(null),
+                };
+                jest.doMock("./utils", () => mockUtils);
+
+                const mockVsCode = jest.requireMock("vscode");
+                mockVsCode.Uri.file = jest.fn(() => { throw new Error(); });
+
+                const dtp = await import("./devtoolsPanel");
+                dtp.DevToolsPanel.createOrShow(context, mockTelemetry, "", mockRuntimeConfig);
+
+                await hookedEvents.get("openInEditor")!(JSON.stringify(expectedRequest));
+                expect(mockVsCode.window.showTextDocument).toHaveBeenCalled();
             });
         });
     });

--- a/src/devtoolsPanel.test.ts
+++ b/src/devtoolsPanel.test.ts
@@ -46,6 +46,7 @@ describe("devtoolsPanel", () => {
             onDidChangeViewState: jest.fn(),
             onDidDispose: jest.fn(),
             reveal: jest.fn(),
+            viewColumn: 1,
             webview: {
                 onDidReceiveMessage: jest.fn(),
                 postMessage: jest.fn(),
@@ -415,14 +416,9 @@ describe("devtoolsPanel", () => {
                 const expectedRequest = {
                     column: 2,
                     line: 4,
+                    omitFocus: true,
                     url: "http://fake.com/app.js",
                 };
-
-                const mockUtils = {
-                    applyPathMapping: jest.fn().mockImplementation((x) => x),
-                    fetchUri: jest.fn().mockRejectedValue(null),
-                };
-                jest.doMock("./utils", () => mockUtils);
 
                 const dtp = await import("./devtoolsPanel");
                 dtp.DevToolsPanel.createOrShow(context, mockTelemetry, "", mockRuntimeConfig);
@@ -438,17 +434,18 @@ describe("devtoolsPanel", () => {
                 const expectedRequest = {
                     column: 5,
                     line: 1,
+                    omitFocus: false,
                     url: "app.js",
                 };
+
+                const mockVsCode = jest.requireMock("vscode");
+                mockVsCode.Uri.file = jest.fn(() => { throw new Error(); });
 
                 const mockUtils = {
                     applyPathMapping: jest.fn().mockImplementation((x) => x),
                     fetchUri: jest.fn().mockRejectedValue(null),
                 };
                 jest.doMock("./utils", () => mockUtils);
-
-                const mockVsCode = jest.requireMock("vscode");
-                mockVsCode.Uri.file = jest.fn(() => { throw new Error(); });
 
                 const dtp = await import("./devtoolsPanel");
                 dtp.DevToolsPanel.createOrShow(context, mockTelemetry, "", mockRuntimeConfig);

--- a/src/devtoolsPanel.ts
+++ b/src/devtoolsPanel.ts
@@ -182,7 +182,15 @@ export class DevToolsPanel {
         });
 
         // Parse message and open the requested file
-        const { column, line, url } = JSON.parse(message) as { column: number, line: number, url: string };
+        const { column, line, url, omitFocus } =
+            JSON.parse(message) as { column: number, line: number, url: string, omitFocus: boolean };
+
+        // If we don't want to focus on the doc and doing so would cause a tab switch ignore it.
+        // This is because just starting to edit a style in the Elements tool with call openInEditor
+        // but if we switch vs code tab the edit will be cancelled.
+        if (omitFocus && this.panel.viewColumn === vscode.ViewColumn.One) {
+            return;
+        }
 
         // Convert the devtools url into a local one
         let sourcePath = url;

--- a/src/host/polyfills/simpleView.test.ts
+++ b/src/host/polyfills/simpleView.test.ts
@@ -7,6 +7,7 @@ describe("simpleView", () => {
         const expected = {
             columnNumber: 0,
             lineNumber: 0,
+            omitFocus: false,
             uiSourceCode: {
                 _url: "http://bing.com",
             },
@@ -16,7 +17,7 @@ describe("simpleView", () => {
             openInEditor: mockOpen,
         };
 
-        await apply.revealInVSCode(expected, false);
+        await apply.revealInVSCode(expected, expected.omitFocus);
 
         expect(mockOpen).toHaveBeenCalled();
     });

--- a/src/host/polyfills/simpleView.ts
+++ b/src/host/polyfills/simpleView.ts
@@ -19,6 +19,7 @@ export function revealInVSCode(revealable: IRevealable | undefined, omitFocus: b
             revealable.uiSourceCode._url,
             revealable.lineNumber,
             revealable.columnNumber,
+            omitFocus,
         );
     }
 

--- a/src/host/toolsHost.test.ts
+++ b/src/host/toolsHost.test.ts
@@ -198,15 +198,15 @@ describe("toolsHost", () => {
 
             const expectedRequest = {
                 column: 500,
+                ignoreTabChanges: true,
                 line: 23,
-                omitFocus: true,
                 url: "webpack://file-to-open.css",
             };
             host.openInEditor(
                 expectedRequest.url,
                 expectedRequest.line,
                 expectedRequest.column,
-                expectedRequest.omitFocus);
+                expectedRequest.ignoreTabChanges);
 
             expect(mockWebviewEvents.encodeMessageForChannel).toHaveBeenCalledWith(
                 expect.any(Function),

--- a/src/host/toolsHost.test.ts
+++ b/src/host/toolsHost.test.ts
@@ -199,9 +199,14 @@ describe("toolsHost", () => {
             const expectedRequest = {
                 column: 500,
                 line: 23,
+                omitFocus: true,
                 url: "webpack://file-to-open.css",
             };
-            host.openInEditor(expectedRequest.url, expectedRequest.line, expectedRequest.column);
+            host.openInEditor(
+                expectedRequest.url,
+                expectedRequest.line,
+                expectedRequest.column,
+                expectedRequest.omitFocus);
 
             expect(mockWebviewEvents.encodeMessageForChannel).toHaveBeenCalledWith(
                 expect.any(Function),

--- a/src/host/toolsHost.ts
+++ b/src/host/toolsHost.ts
@@ -1,7 +1,13 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-import { encodeMessageForChannel, TelemetryData, WebSocketEvent, WebviewEvent } from "../common/webviewEvents";
+import {
+    encodeMessageForChannel,
+    IOpenEditorData,
+    TelemetryData,
+    WebSocketEvent,
+    WebviewEvent,
+} from "../common/webviewEvents";
 import ToolsResourceLoader from "./toolsResourceLoader";
 import ToolsWebSocket from "./toolsWebSocket";
 
@@ -68,9 +74,9 @@ export default class ToolsHost {
         });
     }
 
-    public openInEditor(url: string, line: number, column: number, omitFocus: boolean) {
+    public openInEditor(url: string, line: number, column: number, ignoreTabChanges: boolean) {
         // Forward the data to the extension
-        const request = { column, line, url, omitFocus };
+        const request: IOpenEditorData = { column, line, url, ignoreTabChanges };
         encodeMessageForChannel((msg) => window.parent.postMessage(msg, "*"), "openInEditor", request);
     }
 

--- a/src/host/toolsHost.ts
+++ b/src/host/toolsHost.ts
@@ -68,9 +68,9 @@ export default class ToolsHost {
         });
     }
 
-    public openInEditor(url: string, line: number, column: number) {
+    public openInEditor(url: string, line: number, column: number, omitFocus: boolean) {
         // Forward the data to the extension
-        const request = { column, line, url };
+        const request = { column, line, url, omitFocus };
         encodeMessageForChannel((msg) => window.parent.postMessage(msg, "*"), "openInEditor", request);
     }
 

--- a/src/host/toolsResourceLoader.test.ts
+++ b/src/host/toolsResourceLoader.test.ts
@@ -44,7 +44,7 @@ describe("toolsResourceLoader", () => {
             expect(mockWebviewEvents.encodeMessageForChannel).toHaveBeenCalledWith(
                 expect.any(Function),
                 "getUrl",
-                expect.objectContaining([{ id: 0, url: expectedUrl }]),
+                expect.objectContaining({ id: 0, url: expectedUrl }),
             );
 
             // Ensure that the encoded message is actually passed over to the extension
@@ -70,7 +70,7 @@ describe("toolsResourceLoader", () => {
             expect(mockWebviewEvents.encodeMessageForChannel).toHaveBeenCalledWith(
                 expect.any(Function),
                 "getUrl",
-                expect.objectContaining([{ id: 0, url: expectedUrl }]),
+                expect.objectContaining({ id: 0, url: expectedUrl }),
             );
 
             // Ensure that the encoded message is actually passed over to the extension

--- a/src/host/toolsResourceLoader.ts
+++ b/src/host/toolsResourceLoader.ts
@@ -32,7 +32,7 @@ export default class ToolsResourceLoader {
             const id = this.urlLoadNextId++;
             return new Promise((resolve: (url: string) => void) => {
                 this.urlLoadResolvers.set(id, resolve);
-                encodeMessageForChannel((msg) => window.parent.postMessage(msg, "*"), "getUrl", [{ id, url }]);
+                encodeMessageForChannel((msg) => window.parent.postMessage(msg, "*"), "getUrl", { id, url });
             });
         }
 

--- a/src/test/helpers.ts
+++ b/src/test/helpers.ts
@@ -37,7 +37,7 @@ export function createFakeVSCode() {
             file: jest.fn().mockReturnValue({ with: jest.fn() }),
             parse: jest.fn().mockReturnValue({ with: jest.fn() }),
         },
-        ViewColumn: { Two: 2 },
+        ViewColumn: { One: 1, Two: 2 },
         commands: {
             registerCommand: jest.fn(),
         },

--- a/src/test/helpers.ts
+++ b/src/test/helpers.ts
@@ -29,11 +29,13 @@ export type Writable<T> = {
 export function createFakeVSCode() {
     return {
         EventEmitter: jest.fn(),
+        Range: function Range() { /* constructor */ },
         TreeDataProvider: jest.fn(),
         TreeItem: jest.fn(),
         TreeItemCollapsibleState: { None: 0, Collapsed: 1 },
         Uri: {
             file: jest.fn().mockReturnValue({ with: jest.fn() }),
+            parse: jest.fn().mockReturnValue({ with: jest.fn() }),
         },
         ViewColumn: { Two: 2 },
         commands: {
@@ -51,12 +53,14 @@ export function createFakeVSCode() {
             registerTreeDataProvider: jest.fn(),
             showErrorMessage: jest.fn(),
             showQuickPick: jest.fn().mockResolvedValue(null),
+            showTextDocument: jest.fn(),
         },
         workspace: {
             getConfiguration: jest.fn(() => {
                 return { get: (name: string) => "" };
             }),
             onDidChangeConfiguration: jest.fn(),
+            openTextDocument: jest.fn().mockResolvedValue(null),
         },
     };
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -9,6 +9,7 @@ import * as os from "os";
 import * as path from "path";
 import * as url from "url";
 import * as vscode from "vscode";
+import * as debugCore from "vscode-chrome-debug-core";
 import TelemetryReporter from "vscode-extension-telemetry";
 import packageJson from "../package.json";
 import DebugTelemetryReporter from "./debugTelemetryReporter";
@@ -353,10 +354,93 @@ export function getRuntimeConfig(config: Partial<IUserConfig> = {}): IRuntimeCon
         }
     }
 
+    // Resolve the paths with the webRoot set by the user
+    const resolvedOverrides: IStringDictionary<string> = {};
+    for (const pattern in sourceMapPathOverrides) {
+        if (sourceMapPathOverrides.hasOwnProperty(pattern)) {
+            const replacePattern = replaceWebRootInSourceMapPathOverridesEntry(webRoot, pattern);
+            const replacePatternValue = replaceWebRootInSourceMapPathOverridesEntry(
+                webRoot, sourceMapPathOverrides[pattern]);
+
+            resolvedOverrides[replacePattern] = replacePatternValue;
+        }
+    }
+
     return {
         pathMapping,
-        sourceMapPathOverrides,
+        sourceMapPathOverrides: resolvedOverrides,
         sourceMaps,
         webRoot,
     };
+}
+
+/**
+ * Find '${webRoot}' in a string and replace it with the specified value only if it is at the start.
+ * @param webRoot The value to use for replacement.
+ * @param entry The path containing the '${webRoot}' string that we will replace.
+ */
+export function replaceWebRootInSourceMapPathOverridesEntry(webRoot: string, entry: string) {
+    if (webRoot) {
+        const webRootIndex = entry.indexOf("${webRoot}");
+        if (webRootIndex === 0) {
+            return entry.replace("${webRoot}", webRoot);
+        }
+    }
+    return entry;
+}
+
+/**
+ * Walk through the list of mappings and find one that matches the sourcePath.
+ * Once a match is found, replace the pattern in the value side of the mapping with
+ * the rest of the path.
+ * @param sourcePath The source path to convert
+ * @param pathMapping The list of mappings from source map to authored file path
+ */
+export function applyPathMapping(
+    sourcePath: string,
+    pathMapping: IStringDictionary<string>): string {
+    const forwardSlashSourcePath = sourcePath.replace(/\\/g, "/");
+
+    // Sort the overrides by length, large to small
+    const sortedOverrideKeys = Object.keys(pathMapping)
+        .sort((a, b) => b.length - a.length);
+
+    // Iterate the key/values, only apply the first one that matches.
+    for (const leftPattern of sortedOverrideKeys) {
+        const rightPattern = pathMapping[leftPattern];
+
+        const asterisks = leftPattern.match(/\*/g) || [];
+        if (asterisks.length > 1) {
+            continue;
+        }
+
+        const replacePatternAsterisks = rightPattern.match(/\*/g) || [];
+        if (replacePatternAsterisks.length > asterisks.length) {
+            continue;
+        }
+
+        // Does it match?
+        const escapedLeftPattern = debugCore.utils.escapeRegexSpecialChars(leftPattern, "/*");
+        const leftRegexSegment = escapedLeftPattern
+            .replace(/\*/g, "(.*)")
+            .replace(/\\\\/g, "/");
+        const leftRegex = new RegExp(`^${leftRegexSegment}$`, "i");
+        const overridePatternMatches = forwardSlashSourcePath.match(leftRegex);
+        if (!overridePatternMatches) {
+            continue;
+        }
+
+        // Grab the value of the wildcard from the match above, replace the wildcard in the
+        // replacement pattern, and return the result.
+        const wildcardValue = overridePatternMatches[1];
+        let mappedPath = rightPattern.replace(/\*/g, wildcardValue);
+        mappedPath = debugCore.utils.properJoin(mappedPath); // Fix any ..'s
+        mappedPath = mappedPath.replace(
+            "${workspaceFolder}",
+            vscode.workspace.workspaceFolders ? vscode.workspace.workspaceFolders[0].uri.toString() : "" || "");
+
+        return mappedPath;
+    }
+
+    return sourcePath;
 }


### PR DESCRIPTION
This PR adds the final part of the changes to actually open links in the editor. The onSocketOpenInEditor() function now takes the url from the elements tool (which will be the source mapped url if they are enabled) and calls helpers to convert it to the local workspace path using the config settings. 

Fixes #55, #54

Take a look at this animation to see the results:
![elements-links](https://user-images.githubusercontent.com/10660853/61971895-0c212f00-af95-11e9-977b-85e89307dba3.gif)

* Added utils functions to map elements links to vs code file paths (based on the same work in edge debug adapter)
* Added chrome-debug-core package to perform some mapping
* Updated the openInEditor function to actually open the files
* Updated tests and added new ones