### PR TITLE
SimpleView polyfill refactor

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -17,6 +17,21 @@
             "preLaunchTask": "npm: build"
         },
         {
+            "name": "Launch Extension (Development mode)",
+            "type": "extensionHost",
+            "request": "launch",
+            "runtimeExecutable": "${execPath}",
+            "args": [
+                "--extensionDevelopmentPath=${workspaceFolder}"
+            ],
+            "stopOnEntry": false,
+            "sourceMaps": true,
+            "outFiles": [
+                "${workspaceFolder}/out/**/*.js"
+            ],
+            "preLaunchTask": "npm: build-debug"
+        },
+        {
             "name": "Launch Tests",
             "type": "node",
             "request": "launch",

--- a/package.json
+++ b/package.json
@@ -412,6 +412,7 @@
         "package": "vsce package --out vscode-edge-devtools.vsix",
         "vscode:prepublish": "npm run build-and-lint",
         "build": "npm run build-wp && npm run build-post",
+        "build-debug": "npm run build-wp && ts-node postBuildStep.ts debug",
         "build-wp": "webpack",
         "build-post": "ts-node postBuildStep.ts",
         "build-watch": "npm run build && npm run watch",

--- a/src/host/polyfills/simpleView.test.ts
+++ b/src/host/polyfills/simpleView.test.ts
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+import { getTextFromFile } from "../../test/helpers";
 
 describe("simpleView", () => {
     it("revealInVSCode calls openInEditor", async () => {
@@ -23,41 +24,67 @@ describe("simpleView", () => {
     });
 
     it("applyCommonRevealerPatch correctly changes text", async () => {
+        const comparableText = "let reveal = function(revealable, omitFocus) {";
+        let fileContents = getTextFromFile("common/Revealer.js");
+
+        // The file was not found, so test that at least the text is being replaced.
+        fileContents = fileContents ? fileContents : comparableText;
+
         const apply = await import("./simpleView");
-        const result = apply.applyCommonRevealerPatch(
-            "let reveal = function(revealable, omitFocus) { // code");
+        const result = apply.applyCommonRevealerPatch(fileContents);
+        expect(result).not.toEqual(null);
         expect(result).toEqual(
             expect.stringContaining("let reveal = function revealInVSCode(revealable, omitFocus) {"));
     });
 
-    it("applyInspectorViewPatch correctly changes text", async () => {
+    it("applyInspectorViewPatch correctly changes handleAction text", async () => {
+        const comparableText = "handleAction(context, actionId) {\n";
+        let fileContents = getTextFromFile("ui/InspectorView.js");
+        // The file was not found, so test that at least the text is being replaced.
+        fileContents = fileContents ? fileContents : comparableText;
+
         const apply = await import("./simpleView");
-        const result = apply.applyInspectorViewPatch(
-            "handleAction(context, actionId) { // code");
-        expect(result).toEqual("handleAction(context, actionId) { return false; // code");
+        const result = apply.applyInspectorViewHandleActionPatch(fileContents);
+        expect(result).not.toEqual(null);
+        expect(result).toEqual(
+            expect.stringContaining("handleAction(context, actionId) { return false;"));
+    });
 
-        const result2 = apply.applyInspectorViewPatch(
-            "handleAction(context,actionId) { // code");
-        expect(result2).toEqual("handleAction(context, actionId) { return false; // code");
+    it("applyInspectorViewPatch correctly changes _showDrawer text", async () => {
+        const comparableText = "_showDrawer(focus) {";
+        let fileContents = getTextFromFile("ui/InspectorView.js");
+        // The file was not found, so test that at least the text is being replaced.
+        fileContents = fileContents ? fileContents : comparableText;
 
-        const result3 = apply.applyInspectorViewPatch(
-            "_showDrawer(focus) { // code");
-        expect(result3).toEqual("_showDrawer(focus) { return false; // code");
+        const apply = await import("./simpleView");
+        const result = apply.applyInspectorViewShowDrawerPatch(fileContents);
+        expect(result).not.toEqual(null);
+        expect(result).toEqual(expect.stringContaining("_showDrawer(focus) { return false;"));
     });
 
     it("applyMainViewPatch correctly changes text", async () => {
+        const comparableText = "const moreTools = getExtensions();";
+        let fileContents = getTextFromFile("main/MainImpl.js");
+
+        // The file was not found, so test that at least the text is being replaced.
+        fileContents = fileContents ? fileContents : comparableText;
         const apply = await import("./simpleView");
-        const result = apply.applyMainViewPatch("const moreTools = getExtensions();");
-        expect(result).toEqual("const moreTools = { defaultSection: () => ({ appendItem: () => {} }) };");
+        const result = apply.applyMainViewPatch(comparableText);
+        expect(result).not.toEqual(null);
+        expect(result).toEqual(
+            expect.stringContaining("const moreTools = { defaultSection: () => ({ appendItem: () => {} }) };"));
     });
 
     it("applySelectTabPatch correctly changes text", async () => {
-        const apply = await import("./simpleView");
-        const result = apply.applySelectTabPatch("selectTab(id, userGesture, forceFocus) { // code");
-        expect(result).toEqual(expect.stringContaining("selectTab(id, userGesture, forceFocus) { if ("));
+        const comparableText = "selectTab(id, userGesture, forceFocus) {";
+        let fileContents = getTextFromFile("ui/TabbedPane.js");
 
-        const result2 = apply.applySelectTabPatch("selectTab(id, userGesture, forceFocus) { // code");
-        expect(result2).toEqual(expect.stringContaining("selectTab(id, userGesture, forceFocus) { if ("));
+        // The file was not found, so test that at least the text is being replaced.
+        fileContents = fileContents ? fileContents : comparableText;
+        const apply = await import("./simpleView");
+        const result = apply.applySelectTabPatch(fileContents);
+        expect(result).not.toEqual(null);
+        expect(result).toEqual(expect.stringContaining("selectTab(id, userGesture, forceFocus) { if ("));
     });
 
     it("applyInspectorCommonCssPatch correctly changes tabbed-pane-header-contents", async () => {
@@ -70,9 +97,14 @@ describe("simpleView", () => {
         const expectedResult = `.main-tabbed-pane .tabbed-pane-header-contents {
             display: none !important;
         }`;
+        let fileContents = getTextFromFile("shell.js");
+
+        // The file was not found, so test that at least the text is being replaced.
+        fileContents = fileContents ? fileContents : expectedCss;
         const apply = await import("./simpleView");
-        const result = apply.applyInspectorCommonCssPatch(expectedCss);
-        expect(result === expectedResult).toEqual(true);
+        const result = apply.applyInspectorCommonCssHeaderContentsPatch(fileContents);
+        expect(result).not.toEqual(null);
+        expect(result).toEqual(expect.stringContaining(expectedResult));
     });
 
     it("applyInspectorCommonCssPatch correctly changes tabbed-pane-tab-slider", async () => {
@@ -90,9 +122,14 @@ describe("simpleView", () => {
         const expectedResult = `.tabbed-pane-tab-slider {
             display: none !important;
         }`;
+        let fileContents = getTextFromFile("shell.js");
+
+        // The file was not found, so test that at least the text is being replaced.
+        fileContents = fileContents ? fileContents : expectedCss;
         const apply = await import("./simpleView");
-        const result = apply.applyInspectorCommonCssPatch(expectedCss);
-        expect(result === expectedResult).toEqual(true);
+        const result = apply.applyInspectorCommonCssTabSliderPatch(fileContents);
+        expect(result).not.toEqual(null);
+        expect(result).toEqual(expect.stringContaining(expectedResult));
     });
 
     it("applyInspectorCommonCssPatch correctly changes tabbed-pane-right-toolbar", async () => {
@@ -103,9 +140,14 @@ describe("simpleView", () => {
         const expectedResult = `.tabbed-pane-right-toolbar {
             display: none !important;
         }`;
+        let fileContents = getTextFromFile("shell.js");
+
+        // The file was not found, so test that at least the text is being replaced.
+        fileContents = fileContents ? fileContents : expectedCss;
         const apply = await import("./simpleView");
-        const result = apply.applyInspectorCommonCssPatch(expectedCss);
-        expect(result === expectedResult).toEqual(true);
+        const result = apply.applyInspectorCommonCssRightToolbarPatch(fileContents);
+        expect(result).not.toEqual(null);
+        expect(result).toEqual(expect.stringContaining(expectedResult));
     });
 
     it("applyInspectorCommonCssPatch correctly changes tabbed-pane-header-contents in release mode", async () => {
@@ -117,9 +159,14 @@ describe("simpleView", () => {
         }`;
         const expectedResult =
             ".main-tabbed-pane .tabbed-pane-header-contents {\\n            display: none !important;\\n        }";
+        let fileContents = getTextFromFile("shell.js");
+
+        // The file was not found, so test that at least the text is being replaced.
+        fileContents = fileContents ? fileContents : expectedCss;
         const apply = await import("./simpleView");
-        const result = apply.applyInspectorCommonCssPatch(expectedCss, true);
-        expect(result === expectedResult).toEqual(true);
+        const result = apply.applyInspectorCommonCssHeaderContentsPatch(fileContents, true);
+        expect(result).not.toEqual(null);
+        expect(result).toEqual(expect.stringContaining(expectedResult));
     });
 
     it("applyInspectorCommonCssPatch correctly changes tabbed-pane-tab-slider in release mode", async () => {
@@ -136,9 +183,14 @@ describe("simpleView", () => {
         }`;
         const expectedResult =
             ".tabbed-pane-tab-slider {\\n            display: none !important;\\n        }";
+        let fileContents = getTextFromFile("shell.js");
+
+        // The file was not found, so test that at least the text is being replaced.
+        fileContents = fileContents ? fileContents : expectedCss;
         const apply = await import("./simpleView");
-        const result = apply.applyInspectorCommonCssPatch(expectedCss, true);
-        expect(result === expectedResult).toEqual(true);
+        const result = apply.applyInspectorCommonCssTabSliderPatch(fileContents, true);
+        expect(result).not.toEqual(null);
+        expect(result).toEqual(expect.stringContaining(expectedResult));
     });
 
     it("applyInspectorCommonCssPatch correctly changes tabbed-pane-right-toolbar in release mode", async () => {
@@ -148,8 +200,13 @@ describe("simpleView", () => {
         }`;
         const expectedResult =
             ".tabbed-pane-right-toolbar {\\n            display: none !important;\\n        }";
+        let fileContents = getTextFromFile("shell.js");
+
+        // The file was not found, so test that at least the text is being replaced.
+        fileContents = fileContents ? fileContents : expectedCss;
         const apply = await import("./simpleView");
-        const result = apply.applyInspectorCommonCssPatch(expectedCss, true);
-        expect(result === expectedResult).toEqual(true);
+        const result = apply.applyInspectorCommonCssRightToolbarPatch(fileContents, true);
+        expect(result).not.toEqual(null);
+        expect(result).toEqual(expect.stringContaining(expectedResult));
     });
 });

--- a/src/host/polyfills/simpleView.ts
+++ b/src/host/polyfills/simpleView.ts
@@ -27,25 +27,44 @@ export function revealInVSCode(revealable: IRevealable | undefined, omitFocus: b
 }
 
 export function applyCommonRevealerPatch(content: string) {
-    return content.replace(
-        /let reveal\s*=\s*function\(revealable,\s*omitFocus\)\s*{/g,
-        `let reveal = ${revealInVSCode.toString().slice(0, -1)}`);
+    const pattern = /let reveal\s*=\s*function\(revealable,\s*omitFocus\)\s*{/g;
+    if (content.match(pattern)) {
+        return content.replace(pattern,
+            `let reveal = ${revealInVSCode.toString().slice(0, -1)}`);
+    } else {
+        return null;
+    }
 }
 
-export function applyInspectorViewPatch(content: string) {
-    return content
-        .replace(
-            /handleAction\(context,\s*actionId\)\s*{/g,
-            "handleAction(context, actionId) { return false;")
-        .replace(
-            /_showDrawer\(focus\)\s*{/g,
-            "_showDrawer(focus) { return false;");
+export function applyInspectorViewHandleActionPatch(content: string) {
+    const pattern = /handleAction\(context,\s*actionId\)\s*{/g;
+
+    if (content.match(pattern)) {
+        return content
+        .replace(pattern, "handleAction(context, actionId) { return false;");
+    } else {
+        return null;
+    }
+}
+
+export function applyInspectorViewShowDrawerPatch(content: string) {
+    const pattern = /_showDrawer\(focus\)\s*{/g;
+
+    if (content.match(pattern)) {
+        return content.replace(pattern, "_showDrawer(focus) { return false;");
+    } else {
+        return null;
+    }
 }
 
 export function applyMainViewPatch(content: string) {
-    return content.replace(
-        /const moreTools\s*=\s*[^;]+;/g,
-        "const moreTools = { defaultSection: () => ({ appendItem: () => {} }) };");
+    const pattern = /const moreTools\s*=\s*[^;]+;/g;
+
+    if (content.match(pattern)) {
+        return content.replace(pattern, "const moreTools = { defaultSection: () => ({ appendItem: () => {} }) };");
+    } else {
+        return null;
+    }
 }
 
 export function applySelectTabPatch(content: string) {
@@ -73,36 +92,65 @@ export function applySelectTabPatch(content: string) {
 
     const pattern = /selectTab\(id,\s*userGesture,\s*forceFocus\)\s*{/g;
 
-    return content.replace(
-        pattern,
-        `selectTab(id, userGesture, forceFocus) { if (${condition}) return false;`);
+    if (content.match(pattern)) {
+        return content.replace(
+            pattern,
+            `selectTab(id, userGesture, forceFocus) { if (${condition}) return false;`);
+    } else {
+        return null;
+    }
 }
 
-export function applyInspectorCommonCssPatch(content: string, isRelease?: boolean) {
+export function applyInspectorCommonCssHeaderContentsPatch(content: string, isRelease?: boolean) {
     const separator = (isRelease ? "\\n" : "\n");
     const cssHeaderContents =
         `.main-tabbed-pane .tabbed-pane-header-contents {
             display: none !important;
         }`.replace(/\n/g, separator);
+
+    const mainPattern = /(\.main-tabbed-pane\s*\.tabbed-pane-header-contents\s*\{([^\}]*)?\})/g;
+
+    if (content.match(mainPattern)) {
+        return content.replace(
+            mainPattern,
+            cssHeaderContents);
+    } else {
+        return null;
+    }
+}
+
+export function applyInspectorCommonCssRightToolbarPatch(content: string, isRelease?: boolean) {
+    const separator = (isRelease ? "\\n" : "\n");
     const cssRightToolbar =
         `.tabbed-pane-right-toolbar {
             display: none !important;
         }`.replace(/\n/g, separator);
+
+    const tabbedPanePattern = /(\.tabbed-pane-right-toolbar\s*\{([^\}]*)?\})/g;
+
+    if (content.match(tabbedPanePattern)) {
+        return content.replace(
+                tabbedPanePattern,
+                cssRightToolbar);
+    } else {
+        return null;
+    }
+}
+
+export function applyInspectorCommonCssTabSliderPatch(content: string, isRelease?: boolean) {
+    const separator = (isRelease ? "\\n" : "\n");
     const cssTabSlider =
         `.tabbed-pane-tab-slider {
             display: none !important;
         }`.replace(/\n/g, separator);
 
-    // we need to do this by parts as the code is split between base.css
-    // and dark.css
-    let result = content.replace(
-        /(\.main-tabbed-pane\s*\.tabbed-pane-header-contents\s*\{([^\}]*)?\})/g,
-        cssHeaderContents);
-    result = result.replace(
-            /(\.tabbed-pane-right-toolbar\s*\{([^\}]*)?\})/g,
-            cssRightToolbar);
-    result = result.replace(
-        /(\.tabbed-pane-tab-slider\s*\{([^\}]*)?\})/g,
-        cssTabSlider);
-    return result;
+    const tabbedPaneSlider = /(\.tabbed-pane-tab-slider\s*\{([^\}]*)?\})/g;
+
+    if (content.match(tabbedPaneSlider)) {
+        return content.replace(
+            tabbedPaneSlider,
+            cssTabSlider);
+    } else {
+        return null;
+    }
 }

--- a/src/test/helpers.ts
+++ b/src/test/helpers.ts
@@ -1,11 +1,11 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+import fs from "fs";
+import { ExtensionContext } from "vscode";
+import TelemetryReporter from "vscode-extension-telemetry";
 
 // Allow unused variables in the mocks to have leading underscore
 // tslint:disable: variable-name
-
-import { ExtensionContext } from "vscode";
-import TelemetryReporter from "vscode-extension-telemetry";
 
 export type Mocked<T> = {
     -readonly [P in keyof T]:
@@ -127,4 +127,19 @@ export function getFirstCallback(mock: jest.Mock, callbackArgIndex: number = 0):
     // tslint:disable-next-line: ban-types
     { callback: Function, thisObj: object } {
     return { callback: mock.mock.calls[0][callbackArgIndex], thisObj: mock.mock.instances[0] };
+}
+
+/**
+ * Returns the contents of the specified file, if the file is not found returns null
+ * @param uri The uri relative to the 'gen' folder specified in EDGE_CHROMIUM_PATH environment variable.
+ */
+export function getTextFromFile(uri: string) {
+    const toolsGenDir =
+        `${process.env.EDGE_CHROMIUM_PATH}/out/${process.env.EDGE_CHROMIUM_OUT_DIR}/gen/devtools/`;
+    const filePath = `${toolsGenDir}${uri}`;
+    if (fs.existsSync(filePath)) {
+        return fs.readFileSync(filePath, "utf8");
+    }
+
+    return null;
 }


### PR DESCRIPTION
This PR does a medium size refactoring on simpleView polyfill that I consider need to expand to the rest of polyfills:

- SimpleView.test.ts
Currently the tests verify that a function can be override by the polyfills. The issue is that the actual content of the file constantly changes. This PR forks the behavior as follows:
    - If run in the server: It will continue working as today, verifying that a static text can be patched.
    - If run locally: it will verify if the actual files exist in disk, if they do it will run the tests again the file contents, and it will fail if the contents do not match. This will make patching and spotting differences easier by reducing turnaround time

PostBuild.ts:
Currently "Release" and "Debug" mode are treated as one, this creates issues as the files on DevTools side tend to be moved or refactored, this makes the patching process a manual one. This PR splits the logic between Release and Debug, so if a release file that is needed to be patched is not present it will now throw an error.

launch.json
As part of the change in postbuild.ts, the user can now indicate if they are running a "Release" version (following Contributing.md instructions or if they are doing a development version (full chromium repo)

The rest of the changes are to support the scenarios mentioned above.