### PR TITLE
Fixing issues caused by chromium devtools repository migration.

### DIFF
--- a/postBuildStep.ts
+++ b/postBuildStep.ts
@@ -40,7 +40,7 @@ async function copyStaticFiles() {
     // See CONTRIBUTING.md for more details
 
     const toolsSrcDir =
-        `${process.env.EDGE_CHROMIUM_PATH}/third_party/blink/renderer/devtools/front_end/`;
+        `${process.env.EDGE_CHROMIUM_PATH}/third_party/devtools-frontend/src/front_end/`;
     if (!isDirectory(toolsSrcDir)) {
         throw new Error(`Could not find Microsoft Edge (Chromium) DevTools path at '${toolsSrcDir}'. ` +
             "Did you set the EDGE_CHROMIUM_PATH environment variable?");

--- a/src/host/host.test.ts
+++ b/src/host/host.test.ts
@@ -61,16 +61,16 @@ describe("host", () => {
             expect(mockDevToolsWindow.localStorage).toBeUndefined();
         });
 
-        it("verifies that session storage cannot be modified", async () => {
+        it("emulates session storage", async () => {
             const host = await import("./host");
             host.initialize(mockIframe);
 
             expect(mockDevToolsWindow.sessionStorage).toBeDefined();
-            const previousSessionStorage = mockDevToolsWindow.sessionStorage;
-            const setter = Object.getOwnPropertyDescriptor(mockDevToolsWindow, "sessionStorage");
-            expect(setter).toBeDefined();
-            setter!.set!("some new value");
-            expect(mockDevToolsWindow.sessionStorage).toMatchObject(previousSessionStorage);
+
+            const expectedKey = "key";
+            const expectedVal = "value";
+            (mockDevToolsWindow as any).sessionStorage[expectedKey] = expectedVal;
+            expect(mockDevToolsWindow.sessionStorage[expectedKey]).toEqual(expectedVal);
         });
     });
 

--- a/src/host/host.test.ts
+++ b/src/host/host.test.ts
@@ -17,6 +17,7 @@ describe("host", () => {
             contentWindow: {
                 addEventListener: jest.fn(),
                 localStorage: jest.fn(),
+                Root: {}
             } as object,
         } as Mocked<HTMLIFrameElement>;
 
@@ -58,6 +59,18 @@ describe("host", () => {
             expect(setter).toBeDefined();
             setter!.set!("some new value");
             expect(mockDevToolsWindow.localStorage).toBeUndefined();
+        });
+
+        it("verifies that session storage cannot be modified", async () => {
+            const host = await import("./host");
+            host.initialize(mockIframe);
+
+            expect(mockDevToolsWindow.sessionStorage).toBeDefined();
+            const previousSessionStorage = mockDevToolsWindow.sessionStorage;
+            const setter = Object.getOwnPropertyDescriptor(mockDevToolsWindow, "sessionStorage");
+            expect(setter).toBeDefined();
+            setter!.set!("some new value");
+            expect(mockDevToolsWindow.sessionStorage).toMatchObject(previousSessionStorage);
         });
     });
 

--- a/src/host/host.test.ts
+++ b/src/host/host.test.ts
@@ -15,9 +15,9 @@ describe("host", () => {
 
         mockIframe = {
             contentWindow: {
+                Root: {},
                 addEventListener: jest.fn(),
                 localStorage: jest.fn(),
-                Root: {}
             } as object,
         } as Mocked<HTMLIFrameElement>;
 

--- a/src/host/host.ts
+++ b/src/host/host.ts
@@ -25,6 +25,13 @@ export function initialize(devToolsFrame: HTMLIFrameElement) {
         set() { /* NO-OP */ },
     });
 
+    // Create a mock sessionStorage since it doesn't exist in data url but the devtools use it
+    const sessionStorage = {};
+    Object.defineProperty(dtWindow, "sessionStorage", {
+        get() { return sessionStorage; },
+        set() { /* NO-OP */ },
+    });
+
     // Setup the global objects that must exist at load time
     dtWindow.InspectorFrontendHost = new ToolsHost();
     dtWindow.WebSocket = ToolsWebSocket;

--- a/src/host/host.ts
+++ b/src/host/host.ts
@@ -3,13 +3,17 @@
 
 import { parseMessageFromChannel } from "../common/webviewEvents";
 import ToolsHost from "./toolsHost";
-import ToolsResourceLoader, { IRoot } from "./toolsResourceLoader";
+import ToolsResourceLoader, { IRuntimeResourceLoader } from "./toolsResourceLoader";
 import ToolsWebSocket from "./toolsWebSocket";
 
 export interface IDevToolsWindow extends Window {
     InspectorFrontendHost: ToolsHost;
     WebSocket: typeof ToolsWebSocket;
     Root: IRoot;
+}
+
+export interface IRoot {
+    Runtime: IRuntimeResourceLoader;
 }
 
 export function initialize(devToolsFrame: HTMLIFrameElement) {

--- a/src/host/host.ts
+++ b/src/host/host.ts
@@ -3,13 +3,13 @@
 
 import { parseMessageFromChannel } from "../common/webviewEvents";
 import ToolsHost from "./toolsHost";
-import ToolsResourceLoader, { IRuntimeResourceLoader } from "./toolsResourceLoader";
+import ToolsResourceLoader, { IRoot } from "./toolsResourceLoader";
 import ToolsWebSocket from "./toolsWebSocket";
 
 export interface IDevToolsWindow extends Window {
     InspectorFrontendHost: ToolsHost;
     WebSocket: typeof ToolsWebSocket;
-    Runtime: IRuntimeResourceLoader;
+    Root: IRoot;
 }
 
 export function initialize(devToolsFrame: HTMLIFrameElement) {
@@ -41,7 +41,7 @@ export function initialize(devToolsFrame: HTMLIFrameElement) {
 
     dtWindow.addEventListener("DOMContentLoaded", () => {
         // Override the resource loading once the window has loaded so that we can control it
-        const resourceLoader = ToolsResourceLoader.overrideResourceLoading(dtWindow.Runtime);
+        const resourceLoader = ToolsResourceLoader.overrideResourceLoading(dtWindow.Root.Runtime);
         dtWindow.InspectorFrontendHost.setResourceLoader(resourceLoader);
     });
 }

--- a/src/host/toolsResourceLoader.ts
+++ b/src/host/toolsResourceLoader.ts
@@ -3,6 +3,9 @@
 
 import { encodeMessageForChannel } from "../common/webviewEvents";
 
+export interface IRoot {
+    Runtime: IRuntimeResourceLoader;
+}
 export interface IRuntimeResourceLoader {
     loadResourcePromise: (url: string) => Promise<string>;
 }

--- a/src/host/toolsResourceLoader.ts
+++ b/src/host/toolsResourceLoader.ts
@@ -3,9 +3,6 @@
 
 import { encodeMessageForChannel } from "../common/webviewEvents";
 
-export interface IRoot {
-    Runtime: IRuntimeResourceLoader;
-}
 export interface IRuntimeResourceLoader {
     loadResourcePromise: (url: string) => Promise<string>;
 }


### PR DESCRIPTION
Chromium repository migrated to a new repository and a new path, this PR address the following issues caused by this:

- Fixes the path for devtools folder and updates postBuildStep with the new path.
- Fixes an issue caused by moving window.Runtime to window.Root.Runtime
- Fixes an issue caused by session storage not being available for the developer tools as VsCode does not exposes it
- Fixes associated tests