### PR TITLE
Fixing issue with Revealer polyfill.

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "vscode-edge-devtools",
     "displayName": "Elements for Microsoft Edge (Chromium)",
     "description": "Use the Microsoft Edge (Chromium) Elements tool from within VS Code to see your site's runtime HTML structure, alter its layout, and fix styling issues.",
-    "version": "1.0.6",
+    "version": "1.0.7",
     "license": "SEE LICENSE IN LICENSE",
     "publisher": "ms-edgedevtools",
     "preview": true,

--- a/postBuildStep.ts
+++ b/postBuildStep.ts
@@ -98,7 +98,7 @@ async function patchFilesForWebView(toolsOutDir: string) {
     await patchFileForWebView("dom_extension/DOMExtension.js", toolsOutDir, false, [applyCreateElementPatch]);
     await patchFileForWebView("elements/ElementsPanel.js", toolsOutDir, false, [applySetupTextSelectionPatch]);
     await patchFileForWebView("themes/base.css", toolsOutDir, false, [applyInspectorCommonCssPatch]);
-    await patchFileForWebView("common/ModuleExtensionInterfaces.js", toolsOutDir, false, [applyCommonRevealerPatch]);
+    await patchFileForWebView("common/Revealer.js", toolsOutDir, false, [applyCommonRevealerPatch]);
     await patchFileForWebView("main/Main.js", toolsOutDir, false, [applyMainViewPatch]);
     await patchFileForWebView("ui/InspectorView.js", toolsOutDir, false, [applyInspectorViewPatch]);
     await patchFileForWebView("ui/TabbedPane.js", toolsOutDir, false, [applySelectTabPatch]);

--- a/src/host/polyfills/simpleView.test.ts
+++ b/src/host/polyfills/simpleView.test.ts
@@ -25,9 +25,9 @@ describe("simpleView", () => {
     it("applyCommonRevealerPatch correctly changes text", async () => {
         const apply = await import("./simpleView");
         const result = apply.applyCommonRevealerPatch(
-            "Common.Revealer.reveal = function(revealable, omitFocus) { // code");
+            "const reveal = function(revealable, omitFocus) { // code");
         expect(result).toEqual(
-            expect.stringContaining("Common.Revealer.reveal = function revealInVSCode(revealable, omitFocus) {"));
+            expect.stringContaining("const reveal = function revealInVSCode(revealable, omitFocus) {"));
     });
 
     it("applyInspectorViewPatch correctly changes text", async () => {

--- a/src/host/polyfills/simpleView.test.ts
+++ b/src/host/polyfills/simpleView.test.ts
@@ -25,9 +25,9 @@ describe("simpleView", () => {
     it("applyCommonRevealerPatch correctly changes text", async () => {
         const apply = await import("./simpleView");
         const result = apply.applyCommonRevealerPatch(
-            "const reveal = function(revealable, omitFocus) { // code");
+            "let reveal = function(revealable, omitFocus) { // code");
         expect(result).toEqual(
-            expect.stringContaining("const reveal = function revealInVSCode(revealable, omitFocus) {"));
+            expect.stringContaining("let reveal = function revealInVSCode(revealable, omitFocus) {"));
     });
 
     it("applyInspectorViewPatch correctly changes text", async () => {

--- a/src/host/polyfills/simpleView.ts
+++ b/src/host/polyfills/simpleView.ts
@@ -28,8 +28,8 @@ export function revealInVSCode(revealable: IRevealable | undefined, omitFocus: b
 
 export function applyCommonRevealerPatch(content: string) {
     return content.replace(
-        /const reveal\s*=\s*function\(revealable,\s*omitFocus\)\s*{/g,
-        `const reveal = ${revealInVSCode.toString().slice(0, -1)}`);
+        /let reveal\s*=\s*function\(revealable,\s*omitFocus\)\s*{/g,
+        `let reveal = ${revealInVSCode.toString().slice(0, -1)}`);
 }
 
 export function applyInspectorViewPatch(content: string) {

--- a/src/host/polyfills/simpleView.ts
+++ b/src/host/polyfills/simpleView.ts
@@ -28,8 +28,8 @@ export function revealInVSCode(revealable: IRevealable | undefined, omitFocus: b
 
 export function applyCommonRevealerPatch(content: string) {
     return content.replace(
-        /Common\.Revealer\.reveal\s*=\s*function\(revealable,\s*omitFocus\)\s*{/g,
-        `Common.Revealer.reveal = ${revealInVSCode.toString().slice(0, -1)}`);
+        /const reveal\s*=\s*function\(revealable,\s*omitFocus\)\s*{/g,
+        `const reveal = ${revealInVSCode.toString().slice(0, -1)}`);
 }
 
 export function applyInspectorViewPatch(content: string) {


### PR DESCRIPTION
Fixing issue #100 

**Root cause:**
There were changes on the devtools code regarding ESM migration. 

**Fix:**
Update the polyfill to match the new version.