### PR TITLE
Bumping version to 1.0.3 for next preview release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 1.0.3
+* Added Debugger for Microsoft Edge integration - [PR #96](https://github.com/microsoft/vscode-edge-devtools/pull/96)
+* Fixed content-security-policy - [PR #95](https://github.com/microsoft/vscode-edge-devtools/pull/95)
+* Fixed closing browser now also closes elements tool - [PR #89](https://github.com/microsoft/vscode-edge-devtools/pull/89)
+* Bumped elements tool version to `78.0.273.0`
+* Updated readme
+
 ## 1.0.2
 * Added open links in editor feature - [PR #83](https://github.com/microsoft/vscode-edge-devtools/pull/83)
 * Added new settings and launch.json configs for sourcemaps - See [Sourcemaps](https://github.com/microsoft/vscode-edge-devtools#sourcemaps)

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "vscode-edge-devtools",
     "displayName": "Elements for Microsoft Edge (Chromium)",
     "description": "Use the Microsoft Edge (Chromium) Elements tool from within VS Code to see your site's runtime HTML structure, alter its layout, and fix styling issues.",
-    "version": "1.0.2",
+    "version": "1.0.3",
     "license": "SEE LICENSE IN LICENSE",
     "publisher": "ms-edgedevtools",
     "preview": true,


### PR DESCRIPTION
This PR updates the version number to 1.0.3 and adds information to the change log about the most relevant changes that are going into this update. The change log can be seen from the extension marketplace page or from inside VS Code itself.

Bumped version to 1.0.3
Updated change log