### PR TITLE
Merging Network Extension

### DIFF
--- a/postBuildStep.ts
+++ b/postBuildStep.ts
@@ -16,8 +16,7 @@ import {
     applyInspectorViewShowDrawerPatch,
     applyMainTabTabLocationPatch,
     applyMainViewPatch,
-    applySelectTabPatch,
-    applyShowTabElement,
+    applyAppendTabPatch,
     applyShowElementsTab
 } from "./src/host/polyfills/simpleView";
 import applySetupTextSelectionPatch from "./src/host/polyfills/textSelection";
@@ -107,7 +106,7 @@ async function patchFilesForWebView(toolsOutDir: string, debugMode: boolean) {
 	          applyDrawerTabLocationPatch,
             applyMainTabTabLocationPatch,
 	    ]);
-        await patchFileForWebView("ui/TabbedPane.js", toolsOutDir, true, [applySelectTabPatch, applyShowTabElement]);
+        await patchFileForWebView("ui/TabbedPane.js", toolsOutDir, true, [applyAppendTabPatch]);
         await patchFileForWebView("ui/ViewManager.js", toolsOutDir, true, [applyShowElementsTab]);
     } else {
         // tslint:disable-next-line:no-console
@@ -119,14 +118,14 @@ async function patchFilesForWebView(toolsOutDir: string, debugMode: boolean) {
             applyPaddingInlineCssPatch,
         ]);
         await patchFileForWebView("inspector.html", toolsOutDir, false, [applyContentSecurityPolicyPatch]);
-        await patchFileForWebView("ui/TabbedPane.js", toolsOutDir, false, [applySelectTabPatch, applyShowTabElement]);
+        await patchFileForWebView("ui/TabbedPane.js", toolsOutDir, false, [applyAppendTabPatch]);
         await patchFileForWebView("ui/InspectorView.js", toolsOutDir, false, [
             applyInspectorViewHandleActionPatch,
             applyInspectorViewShowDrawerPatch,
             applyDrawerTabLocationPatch,
             applyMainTabTabLocationPatch
 	      ]);
-        await patchFileForWebView("ui/TabbedPane.js", toolsOutDir, false, [applySelectTabPatch]);
+        await patchFileForWebView("ui/TabbedPane.js", toolsOutDir, false, [applyAppendTabPatch]);
         await patchFileForWebView("ui/ViewManager.js", toolsOutDir, true, [applyShowElementsTab]);
         // Debug file versions
         await patchFileForWebView("ui/UIUtils.js", toolsOutDir, false, [applyUIUtilsPatch]);

--- a/postBuildStep.ts
+++ b/postBuildStep.ts
@@ -94,40 +94,40 @@ async function patchFilesForWebView(toolsOutDir: string, debugMode: boolean) {
             applyInspectorCommonCssTabSliderPatch,
         ]);
 
-        await patchFileForWebView("main/MainImpl.js", toolsOutDir, true, [applyMainViewPatch]);
-        await patchFileForWebView("common/Revealer.js", toolsOutDir, true, [applyCommonRevealerPatch]);
+        await patchFileForWebView("main/main.js", toolsOutDir, true, [applyMainViewPatch]);
+        await patchFileForWebView("common/common.js", toolsOutDir, true, [applyCommonRevealerPatch]);
         await patchFileForWebView("elements/elements_module.js", toolsOutDir, true, [
             applySetupTextSelectionPatch,
             applyPaddingInlineCssPatch,
         ]);
         await patchFileForWebView("inspector.html", toolsOutDir, true, [applyContentSecurityPolicyPatch]);
-        await patchFileForWebView("ui/InspectorView.js", toolsOutDir, true, [
+        await patchFileForWebView("ui/ui.js", toolsOutDir, true, [
             applyInspectorViewHandleActionPatch,
             applyInspectorViewShowDrawerPatch,
 	        applyDrawerTabLocationPatch,
             applyMainTabTabLocationPatch,
 	    ]);
-        await patchFileForWebView("ui/TabbedPane.js", toolsOutDir, true, [applySelectTabPatch, applyShowTabElement]);
+        await patchFileForWebView("ui/ui.js", toolsOutDir, true, [applySelectTabPatch, applyShowTabElement]);
     } else {
         // tslint:disable-next-line:no-console
         console.log("Patching files for debug version");
-        await patchFileForWebView("main/MainImpl.js", toolsOutDir, false, [applyMainViewPatch]);
-        await patchFileForWebView("common/Revealer.js", toolsOutDir, false, [applyCommonRevealerPatch]);
+        await patchFileForWebView("main/main.js", toolsOutDir, false, [applyMainViewPatch]);
+        await patchFileForWebView("common/common.js", toolsOutDir, false, [applyCommonRevealerPatch]);
         await patchFileForWebView("elements/elements_module.js", toolsOutDir, false, [
             applySetupTextSelectionPatch,
             applyPaddingInlineCssPatch,
         ]);
         await patchFileForWebView("inspector.html", toolsOutDir, false, [applyContentSecurityPolicyPatch]);
-        await patchFileForWebView("ui/TabbedPane.js", toolsOutDir, false, [applySelectTabPatch, applyShowTabElement]);
-        await patchFileForWebView("ui/InspectorView.js", toolsOutDir, false, [
+        await patchFileForWebView("ui/ui.js", toolsOutDir, false, [applySelectTabPatch, applyShowTabElement]);
+        await patchFileForWebView("ui/ui.js", toolsOutDir, false, [
             applyInspectorViewHandleActionPatch,
             applyInspectorViewShowDrawerPatch,
             applyDrawerTabLocationPatch,
             applyMainTabTabLocationPatch
 	]);
-        await patchFileForWebView("ui/TabbedPane.js", toolsOutDir, false, [applySelectTabPatch]);
+        await patchFileForWebView("ui/ui.js", toolsOutDir, false, [applySelectTabPatch]);
         // Debug file versions
-        await patchFileForWebView("ui/UIUtils.js", toolsOutDir, false, [applyUIUtilsPatch]);
+        await patchFileForWebView("ui/ui.js", toolsOutDir, false, [applyUIUtilsPatch]);
         await patchFileForWebView("dom_extension/DOMExtension.js", toolsOutDir, false, [applyCreateElementPatch]);
         await patchFileForWebView("elements/ElementsPanel.js", toolsOutDir, false, [applySetupTextSelectionPatch]);
         await patchFileForWebView("themes/base.css", toolsOutDir, false, [

--- a/postBuildStep.ts
+++ b/postBuildStep.ts
@@ -7,6 +7,7 @@ import applyPaddingInlineCssPatch from "./src/host/polyfills/cssPaddingInline";
 import { applyCreateElementPatch, applyUIUtilsPatch } from "./src/host/polyfills/customElements";
 import { applyContentSecurityPolicyPatch } from "./src/host/polyfills/inspectorContentPolicy";
 import {
+    applyAppendTabPatch,
     applyCommonRevealerPatch,
     applyDrawerTabLocationPatch,
     applyInspectorCommonCssPatch,
@@ -15,7 +16,6 @@ import {
     applyInspectorViewHandleActionPatch,
     applyInspectorViewShowDrawerPatch,
     applyMainTabTabLocationPatch,
-    applyAppendTabPatch,
     applyMainViewPatch,
     applyShowElementsTab,
 } from "./src/host/polyfills/simpleView";

--- a/postBuildStep.ts
+++ b/postBuildStep.ts
@@ -18,6 +18,7 @@ import {
     applyMainViewPatch,
     applySelectTabPatch,
     applyShowTabElement,
+    applyShowElementsTab
 } from "./src/host/polyfills/simpleView";
 import applySetupTextSelectionPatch from "./src/host/polyfills/textSelection";
 
@@ -81,7 +82,6 @@ async function copyStaticFiles(debugMode: boolean) {
 }
 
 async function patchFilesForWebView(toolsOutDir: string, debugMode: boolean) {
-
     // Release file versions
     if (!debugMode) {
         // tslint:disable-next-line:no-console
@@ -94,40 +94,42 @@ async function patchFilesForWebView(toolsOutDir: string, debugMode: boolean) {
             applyInspectorCommonCssTabSliderPatch,
         ]);
 
-        await patchFileForWebView("main/main.js", toolsOutDir, true, [applyMainViewPatch]);
-        await patchFileForWebView("common/common.js", toolsOutDir, true, [applyCommonRevealerPatch]);
+        await patchFileForWebView("main/MainImpl.js", toolsOutDir, true, [applyMainViewPatch]);
+        await patchFileForWebView("common/Revealer.js", toolsOutDir, true, [applyCommonRevealerPatch]);
         await patchFileForWebView("elements/elements_module.js", toolsOutDir, true, [
             applySetupTextSelectionPatch,
             applyPaddingInlineCssPatch,
         ]);
         await patchFileForWebView("inspector.html", toolsOutDir, true, [applyContentSecurityPolicyPatch]);
-        await patchFileForWebView("ui/ui.js", toolsOutDir, true, [
+        await patchFileForWebView("ui/InspectorView.js", toolsOutDir, true, [
             applyInspectorViewHandleActionPatch,
             applyInspectorViewShowDrawerPatch,
-	        applyDrawerTabLocationPatch,
+	          applyDrawerTabLocationPatch,
             applyMainTabTabLocationPatch,
 	    ]);
-        await patchFileForWebView("ui/ui.js", toolsOutDir, true, [applySelectTabPatch, applyShowTabElement]);
+        await patchFileForWebView("ui/TabbedPane.js", toolsOutDir, true, [applySelectTabPatch, applyShowTabElement]);
+        await patchFileForWebView("ui/ViewManager.js", toolsOutDir, true, [applyShowElementsTab]);
     } else {
         // tslint:disable-next-line:no-console
         console.log("Patching files for debug version");
-        await patchFileForWebView("main/main.js", toolsOutDir, false, [applyMainViewPatch]);
-        await patchFileForWebView("common/common.js", toolsOutDir, false, [applyCommonRevealerPatch]);
+        await patchFileForWebView("main/MainImpl.js", toolsOutDir, false, [applyMainViewPatch]);
+        await patchFileForWebView("common/Revealer.js", toolsOutDir, false, [applyCommonRevealerPatch]);
         await patchFileForWebView("elements/elements_module.js", toolsOutDir, false, [
             applySetupTextSelectionPatch,
             applyPaddingInlineCssPatch,
         ]);
         await patchFileForWebView("inspector.html", toolsOutDir, false, [applyContentSecurityPolicyPatch]);
-        await patchFileForWebView("ui/ui.js", toolsOutDir, false, [applySelectTabPatch, applyShowTabElement]);
-        await patchFileForWebView("ui/ui.js", toolsOutDir, false, [
+        await patchFileForWebView("ui/TabbedPane.js", toolsOutDir, false, [applySelectTabPatch, applyShowTabElement]);
+        await patchFileForWebView("ui/InspectorView.js", toolsOutDir, false, [
             applyInspectorViewHandleActionPatch,
             applyInspectorViewShowDrawerPatch,
             applyDrawerTabLocationPatch,
             applyMainTabTabLocationPatch
-	]);
-        await patchFileForWebView("ui/ui.js", toolsOutDir, false, [applySelectTabPatch]);
+	      ]);
+        await patchFileForWebView("ui/TabbedPane.js", toolsOutDir, false, [applySelectTabPatch]);
+        await patchFileForWebView("ui/ViewManager.js", toolsOutDir, true, [applyShowElementsTab]);
         // Debug file versions
-        await patchFileForWebView("ui/ui.js", toolsOutDir, false, [applyUIUtilsPatch]);
+        await patchFileForWebView("ui/UIUtils.js", toolsOutDir, false, [applyUIUtilsPatch]);
         await patchFileForWebView("dom_extension/DOMExtension.js", toolsOutDir, false, [applyCreateElementPatch]);
         await patchFileForWebView("elements/ElementsPanel.js", toolsOutDir, false, [applySetupTextSelectionPatch]);
         await patchFileForWebView("themes/base.css", toolsOutDir, false, [

--- a/postBuildStep.ts
+++ b/postBuildStep.ts
@@ -8,13 +8,16 @@ import { applyCreateElementPatch, applyUIUtilsPatch } from "./src/host/polyfills
 import { applyContentSecurityPolicyPatch } from "./src/host/polyfills/inspectorContentPolicy";
 import {
     applyCommonRevealerPatch,
-    applyInspectorCommonCssHeaderContentsPatch,
+    applyDrawerTabLocationPatch,
+    applyInspectorCommonCssPatch,
     applyInspectorCommonCssRightToolbarPatch,
     applyInspectorCommonCssTabSliderPatch,
     applyInspectorViewHandleActionPatch,
     applyInspectorViewShowDrawerPatch,
+    applyMainTabTabLocationPatch,
     applyMainViewPatch,
     applySelectTabPatch,
+    applyShowTabElement,
 } from "./src/host/polyfills/simpleView";
 import applySetupTextSelectionPatch from "./src/host/polyfills/textSelection";
 
@@ -86,8 +89,8 @@ async function patchFilesForWebView(toolsOutDir: string, debugMode: boolean) {
         await patchFileForWebView("shell.js", toolsOutDir, true, [
             applyUIUtilsPatch,
             applyCreateElementPatch,
-            applyInspectorCommonCssHeaderContentsPatch,
             applyInspectorCommonCssRightToolbarPatch,
+	          applyInspectorCommonCssPatch,
             applyInspectorCommonCssTabSliderPatch,
         ]);
 
@@ -100,9 +103,11 @@ async function patchFilesForWebView(toolsOutDir: string, debugMode: boolean) {
         await patchFileForWebView("inspector.html", toolsOutDir, true, [applyContentSecurityPolicyPatch]);
         await patchFileForWebView("ui/InspectorView.js", toolsOutDir, true, [
             applyInspectorViewHandleActionPatch,
-            applyInspectorViewShowDrawerPatch]);
-        await patchFileForWebView("ui/TabbedPane.js", toolsOutDir, true, [applySelectTabPatch]);
-
+            applyInspectorViewShowDrawerPatch,
+	        applyDrawerTabLocationPatch,
+            applyMainTabTabLocationPatch,
+	    ]);
+        await patchFileForWebView("ui/TabbedPane.js", toolsOutDir, true, [applySelectTabPatch, applyShowTabElement]);
     } else {
         // tslint:disable-next-line:no-console
         console.log("Patching files for debug version");
@@ -113,15 +118,19 @@ async function patchFilesForWebView(toolsOutDir: string, debugMode: boolean) {
             applyPaddingInlineCssPatch,
         ]);
         await patchFileForWebView("inspector.html", toolsOutDir, false, [applyContentSecurityPolicyPatch]);
+        await patchFileForWebView("ui/TabbedPane.js", toolsOutDir, false, [applySelectTabPatch, applyShowTabElement]);
         await patchFileForWebView("ui/InspectorView.js", toolsOutDir, false, [
             applyInspectorViewHandleActionPatch,
-            applyInspectorViewShowDrawerPatch]);
+            applyInspectorViewShowDrawerPatch,
+            applyDrawerTabLocationPatch,
+            applyMainTabTabLocationPatch
+	]);
         await patchFileForWebView("ui/TabbedPane.js", toolsOutDir, false, [applySelectTabPatch]);
         // Debug file versions
         await patchFileForWebView("ui/UIUtils.js", toolsOutDir, false, [applyUIUtilsPatch]);
         await patchFileForWebView("dom_extension/DOMExtension.js", toolsOutDir, false, [applyCreateElementPatch]);
         await patchFileForWebView("elements/ElementsPanel.js", toolsOutDir, false, [applySetupTextSelectionPatch]);
-        await patchFileForWebView("themes/base.css", toolsOutDir, false, [applyInspectorCommonCssHeaderContentsPatch,
+        await patchFileForWebView("themes/base.css", toolsOutDir, false, [
            applyInspectorCommonCssRightToolbarPatch, applyInspectorCommonCssTabSliderPatch]);
         await patchFileForWebView("elements/elementsTreeOutline.css", toolsOutDir, false, [applyPaddingInlineCssPatch]);
         await patchFileForWebView("elements/stylesSectionTree.css", toolsOutDir, false, [applyPaddingInlineCssPatch]);

--- a/postBuildStep.ts
+++ b/postBuildStep.ts
@@ -15,9 +15,9 @@ import {
     applyInspectorViewHandleActionPatch,
     applyInspectorViewShowDrawerPatch,
     applyMainTabTabLocationPatch,
-    applyMainViewPatch,
     applyAppendTabPatch,
-    applyShowElementsTab
+    applyMainViewPatch,
+    applyShowElementsTab,
 } from "./src/host/polyfills/simpleView";
 import applySetupTextSelectionPatch from "./src/host/polyfills/textSelection";
 
@@ -89,7 +89,7 @@ async function patchFilesForWebView(toolsOutDir: string, debugMode: boolean) {
             applyUIUtilsPatch,
             applyCreateElementPatch,
             applyInspectorCommonCssRightToolbarPatch,
-	          applyInspectorCommonCssPatch,
+            applyInspectorCommonCssPatch,
             applyInspectorCommonCssTabSliderPatch,
         ]);
 
@@ -103,9 +103,9 @@ async function patchFilesForWebView(toolsOutDir: string, debugMode: boolean) {
         await patchFileForWebView("ui/InspectorView.js", toolsOutDir, true, [
             applyInspectorViewHandleActionPatch,
             applyInspectorViewShowDrawerPatch,
-	          applyDrawerTabLocationPatch,
+            applyDrawerTabLocationPatch,
             applyMainTabTabLocationPatch,
-	    ]);
+        ]);
         await patchFileForWebView("ui/TabbedPane.js", toolsOutDir, true, [applyAppendTabPatch]);
         await patchFileForWebView("ui/ViewManager.js", toolsOutDir, true, [applyShowElementsTab]);
     } else {
@@ -123,8 +123,8 @@ async function patchFilesForWebView(toolsOutDir: string, debugMode: boolean) {
             applyInspectorViewHandleActionPatch,
             applyInspectorViewShowDrawerPatch,
             applyDrawerTabLocationPatch,
-            applyMainTabTabLocationPatch
-	      ]);
+            applyMainTabTabLocationPatch,
+        ]);
         await patchFileForWebView("ui/TabbedPane.js", toolsOutDir, false, [applyAppendTabPatch]);
         await patchFileForWebView("ui/ViewManager.js", toolsOutDir, true, [applyShowElementsTab]);
         // Debug file versions
@@ -132,7 +132,7 @@ async function patchFilesForWebView(toolsOutDir: string, debugMode: boolean) {
         await patchFileForWebView("dom_extension/DOMExtension.js", toolsOutDir, false, [applyCreateElementPatch]);
         await patchFileForWebView("elements/ElementsPanel.js", toolsOutDir, false, [applySetupTextSelectionPatch]);
         await patchFileForWebView("themes/base.css", toolsOutDir, false, [
-           applyInspectorCommonCssRightToolbarPatch, applyInspectorCommonCssTabSliderPatch]);
+            applyInspectorCommonCssRightToolbarPatch, applyInspectorCommonCssTabSliderPatch]);
         await patchFileForWebView("elements/elementsTreeOutline.css", toolsOutDir, false, [applyPaddingInlineCssPatch]);
         await patchFileForWebView("elements/stylesSectionTree.css", toolsOutDir, false, [applyPaddingInlineCssPatch]);
     }

--- a/postBuildStep.ts
+++ b/postBuildStep.ts
@@ -15,11 +15,10 @@ import {
     applyInspectorCommonCssRightToolbarPatch,
     applyInspectorCommonCssTabSliderPatch,
     applyInspectorCommonNetworkPatch,
-    applyInspectorViewHandleActionPatch,
-    applyInspectorViewShowDrawerPatch,
-    applyMainTabTabLocationPatch,
     applyMainViewPatch,
+    applyPersistRequestBlockingTab,
     applyShowElementsTab,
+    applyShowRequestBlockingTab,
 } from "./src/host/polyfills/simpleView";
 import applySetupTextSelectionPatch from "./src/host/polyfills/textSelection";
 
@@ -104,14 +103,15 @@ async function patchFilesForWebView(toolsOutDir: string, debugMode: boolean) {
             applyPaddingInlineCssPatch,
         ]);
         await patchFileForWebView("inspector.html", toolsOutDir, true, [applyContentSecurityPolicyPatch]);
-        await patchFileForWebView("ui/InspectorView.js", toolsOutDir, true, [
-            applyInspectorViewHandleActionPatch,
-            applyInspectorViewShowDrawerPatch,
-            applyDrawerTabLocationPatch,
-            applyMainTabTabLocationPatch,
+        await patchFileForWebView("ui/InspectorView.js", toolsOutDir, true, [applyDrawerTabLocationPatch]);
+        await patchFileForWebView("ui/TabbedPane.js", toolsOutDir, true, [
+            applyAppendTabPatch,
+            applyPersistRequestBlockingTab,
         ]);
-        await patchFileForWebView("ui/TabbedPane.js", toolsOutDir, true, [applyAppendTabPatch]);
-        await patchFileForWebView("ui/ViewManager.js", toolsOutDir, true, [applyShowElementsTab]);
+        await patchFileForWebView("ui/ViewManager.js", toolsOutDir, true, [
+            applyShowElementsTab,
+            applyShowRequestBlockingTab,
+        ]);
     } else {
         // tslint:disable-next-line:no-console
         console.log("Patching files for debug version");
@@ -122,15 +122,15 @@ async function patchFilesForWebView(toolsOutDir: string, debugMode: boolean) {
             applyPaddingInlineCssPatch,
         ]);
         await patchFileForWebView("inspector.html", toolsOutDir, false, [applyContentSecurityPolicyPatch]);
-        await patchFileForWebView("ui/TabbedPane.js", toolsOutDir, false, [applyAppendTabPatch]);
-        await patchFileForWebView("ui/InspectorView.js", toolsOutDir, false, [
-            applyInspectorViewHandleActionPatch,
-            applyInspectorViewShowDrawerPatch,
-            applyDrawerTabLocationPatch,
-            applyMainTabTabLocationPatch,
+        await patchFileForWebView("ui/InspectorView.js", toolsOutDir, false, [applyDrawerTabLocationPatch]);
+        await patchFileForWebView("ui/TabbedPane.js", toolsOutDir, false, [
+            applyAppendTabPatch,
+            applyPersistRequestBlockingTab,
         ]);
-        await patchFileForWebView("ui/TabbedPane.js", toolsOutDir, false, [applyAppendTabPatch]);
-        await patchFileForWebView("ui/ViewManager.js", toolsOutDir, true, [applyShowElementsTab]);
+        await patchFileForWebView("ui/ViewManager.js", toolsOutDir, true, [
+            applyShowElementsTab,
+            applyShowRequestBlockingTab,
+        ]);
         // Debug file versions
         await patchFileForWebView("ui/UIUtils.js", toolsOutDir, false, [applyUIUtilsPatch]);
         await patchFileForWebView("dom_extension/DOMExtension.js", toolsOutDir, false, [applyCreateElementPatch]);

--- a/postBuildStep.ts
+++ b/postBuildStep.ts
@@ -10,9 +10,11 @@ import {
     applyAppendTabPatch,
     applyCommonRevealerPatch,
     applyDrawerTabLocationPatch,
+    applyInspectorCommonContextMenuPatch,
     applyInspectorCommonCssPatch,
     applyInspectorCommonCssRightToolbarPatch,
     applyInspectorCommonCssTabSliderPatch,
+    applyInspectorCommonNetworkPatch,
     applyInspectorViewHandleActionPatch,
     applyInspectorViewShowDrawerPatch,
     applyMainTabTabLocationPatch,
@@ -88,8 +90,10 @@ async function patchFilesForWebView(toolsOutDir: string, debugMode: boolean) {
         await patchFileForWebView("shell.js", toolsOutDir, true, [
             applyUIUtilsPatch,
             applyCreateElementPatch,
+            applyInspectorCommonContextMenuPatch,
             applyInspectorCommonCssRightToolbarPatch,
             applyInspectorCommonCssPatch,
+            applyInspectorCommonNetworkPatch,
             applyInspectorCommonCssTabSliderPatch,
         ]);
 
@@ -132,6 +136,7 @@ async function patchFilesForWebView(toolsOutDir: string, debugMode: boolean) {
         await patchFileForWebView("dom_extension/DOMExtension.js", toolsOutDir, false, [applyCreateElementPatch]);
         await patchFileForWebView("elements/ElementsPanel.js", toolsOutDir, false, [applySetupTextSelectionPatch]);
         await patchFileForWebView("themes/base.css", toolsOutDir, false, [
+            applyInspectorCommonContextMenuPatch, applyInspectorCommonCssPatch, applyInspectorCommonNetworkPatch,
             applyInspectorCommonCssRightToolbarPatch, applyInspectorCommonCssTabSliderPatch]);
         await patchFileForWebView("elements/elementsTreeOutline.css", toolsOutDir, false, [applyPaddingInlineCssPatch]);
         await patchFileForWebView("elements/stylesSectionTree.css", toolsOutDir, false, [applyPaddingInlineCssPatch]);

--- a/postBuildStep.ts
+++ b/postBuildStep.ts
@@ -17,6 +17,7 @@ import {
     applyInspectorCommonNetworkPatch,
     applyMainViewPatch,
     applyPersistRequestBlockingTab,
+    applySetTabIconPatch,
     applyShowElementsTab,
     applyShowRequestBlockingTab,
 } from "./src/host/polyfills/simpleView";
@@ -107,6 +108,7 @@ async function patchFilesForWebView(toolsOutDir: string, debugMode: boolean) {
         await patchFileForWebView("ui/TabbedPane.js", toolsOutDir, true, [
             applyAppendTabPatch,
             applyPersistRequestBlockingTab,
+            applySetTabIconPatch,
         ]);
         await patchFileForWebView("ui/ViewManager.js", toolsOutDir, true, [
             applyShowElementsTab,
@@ -126,6 +128,7 @@ async function patchFilesForWebView(toolsOutDir: string, debugMode: boolean) {
         await patchFileForWebView("ui/TabbedPane.js", toolsOutDir, false, [
             applyAppendTabPatch,
             applyPersistRequestBlockingTab,
+            applySetTabIconPatch,
         ]);
         await patchFileForWebView("ui/ViewManager.js", toolsOutDir, true, [
             applyShowElementsTab,

--- a/src/host/polyfills/simpleView.test.ts
+++ b/src/host/polyfills/simpleView.test.ts
@@ -75,38 +75,6 @@ describe("simpleView", () => {
             expect.stringContaining("const moreTools = { defaultSection: () => ({ appendItem: () => {} }) };"));
     });
 
-    it("applySelectTabPatch correctly changes text", async () => {
-        const comparableText = "selectTab(id, userGesture, forceFocus) {";
-        let fileContents = getTextFromFile("ui/TabbedPane.js");
-
-        // The file was not found, so test that at least the text is being replaced.
-        fileContents = fileContents ? fileContents : comparableText;
-        const apply = await import("./simpleView");
-        const result = apply.applySelectTabPatch(fileContents);
-        expect(result).not.toEqual(null);
-        expect(result).toEqual(expect.stringContaining("selectTab(id, userGesture, forceFocus) { if ("));
-    });
-
-    it("applyInspectorCommonCssPatch correctly changes tabbed-pane-header-contents", async () => {
-        const expectedCss = `.main-tabbed-pane .tabbed-pane-header-contents {
-            flex: auto;
-            pointer-events: none;
-            margin-left: 0;
-            position: relative;
-        }`;
-        const expectedResult = `.main-tabbed-pane .tabbed-pane-header-contents {
-            display: none !important;
-        }`;
-        let fileContents = getTextFromFile("shell.js");
-
-        // The file was not found, so test that at least the text is being replaced.
-        fileContents = fileContents ? fileContents : expectedCss;
-        const apply = await import("./simpleView");
-        const result = apply.applyInspectorCommonCssHeaderContentsPatch(fileContents);
-        expect(result).not.toEqual(null);
-        expect(result).toEqual(expect.stringContaining(expectedResult));
-    });
-
     it("applyInspectorCommonCssPatch correctly changes tabbed-pane-tab-slider", async () => {
         const expectedCss = `.tabbed-pane-tab-slider {
             height: 2px;
@@ -150,25 +118,6 @@ describe("simpleView", () => {
         expect(result).toEqual(expect.stringContaining(expectedResult));
     });
 
-    it("applyInspectorCommonCssPatch correctly changes tabbed-pane-header-contents in release mode", async () => {
-        const expectedCss = `.main-tabbed-pane .tabbed-pane-header-contents {
-            flex: auto;
-            pointer-events: none;
-            margin-left: 0;
-            position: relative;
-        }`;
-        const expectedResult =
-            ".main-tabbed-pane .tabbed-pane-header-contents {\\n            display: none !important;\\n        }";
-        let fileContents = getTextFromFile("shell.js");
-
-        // The file was not found, so test that at least the text is being replaced.
-        fileContents = fileContents ? fileContents : expectedCss;
-        const apply = await import("./simpleView");
-        const result = apply.applyInspectorCommonCssHeaderContentsPatch(fileContents, true);
-        expect(result).not.toEqual(null);
-        expect(result).toEqual(expect.stringContaining(expectedResult));
-    });
-
     it("applyInspectorCommonCssPatch correctly changes tabbed-pane-tab-slider in release mode", async () => {
         const expectedCss = `.tabbed-pane-tab-slider {
             height: 2px;
@@ -208,5 +157,75 @@ describe("simpleView", () => {
         const result = apply.applyInspectorCommonCssRightToolbarPatch(fileContents, true);
         expect(result).not.toEqual(null);
         expect(result).toEqual(expect.stringContaining(expectedResult));
+    });
+
+    it("applyInspectorViewPatch correctly changes text", async () => {
+        const apply = await import("./simpleView");
+
+        const comparableText3 = "this._showDrawer.bind(this, false), 'drawer-view', true, true // code";
+        let fileContents3 = getTextFromFile("ui/ui.js");
+        // The file was not found, so test that at least the text is being replaced.
+        fileContents3 = fileContents3 ? fileContents3 : comparableText3;
+        const result3 = apply.applyDrawerTabLocationPatch(fileContents3);
+        expect(result3).not.toEqual(null);
+        expect(result3).toEqual(
+            "this._showDrawer.bind(this, false), 'drawer-view', true, true, 'network.blocked-urls' // code");
+
+        const comparableText4 = "InspectorFrontendHostInstance), 'panel', true, true, Root.Runtime.queryParam('panel') // code";
+        let fileContents4 = getTextFromFile("ui/ui.js");
+        // The file was not found, so test that at least the text is being replaced.
+        fileContents4 = fileContents4 ? fileContents4 : comparableText4;
+        const result4 = apply.applyMainTabTabLocationPatch(fileContents4);
+        expect(result4).not.toEqual(null);
+        expect(result4).toEqual("InspectorFrontendHostInstance), 'panel', true, true, 'network' // code");
+    });
+
+    it("applySelectTabPatch correctly changes text", async () => {
+        const apply = await import("./simpleView");
+        const comparableText = "selectTab(id, userGesture, forceFocus) { // code"
+
+        let fileContents = getTextFromFile("ui/TabbedPane.js");
+        fileContents = fileContents ? fileContents : comparableText;
+        const result = apply.applySelectTabPatch(fileContents);
+        expect(result).not.toEqual(null);
+        expect(result).toEqual(expect.stringContaining("selectTab(id, userGesture, forceFocus) { if ("));
+    });
+
+    it("applyShowTabElementPatch correctly changes text", async () => {
+        const apply = await import("./simpleView");
+
+        const comparableText = "_showTabElement(index, tab) { // code";
+        let fileContents = getTextFromFile("ui/TabbedPane.js");
+        fileContents = fileContents ? fileContents : comparableText;
+        const result = apply.applyShowTabElement(fileContents);
+        expect(result).not.toEqual(null);
+        expect(result).toEqual(expect.stringContaining("_showTabElement(index, tab) { if ("));
+    });
+
+    it("applyInspectorCommonCssPatch correctly changes text", async () => {
+        const apply = await import("./simpleView");
+        const comparableText = ":host-context(.platform-mac) .monospace,";
+        let fileContents = getTextFromFile("shell.js");
+        fileContents = fileContents ? fileContents : comparableText;
+        const result = apply.applyInspectorCommonCssPatch(fileContents);
+        expect(result).not.toEqual(null);
+        if (result) {
+          expect(result.startsWith(".main-tabbed-pane")).toEqual(true);
+          expect(result.endsWith(".monospace,")).toEqual(true);
+        }
+    });
+
+    it("applyInspectorCommonCssPatch correctly changes text in release mode", async () => {
+        const apply = await import("./simpleView");
+        const comparableText = ":host-context(.platform-mac) .monospace,";
+        let fileContents = getTextFromFile("shell.js");
+        fileContents = fileContents ? fileContents : comparableText;
+        const result = apply.applyInspectorCommonCssPatch(fileContents, true);
+        expect(result).not.toEqual(null);
+        if (result) {
+          expect(result.startsWith(".main-tabbed-pane")).toEqual(true);
+          expect(result.endsWith(".monospace,")).toEqual(true);
+          expect(result.indexOf("\\n") > -1).toEqual(true);
+        }
     });
 });

--- a/src/host/polyfills/simpleView.test.ts
+++ b/src/host/polyfills/simpleView.test.ts
@@ -106,7 +106,7 @@ describe("simpleView", () => {
             flex: none;
         }`;
         const expectedResult = `.tabbed-pane-right-toolbar {
-            display: none !important;
+            visibility: hidden !important;
         }`;
         let fileContents = getTextFromFile("shell.js");
 
@@ -148,7 +148,7 @@ describe("simpleView", () => {
             flex: none;
         }`;
         const expectedResult =
-            ".tabbed-pane-right-toolbar {\\n            display: none !important;\\n        }";
+            ".tabbed-pane-right-toolbar {\\n            visibility: hidden !important;\\n        }";
         let fileContents = getTextFromFile("shell.js");
 
         // The file was not found, so test that at least the text is being replaced.

--- a/src/host/polyfills/simpleView.test.ts
+++ b/src/host/polyfills/simpleView.test.ts
@@ -184,26 +184,15 @@ describe("simpleView", () => {
         expect(result).toEqual(expect.stringContaining("InspectorFrontendHostInstance), 'panel', true, true, 'network'"));
     });
 
-    it("applySelectTabPatch correctly changes text", async () => {
+    it("applyAppendTabPatch correctly changes text", async () => {
         const apply = await import("./simpleView");
-        const comparableText = "selectTab(id, userGesture, forceFocus) {"
+        const comparableText = "appendTab(id, tabTitle, view, tabTooltip, userGesture, isCloseable, index) {"
 
         let fileContents = getTextFromFile("ui/TabbedPane.js");
         fileContents = fileContents ? fileContents : comparableText;
-        const result = apply.applySelectTabPatch(fileContents);
+        const result = apply.applyAppendTabPatch(fileContents);
         expect(result).not.toEqual(null);
-        expect(result).toEqual(expect.stringContaining("selectTab(id, userGesture, forceFocus) { if ("));
-    });
-
-    it("applyShowTabElementPatch correctly changes text", async () => {
-        const apply = await import("./simpleView");
-
-        const comparableText = "_showTabElement(index, tab) {";
-        let fileContents = getTextFromFile("ui/TabbedPane.js");
-        fileContents = fileContents ? fileContents : comparableText;
-        const result = apply.applyShowTabElement(fileContents);
-        expect(result).not.toEqual(null);
-        expect(result).toEqual(expect.stringContaining("_showTabElement(index, tab) { if ("));
+        expect(result).toEqual(expect.stringContaining("appendTab(id, tabTitle, view, tabTooltip, userGesture, isCloseable, index) { if (id"));
     });
 
     it("applyInspectorCommonCssPatch correctly changes text", async () => {
@@ -214,7 +203,7 @@ describe("simpleView", () => {
         const result = apply.applyInspectorCommonCssPatch(fileContents);
 
         // If this part of the css was correctly applied to the file, the rest of the css will be there as well.
-        const expectedString = ".tabbed-pane-header-tabs-drop-down-container {\n        display: none";
+        const expectedString = ".toolbar-button[aria-label='Toggle screencast'] {\n            visibility: visible !important;"
 
         expect(result).not.toEqual(null);
         if (result) {
@@ -229,7 +218,7 @@ describe("simpleView", () => {
         fileContents = fileContents ? fileContents : comparableText;
         const result = apply.applyInspectorCommonCssPatch(fileContents, true);
 
-        const expectedString = ".tabbed-pane-header-tabs-drop-down-container {\\n        display: none";
+        const expectedString = ".toolbar-button[aria-label='Toggle screencast'] {\\n            visibility: visible !important;";
 
         expect(result).not.toEqual(null);
         if (result) {

--- a/src/host/polyfills/simpleView.test.ts
+++ b/src/host/polyfills/simpleView.test.ts
@@ -87,18 +87,6 @@ describe("simpleView", () => {
             "this._showDrawer.bind(this, false), 'drawer-view', true, true, 'network.blocked-urls'"));
     });
 
-    it("applyMainTabTabLocationPatch correctly changes text", async () => {
-        const apply = await import("./simpleView");
-        const comparableText = "InspectorFrontendHostInstance), 'panel', true, true, Root.Runtime.queryParam('panel')";
-        let fileContents = getTextFromFile("ui/InspectorView.js");
-        // The file was not found, so test that at least the text is being replaced.
-        fileContents = fileContents ? fileContents : comparableText;
-        const result = apply.applyMainTabTabLocationPatch(fileContents);
-        expect(result).not.toEqual(null);
-        expect(result).toEqual(expect.stringContaining(
-            "InspectorFrontendHostInstance), 'panel', true, true, 'network'"));
-    });
-
     it("applyAppendTabPatch correctly changes text", async () => {
         const apply = await import("./simpleView");
         const comparableText = "appendTab(id, tabTitle, view, tabTooltip, userGesture, isCloseable, index) {";
@@ -119,6 +107,32 @@ describe("simpleView", () => {
         expect(result).not.toEqual(null);
         if (result) {
             expect(result).toEqual(expect.stringContaining("this._defaultTab = 'elements';"));
+        }
+    });
+
+    it("applyShowRequestBlockingTab correctly changes text", async () => {
+        const apply = await import("./simpleView");
+        const comparableText = "if(!view.isCloseable())";
+        let fileContents = getTextFromFile("ui/ViewManager.js");
+        fileContents = fileContents ? fileContents : comparableText;
+        const result = apply.applyShowRequestBlockingTab(fileContents);
+        expect(result).not.toEqual(null);
+        if (result) {
+            expect(result).toEqual(expect.stringContaining(
+                "if(!view.isCloseable()||id==='network.blocked-urls')"));
+        }
+    });
+
+    it("applyPersistRequestBlockingTab correctly changes text", async () => {
+        const apply = await import("./simpleView");
+        const comparableText = "this._closeable = closeable;";
+        let fileContents = getTextFromFile("ui/TabbedPane.js");
+        fileContents = fileContents ? fileContents : comparableText;
+        const result = apply.applyPersistRequestBlockingTab(fileContents);
+        expect(result).not.toEqual(null);
+        if (result) {
+            expect(result).toEqual(expect.stringContaining(
+                "this._closeable=id==='network.blocked-urls'?false:closeable;"));
         }
     });
 

--- a/src/host/polyfills/simpleView.test.ts
+++ b/src/host/polyfills/simpleView.test.ts
@@ -89,7 +89,8 @@ describe("simpleView", () => {
 
     it("applySetTabIconPatch correctly changes text", async () => {
         const apply = await import("./simpleView");
-        const comparableText = " setTabIcon(id, icon) {const tab = this._tabsById.get(id); tab._setIcon(icon);this._updateTabElements();}";
+        const comparableText =
+            " setTabIcon(id, icon) {const tab = this._tabsById.get(id); tab._setIcon(icon);this._updateTabElements();}";
         let fileContents = getTextFromFile("ui/TabbedPane.js");
         fileContents = fileContents ? fileContents : comparableText;
         const result = apply.applySetTabIconPatch(fileContents);

--- a/src/host/polyfills/simpleView.test.ts
+++ b/src/host/polyfills/simpleView.test.ts
@@ -75,29 +75,147 @@ describe("simpleView", () => {
             expect.stringContaining("const moreTools = { defaultSection: () => ({ appendItem: () => {} }) };"));
     });
 
-    it("applyInspectorCommonCssPatch correctly changes tabbed-pane-tab-slider", async () => {
-        const comparableText = `.tabbed-pane-tab-slider {
-            height: 2px;
-            position: absolute;
-            bottom: -1px;
-            background-color: var(--accent-color);
-            left: 0;
-            z-index: 50;
-            transform-origin: 0 100%;
-            transition: transform 150ms cubic-bezier(0, 0, 0.2, 1);
-            visibility: hidden;
-        }`;
-        const expectedResult = `.tabbed-pane-tab-slider {
-            display: none !important;
-        }`;
-        let fileContents = getTextFromFile("shell.js");
-
+    it("applyDrawerTabLocationPatch correctly changes text", async () => {
+        const apply = await import("./simpleView");
+        const comparableText = "this._showDrawer.bind(this, false), 'drawer-view', true, true";
+        let fileContents = getTextFromFile("ui/InspectorView.js");
         // The file was not found, so test that at least the text is being replaced.
         fileContents = fileContents ? fileContents : comparableText;
-        const apply = await import("./simpleView");
-        const result = apply.applyInspectorCommonCssTabSliderPatch(fileContents);
+        const result = apply.applyDrawerTabLocationPatch(fileContents);
         expect(result).not.toEqual(null);
-        expect(result).toEqual(expect.stringContaining(expectedResult));
+        expect(result).toEqual(expect.stringContaining(
+            "this._showDrawer.bind(this, false), 'drawer-view', true, true, 'network.blocked-urls'"));
+    });
+
+    it("applyMainTabTabLocationPatch correctly changes text", async () => {
+        const apply = await import("./simpleView");
+        const comparableText = "InspectorFrontendHostInstance), 'panel', true, true, Root.Runtime.queryParam('panel')";
+        let fileContents = getTextFromFile("ui/InspectorView.js");
+        // The file was not found, so test that at least the text is being replaced.
+        fileContents = fileContents ? fileContents : comparableText;
+        const result = apply.applyMainTabTabLocationPatch(fileContents);
+        expect(result).not.toEqual(null);
+        expect(result).toEqual(expect.stringContaining(
+            "InspectorFrontendHostInstance), 'panel', true, true, 'network'"));
+    });
+
+    it("applyAppendTabPatch correctly changes text", async () => {
+        const apply = await import("./simpleView");
+        const comparableText = "appendTab(id, tabTitle, view, tabTooltip, userGesture, isCloseable, index) {";
+        let fileContents = getTextFromFile("ui/TabbedPane.js");
+        fileContents = fileContents ? fileContents : comparableText;
+        const result = apply.applyAppendTabPatch(fileContents);
+        expect(result).not.toEqual(null);
+        expect(result).toEqual(expect.stringContaining(
+            "appendTab(id, tabTitle, view, tabTooltip, userGesture, isCloseable, index) { if (id"));
+    });
+
+    it("applyShowElementsTab correctly changes text", async () => {
+        const apply = await import("./simpleView");
+        const comparableText = "this._defaultTab = defaultTab;";
+        let fileContents = getTextFromFile("ui/ViewManager.js");
+        fileContents = fileContents ? fileContents : comparableText;
+        const result = apply.applyShowElementsTab(fileContents);
+        expect(result).not.toEqual(null);
+        if (result) {
+            expect(result).toEqual(expect.stringContaining("this._defaultTab = 'elements';"));
+        }
+    });
+
+    it("applyInspectorCommonCssPatch correctly changes text", async () => {
+        const apply = await import("./simpleView");
+        const comparableText = ":host-context(.platform-mac) .monospace,";
+        let fileContents = getTextFromFile("shell.js");
+        fileContents = fileContents ? fileContents : comparableText;
+        const result = apply.applyInspectorCommonCssPatch(fileContents);
+
+        // If this part of the css was correctly applied to the file, the rest of the css will be there as well.
+        const expectedString =
+            ".toolbar-button[aria-label='Toggle screencast'] {\n            visibility: visible !important;";
+        expect(result).not.toEqual(null);
+        if (result) {
+            expect(result).toEqual(expect.stringContaining(expectedString));
+        }
+    });
+
+    it("applyInspectorCommonCssPatch correctly changes text (release)", async () => {
+        const apply = await import("./simpleView");
+        const comparableText = ":host-context(.platform-mac) .monospace,";
+        let fileContents = getTextFromFile("shell.js");
+        fileContents = fileContents ? fileContents : comparableText;
+        const result = apply.applyInspectorCommonCssPatch(fileContents, true);
+        // If this part of the css was correctly applied to the file, the rest of the css will be there as well.
+        const expectedString =
+            ".toolbar-button[aria-label='Toggle screencast'] {\\n            visibility: visible !important;";
+
+        expect(result).not.toEqual(null);
+        if (result) {
+            expect(result).toEqual(expect.stringContaining(expectedString));
+        }
+    });
+
+    it("applyInspectorCommonNetworkPatch correctly changes text", async () => {
+        const apply = await import("./simpleView");
+        const comparableText = ":host-context(.platform-mac) .monospace,";
+        let fileContents = getTextFromFile("shell.js");
+        fileContents = fileContents ? fileContents : comparableText;
+        const result = apply.applyInspectorCommonNetworkPatch(fileContents);
+
+        // If this part of the css was correctly applied to the file, the rest of the css will be there as well.
+        const expectedString =
+            ".toolbar-button[aria-label='Export HAR...'] {\n            display: none !important;";
+        expect(result).not.toEqual(null);
+        if (result) {
+            expect(result).toEqual(expect.stringContaining(expectedString));
+        }
+    });
+
+    it("applyInspectorCommonNetworkPatch correctly changes text (release)", async () => {
+        const apply = await import("./simpleView");
+        const comparableText = ":host-context(.platform-mac) .monospace,";
+        let fileContents = getTextFromFile("shell.js");
+        fileContents = fileContents ? fileContents : comparableText;
+        const result = apply.applyInspectorCommonNetworkPatch(fileContents, true);
+        // If this part of the css was correctly applied to the file, the rest of the css will be there as well.
+        const expectedString =
+            ".toolbar-button[aria-label='Export HAR...'] {\\n            display: none !important;";
+
+        expect(result).not.toEqual(null);
+        if (result) {
+            expect(result).toEqual(expect.stringContaining(expectedString));
+        }
+    });
+
+    it("applyInspectorCommonContextMenuPatch correctly changes text", async () => {
+        const apply = await import("./simpleView");
+        const comparableText = ":host-context(.platform-mac) .monospace,";
+        let fileContents = getTextFromFile("shell.js");
+        fileContents = fileContents ? fileContents : comparableText;
+        const result = apply.applyInspectorCommonContextMenuPatch(fileContents);
+
+        // If this part of the css was correctly applied to the file, the rest of the css will be there as well.
+        const expectedString =
+            ".soft-context-menu-item[aria-label='Save as...'] {\n            display: none !important;";
+        expect(result).not.toEqual(null);
+        if (result) {
+            expect(result).toEqual(expect.stringContaining(expectedString));
+        }
+    });
+
+    it("applyInspectorCommonContextMenuPatch correctly changes text (release)", async () => {
+        const apply = await import("./simpleView");
+        const comparableText = ":host-context(.platform-mac) .monospace,";
+        let fileContents = getTextFromFile("shell.js");
+        fileContents = fileContents ? fileContents : comparableText;
+        const result = apply.applyInspectorCommonContextMenuPatch(fileContents, true);
+        // If this part of the css was correctly applied to the file, the rest of the css will be there as well.
+        const expectedString =
+            ".soft-context-menu-item[aria-label='Save as...'] {\\n            display: none !important;";
+
+        expect(result).not.toEqual(null);
+        if (result) {
+            expect(result).toEqual(expect.stringContaining(expectedString));
+        }
     });
 
     it("applyInspectorCommonCssRightToolbarPatch correctly changes tabbed-pane-right-toolbar (release)", async () => {
@@ -114,6 +232,23 @@ describe("simpleView", () => {
         fileContents = fileContents ? fileContents : comparableText;
         const apply = await import("./simpleView");
         const result = apply.applyInspectorCommonCssRightToolbarPatch(fileContents);
+        expect(result).not.toEqual(null);
+        expect(result).toEqual(expect.stringContaining(expectedResult));
+    });
+
+    it("applyInspectorCommonCssRightToolbarPatch correctly changes tabbed-pane-right-toolbar", async () => {
+        const comparableText = `.tabbed-pane-right-toolbar {
+            margin-left: -4px;
+            flex: none;
+        }`;
+        const expectedResult =
+            ".tabbed-pane-right-toolbar {\\n            visibility: hidden !important;\\n        }";
+        let fileContents = getTextFromFile("shell.js");
+
+        // The file was not found, so test that at least the text is being replaced.
+        fileContents = fileContents ? fileContents : comparableText;
+        const apply = await import("./simpleView");
+        const result = apply.applyInspectorCommonCssRightToolbarPatch(fileContents, true);
         expect(result).not.toEqual(null);
         expect(result).toEqual(expect.stringContaining(expectedResult));
     });
@@ -142,103 +277,28 @@ describe("simpleView", () => {
         expect(result).toEqual(expect.stringContaining(expectedResult));
     });
 
-    it("applyInspectorCommonCssRightToolbarPatch correctly changes tabbed-pane-right-toolbar", async () => {
-        const comparableText = `.tabbed-pane-right-toolbar {
-            margin-left: -4px;
-            flex: none;
+    it("applyInspectorCommonCssTabSliderPatch correctly changes tabbed-pane-tab-slider", async () => {
+        const comparableText = `.tabbed-pane-tab-slider {
+            height: 2px;
+            position: absolute;
+            bottom: -1px;
+            background-color: var(--accent-color);
+            left: 0;
+            z-index: 50;
+            transform-origin: 0 100%;
+            transition: transform 150ms cubic-bezier(0, 0, 0.2, 1);
+            visibility: hidden;
         }`;
-        const expectedResult =
-            ".tabbed-pane-right-toolbar {\\n            visibility: hidden !important;\\n        }";
+        const expectedResult = `.tabbed-pane-tab-slider {
+            display: none !important;
+        }`;
         let fileContents = getTextFromFile("shell.js");
 
         // The file was not found, so test that at least the text is being replaced.
         fileContents = fileContents ? fileContents : comparableText;
         const apply = await import("./simpleView");
-        const result = apply.applyInspectorCommonCssRightToolbarPatch(fileContents, true);
+        const result = apply.applyInspectorCommonCssTabSliderPatch(fileContents);
         expect(result).not.toEqual(null);
         expect(result).toEqual(expect.stringContaining(expectedResult));
     });
-
-    it("applyDrawerTabLocationPatch correctly changes text", async () => {
-        const apply = await import("./simpleView");
-
-        const comparableText = "this._showDrawer.bind(this, false), 'drawer-view', true, true";
-        let fileContents = getTextFromFile("ui/InspectorView.js");
-        // The file was not found, so test that at least the text is being replaced.
-        fileContents = fileContents ? fileContents : comparableText;
-        const result = apply.applyDrawerTabLocationPatch(fileContents);
-        expect(result).not.toEqual(null);
-        expect(result).toEqual(expect.stringContaining(
-            "this._showDrawer.bind(this, false), 'drawer-view', true, true, 'network.blocked-urls'"));
-    });
-
-    it("applyMainTabTabLocationPatch correctly changes text", async () => {
-        const apply = await import("./simpleView");
-
-        const comparableText = "InspectorFrontendHostInstance), 'panel', true, true, Root.Runtime.queryParam('panel')";
-        let fileContents = getTextFromFile("ui/InspectorView.js");
-        // The file was not found, so test that at least the text is being replaced.
-        fileContents = fileContents ? fileContents : comparableText;
-        const result = apply.applyMainTabTabLocationPatch(fileContents);
-        expect(result).not.toEqual(null);
-        expect(result).toEqual(expect.stringContaining(
-            "InspectorFrontendHostInstance), 'panel', true, true, 'network'"));
-    });
-
-    it("applyAppendTabPatch correctly changes text", async () => {
-        const apply = await import("./simpleView");
-        const comparableText = "appendTab(id, tabTitle, view, tabTooltip, userGesture, isCloseable, index) {";
-
-        let fileContents = getTextFromFile("ui/TabbedPane.js");
-        fileContents = fileContents ? fileContents : comparableText;
-        const result = apply.applyAppendTabPatch(fileContents);
-        expect(result).not.toEqual(null);
-        expect(result).toEqual(expect.stringContaining(
-            "appendTab(id, tabTitle, view, tabTooltip, userGesture, isCloseable, index) { if (id"));
-    });
-
-    it("applyInspectorCommonCssPatch correctly changes text", async () => {
-        const apply = await import("./simpleView");
-        const comparableText = ":host-context(.platform-mac) .monospace,";
-        let fileContents = getTextFromFile("shell.js");
-        fileContents = fileContents ? fileContents : comparableText;
-        const result = apply.applyInspectorCommonCssPatch(fileContents);
-
-        // If this part of the css was correctly applied to the file, the rest of the css will be there as well.
-        const expectedString =
-            ".toolbar-button[aria-label='Toggle screencast'] {\n            visibility: visible !important;";
-
-        expect(result).not.toEqual(null);
-        if (result) {
-          expect(result).toEqual(expect.stringContaining(expectedString));
-        }
-    });
-
-    it("applyInspectorCommonCssPatch correctly changes text (release)", async () => {
-        const apply = await import("./simpleView");
-        const comparableText = ":host-context(.platform-mac) .monospace,";
-        let fileContents = getTextFromFile("shell.js");
-        fileContents = fileContents ? fileContents : comparableText;
-        const result = apply.applyInspectorCommonCssPatch(fileContents, true);
-        // If this part of the css was correctly applied to the file, the rest of the css will be there as well.
-        const expectedString =
-            ".toolbar-button[aria-label='Toggle screencast'] {\\n            visibility: visible !important;";
-
-        expect(result).not.toEqual(null);
-        if (result) {
-          expect(result).toEqual(expect.stringContaining(expectedString));
-        }
-    });
-
-    it("applyShowElementsTab correctly changes text", async () => {
-      const apply = await import("./simpleView");
-      const comparableText = "this._defaultTab = defaultTab;";
-      let fileContents = getTextFromFile("ui/ViewManager.js");
-      fileContents = fileContents ? fileContents : comparableText;
-      const result = apply.applyShowElementsTab(fileContents);
-      expect(result).not.toEqual(null);
-      if (result) {
-        expect(result).toEqual(expect.stringContaining("this._defaultTab = 'elements';"));
-      }
-  });
 });

--- a/src/host/polyfills/simpleView.test.ts
+++ b/src/host/polyfills/simpleView.test.ts
@@ -87,6 +87,16 @@ describe("simpleView", () => {
             "this._showDrawer.bind(this, false), 'drawer-view', true, true, 'network.blocked-urls'"));
     });
 
+    it("applySetTabIconPatch correctly changes text", async () => {
+        const apply = await import("./simpleView");
+        const comparableText = " setTabIcon(id, icon) {const tab = this._tabsById.get(id); tab._setIcon(icon);this._updateTabElements();}";
+        let fileContents = getTextFromFile("ui/TabbedPane.js");
+        fileContents = fileContents ? fileContents : comparableText;
+        const result = apply.applySetTabIconPatch(fileContents);
+        expect(result).not.toEqual(null);
+        expect(result).toEqual(expect.stringContaining("if(!tab){return;}"));
+    });
+
     it("applyAppendTabPatch correctly changes text", async () => {
         const apply = await import("./simpleView");
         const comparableText = "appendTab(id, tabTitle, view, tabTooltip, userGesture, isCloseable, index) {";

--- a/src/host/polyfills/simpleView.test.ts
+++ b/src/host/polyfills/simpleView.test.ts
@@ -37,7 +37,7 @@ describe("simpleView", () => {
             expect.stringContaining("let reveal = function revealInVSCode(revealable, omitFocus) {"));
     });
 
-    it("applyInspectorViewPatch correctly changes handleAction text", async () => {
+    it("applyInspectorViewPatch correctly changes handleAction text", async () => { 
         const comparableText = "handleAction(context, actionId) {\n";
         let fileContents = getTextFromFile("ui/InspectorView.js");
         // The file was not found, so test that at least the text is being replaced.
@@ -76,7 +76,7 @@ describe("simpleView", () => {
     });
 
     it("applyInspectorCommonCssPatch correctly changes tabbed-pane-tab-slider", async () => {
-        const expectedCss = `.tabbed-pane-tab-slider {
+        const comparableText = `.tabbed-pane-tab-slider {
             height: 2px;
             position: absolute;
             bottom: -1px;
@@ -93,15 +93,15 @@ describe("simpleView", () => {
         let fileContents = getTextFromFile("shell.js");
 
         // The file was not found, so test that at least the text is being replaced.
-        fileContents = fileContents ? fileContents : expectedCss;
+        fileContents = fileContents ? fileContents : comparableText;
         const apply = await import("./simpleView");
         const result = apply.applyInspectorCommonCssTabSliderPatch(fileContents);
         expect(result).not.toEqual(null);
         expect(result).toEqual(expect.stringContaining(expectedResult));
     });
 
-    it("applyInspectorCommonCssPatch correctly changes tabbed-pane-right-toolbar", async () => {
-        const expectedCss = `.tabbed-pane-right-toolbar {
+    it("applyInspectorCommonCssRightToolbarPatch correctly changes tabbed-pane-right-toolbar", async () => {
+        const comparableText = `.tabbed-pane-right-toolbar {
             margin-left: -4px;
             flex: none;
         }`;
@@ -111,15 +111,15 @@ describe("simpleView", () => {
         let fileContents = getTextFromFile("shell.js");
 
         // The file was not found, so test that at least the text is being replaced.
-        fileContents = fileContents ? fileContents : expectedCss;
+        fileContents = fileContents ? fileContents : comparableText;
         const apply = await import("./simpleView");
         const result = apply.applyInspectorCommonCssRightToolbarPatch(fileContents);
         expect(result).not.toEqual(null);
         expect(result).toEqual(expect.stringContaining(expectedResult));
     });
 
-    it("applyInspectorCommonCssPatch correctly changes tabbed-pane-tab-slider in release mode", async () => {
-        const expectedCss = `.tabbed-pane-tab-slider {
+    it("applyInspectorCommonCssTabSliderPatch correctly changes tabbed-pane-tab-slider in release mode", async () => {
+        const comparableText = `.tabbed-pane-tab-slider {
             height: 2px;
             position: absolute;
             bottom: -1px;
@@ -135,15 +135,15 @@ describe("simpleView", () => {
         let fileContents = getTextFromFile("shell.js");
 
         // The file was not found, so test that at least the text is being replaced.
-        fileContents = fileContents ? fileContents : expectedCss;
+        fileContents = fileContents ? fileContents : comparableText;
         const apply = await import("./simpleView");
         const result = apply.applyInspectorCommonCssTabSliderPatch(fileContents, true);
         expect(result).not.toEqual(null);
         expect(result).toEqual(expect.stringContaining(expectedResult));
     });
 
-    it("applyInspectorCommonCssPatch correctly changes tabbed-pane-right-toolbar in release mode", async () => {
-        const expectedCss = `.tabbed-pane-right-toolbar {
+    it("applyInspectorCommonCssRightToolbarPatch correctly changes tabbed-pane-right-toolbar in release mode", async () => {
+        const comparableText = `.tabbed-pane-right-toolbar {
             margin-left: -4px;
             flex: none;
         }`;
@@ -152,37 +152,41 @@ describe("simpleView", () => {
         let fileContents = getTextFromFile("shell.js");
 
         // The file was not found, so test that at least the text is being replaced.
-        fileContents = fileContents ? fileContents : expectedCss;
+        fileContents = fileContents ? fileContents : comparableText;
         const apply = await import("./simpleView");
         const result = apply.applyInspectorCommonCssRightToolbarPatch(fileContents, true);
         expect(result).not.toEqual(null);
         expect(result).toEqual(expect.stringContaining(expectedResult));
     });
 
-    it("applyInspectorViewPatch correctly changes text", async () => {
+    it("applyDrawerTabLocationPatch correctly changes text", async () => {
         const apply = await import("./simpleView");
 
-        const comparableText3 = "this._showDrawer.bind(this, false), 'drawer-view', true, true // code";
-        let fileContents3 = getTextFromFile("ui/ui.js");
+        const comparableText = "this._showDrawer.bind(this, false), 'drawer-view', true, true";
+        let fileContents = getTextFromFile("ui/InspectorView.js");
         // The file was not found, so test that at least the text is being replaced.
-        fileContents3 = fileContents3 ? fileContents3 : comparableText3;
-        const result3 = apply.applyDrawerTabLocationPatch(fileContents3);
-        expect(result3).not.toEqual(null);
-        expect(result3).toEqual(
-            "this._showDrawer.bind(this, false), 'drawer-view', true, true, 'network.blocked-urls' // code");
+        fileContents = fileContents ? fileContents : comparableText;
+        const result = apply.applyDrawerTabLocationPatch(fileContents);
+        expect(result).not.toEqual(null);
+        expect(result).toEqual(expect.stringContaining(
+            "this._showDrawer.bind(this, false), 'drawer-view', true, true, 'network.blocked-urls'"));
+    });
 
-        const comparableText4 = "InspectorFrontendHostInstance), 'panel', true, true, Root.Runtime.queryParam('panel') // code";
-        let fileContents4 = getTextFromFile("ui/ui.js");
+    it("applyMainTabTabLocationPatch correctly changes text", async () => {
+        const apply = await import("./simpleView");
+
+        const comparableText = "InspectorFrontendHostInstance), 'panel', true, true, Root.Runtime.queryParam('panel')";
+        let fileContents = getTextFromFile("ui/InspectorView.js");
         // The file was not found, so test that at least the text is being replaced.
-        fileContents4 = fileContents4 ? fileContents4 : comparableText4;
-        const result4 = apply.applyMainTabTabLocationPatch(fileContents4);
-        expect(result4).not.toEqual(null);
-        expect(result4).toEqual("InspectorFrontendHostInstance), 'panel', true, true, 'network' // code");
+        fileContents = fileContents ? fileContents : comparableText;
+        const result = apply.applyMainTabTabLocationPatch(fileContents);
+        expect(result).not.toEqual(null);
+        expect(result).toEqual(expect.stringContaining("InspectorFrontendHostInstance), 'panel', true, true, 'network'"));
     });
 
     it("applySelectTabPatch correctly changes text", async () => {
         const apply = await import("./simpleView");
-        const comparableText = "selectTab(id, userGesture, forceFocus) { // code"
+        const comparableText = "selectTab(id, userGesture, forceFocus) {"
 
         let fileContents = getTextFromFile("ui/TabbedPane.js");
         fileContents = fileContents ? fileContents : comparableText;
@@ -194,7 +198,7 @@ describe("simpleView", () => {
     it("applyShowTabElementPatch correctly changes text", async () => {
         const apply = await import("./simpleView");
 
-        const comparableText = "_showTabElement(index, tab) { // code";
+        const comparableText = "_showTabElement(index, tab) {";
         let fileContents = getTextFromFile("ui/TabbedPane.js");
         fileContents = fileContents ? fileContents : comparableText;
         const result = apply.applyShowTabElement(fileContents);
@@ -208,10 +212,13 @@ describe("simpleView", () => {
         let fileContents = getTextFromFile("shell.js");
         fileContents = fileContents ? fileContents : comparableText;
         const result = apply.applyInspectorCommonCssPatch(fileContents);
+
+        // If this part of the css was correctly applied to the file, the rest of the css will be there as well.
+        const expectedString = ".tabbed-pane-header-tabs-drop-down-container {\n        display: none";
+
         expect(result).not.toEqual(null);
         if (result) {
-          expect(result.startsWith(".main-tabbed-pane")).toEqual(true);
-          expect(result.endsWith(".monospace,")).toEqual(true);
+          expect(result).toEqual(expect.stringContaining(expectedString));
         }
     });
 
@@ -221,11 +228,24 @@ describe("simpleView", () => {
         let fileContents = getTextFromFile("shell.js");
         fileContents = fileContents ? fileContents : comparableText;
         const result = apply.applyInspectorCommonCssPatch(fileContents, true);
+
+        const expectedString = ".tabbed-pane-header-tabs-drop-down-container {\\n        display: none";
+
         expect(result).not.toEqual(null);
         if (result) {
-          expect(result.startsWith(".main-tabbed-pane")).toEqual(true);
-          expect(result.endsWith(".monospace,")).toEqual(true);
-          expect(result.indexOf("\\n") > -1).toEqual(true);
+          expect(result).toEqual(expect.stringContaining(expectedString));
         }
     });
+
+    it("applyShowElementsTab correctly changes text", async () => {
+      const apply = await import("./simpleView");
+      const comparableText = "this._defaultTab = defaultTab;";
+      let fileContents = getTextFromFile("ui/ViewManager.js");
+      fileContents = fileContents ? fileContents : comparableText;
+      const result = apply.applyShowElementsTab(fileContents);
+      expect(result).not.toEqual(null);
+      if (result) {
+        expect(result).toEqual(expect.stringContaining("this._defaultTab = 'elements';"));
+      }
+  });
 });

--- a/src/host/polyfills/simpleView.test.ts
+++ b/src/host/polyfills/simpleView.test.ts
@@ -37,7 +37,7 @@ describe("simpleView", () => {
             expect.stringContaining("let reveal = function revealInVSCode(revealable, omitFocus) {"));
     });
 
-    it("applyInspectorViewPatch correctly changes handleAction text", async () => { 
+    it("applyInspectorViewPatch correctly changes handleAction text", async () => {
         const comparableText = "handleAction(context, actionId) {\n";
         let fileContents = getTextFromFile("ui/InspectorView.js");
         // The file was not found, so test that at least the text is being replaced.
@@ -100,7 +100,7 @@ describe("simpleView", () => {
         expect(result).toEqual(expect.stringContaining(expectedResult));
     });
 
-    it("applyInspectorCommonCssRightToolbarPatch correctly changes tabbed-pane-right-toolbar", async () => {
+    it("applyInspectorCommonCssRightToolbarPatch correctly changes tabbed-pane-right-toolbar (release)", async () => {
         const comparableText = `.tabbed-pane-right-toolbar {
             margin-left: -4px;
             flex: none;
@@ -118,7 +118,7 @@ describe("simpleView", () => {
         expect(result).toEqual(expect.stringContaining(expectedResult));
     });
 
-    it("applyInspectorCommonCssTabSliderPatch correctly changes tabbed-pane-tab-slider in release mode", async () => {
+    it("applyInspectorCommonCssTabSliderPatch correctly changes tabbed-pane-tab-slider (release)", async () => {
         const comparableText = `.tabbed-pane-tab-slider {
             height: 2px;
             position: absolute;
@@ -142,7 +142,7 @@ describe("simpleView", () => {
         expect(result).toEqual(expect.stringContaining(expectedResult));
     });
 
-    it("applyInspectorCommonCssRightToolbarPatch correctly changes tabbed-pane-right-toolbar in release mode", async () => {
+    it("applyInspectorCommonCssRightToolbarPatch correctly changes tabbed-pane-right-toolbar", async () => {
         const comparableText = `.tabbed-pane-right-toolbar {
             margin-left: -4px;
             flex: none;
@@ -181,18 +181,20 @@ describe("simpleView", () => {
         fileContents = fileContents ? fileContents : comparableText;
         const result = apply.applyMainTabTabLocationPatch(fileContents);
         expect(result).not.toEqual(null);
-        expect(result).toEqual(expect.stringContaining("InspectorFrontendHostInstance), 'panel', true, true, 'network'"));
+        expect(result).toEqual(expect.stringContaining(
+            "InspectorFrontendHostInstance), 'panel', true, true, 'network'"));
     });
 
     it("applyAppendTabPatch correctly changes text", async () => {
         const apply = await import("./simpleView");
-        const comparableText = "appendTab(id, tabTitle, view, tabTooltip, userGesture, isCloseable, index) {"
+        const comparableText = "appendTab(id, tabTitle, view, tabTooltip, userGesture, isCloseable, index) {";
 
         let fileContents = getTextFromFile("ui/TabbedPane.js");
         fileContents = fileContents ? fileContents : comparableText;
         const result = apply.applyAppendTabPatch(fileContents);
         expect(result).not.toEqual(null);
-        expect(result).toEqual(expect.stringContaining("appendTab(id, tabTitle, view, tabTooltip, userGesture, isCloseable, index) { if (id"));
+        expect(result).toEqual(expect.stringContaining(
+            "appendTab(id, tabTitle, view, tabTooltip, userGesture, isCloseable, index) { if (id"));
     });
 
     it("applyInspectorCommonCssPatch correctly changes text", async () => {
@@ -203,7 +205,8 @@ describe("simpleView", () => {
         const result = apply.applyInspectorCommonCssPatch(fileContents);
 
         // If this part of the css was correctly applied to the file, the rest of the css will be there as well.
-        const expectedString = ".toolbar-button[aria-label='Toggle screencast'] {\n            visibility: visible !important;"
+        const expectedString =
+            ".toolbar-button[aria-label='Toggle screencast'] {\n            visibility: visible !important;";
 
         expect(result).not.toEqual(null);
         if (result) {
@@ -211,14 +214,15 @@ describe("simpleView", () => {
         }
     });
 
-    it("applyInspectorCommonCssPatch correctly changes text in release mode", async () => {
+    it("applyInspectorCommonCssPatch correctly changes text (release)", async () => {
         const apply = await import("./simpleView");
         const comparableText = ":host-context(.platform-mac) .monospace,";
         let fileContents = getTextFromFile("shell.js");
         fileContents = fileContents ? fileContents : comparableText;
         const result = apply.applyInspectorCommonCssPatch(fileContents, true);
-
-        const expectedString = ".toolbar-button[aria-label='Toggle screencast'] {\\n            visibility: visible !important;";
+        // If this part of the css was correctly applied to the file, the rest of the css will be there as well.
+        const expectedString =
+            ".toolbar-button[aria-label='Toggle screencast'] {\\n            visibility: visible !important;";
 
         expect(result).not.toEqual(null);
         if (result) {

--- a/src/host/polyfills/simpleView.ts
+++ b/src/host/polyfills/simpleView.ts
@@ -164,12 +164,16 @@ export function applyInspectorCommonCssPatch(content: string, isRelease?: boolea
         unHideScreenCastBtn +
         unHideSearchCloseButton;
 
-    const hideMoreToolsBtn =
-        `.toolbar-button[aria-label='More Tools'] {
-            display: none !important;
-        }`.replace(/\n/g, separator);
+    const pattern = /(:host-context\(\.platform-mac\)\s*\.monospace,)/g;
+    if (content.match(pattern)) {
+        return content.replace(pattern, `${topHeaderCSS}${separator} $1`);
+    } else {
+        return null;
+    }
+}
 
-    const drawerCSS = hideMoreToolsBtn;
+export function applyInspectorCommonNetworkPatch(content: string, isRelease?: boolean) {
+    const separator = (isRelease ? "\\n" : "\n");
 
     const hideExportHarBtn =
         `.toolbar-button[aria-label='Export HAR...'] {
@@ -181,7 +185,22 @@ export function applyInspectorCommonCssPatch(content: string, isRelease?: boolea
             display: none !important;
         }`.replace(/\n/g, separator);
 
-    const hideSomeContextMenuItems =
+    const networkCSS =
+        hideExportHarBtn +
+        hidePrettyPrintBtn;
+
+    const pattern = /(:host-context\(\.platform-mac\)\s*\.monospace,)/g;
+    if (content.match(pattern)) {
+        return content.replace(pattern, `${networkCSS}${separator} $1`);
+    } else {
+        return null;
+    }
+}
+
+export function applyInspectorCommonContextMenuPatch(content: string, isRelease?: boolean) {
+    const separator = (isRelease ? "\\n" : "\n");
+
+    const hideContextMenuItems =
         `.soft-context-menu-separator,
         .soft-context-menu-item[aria-label='Open in new tab'],
         .soft-context-menu-item[aria-label='Open in Sources panel'],
@@ -192,19 +211,9 @@ export function applyInspectorCommonCssPatch(content: string, isRelease?: boolea
             display: none !important;
         }`.replace(/\n/g, separator);
 
-    const networkCSS =
-        hideExportHarBtn +
-        hidePrettyPrintBtn +
-        hideSomeContextMenuItems;
-
-    const addCSS =
-        topHeaderCSS +
-        drawerCSS +
-        networkCSS;
-
     const pattern = /(:host-context\(\.platform-mac\)\s*\.monospace,)/g;
     if (content.match(pattern)) {
-        return content.replace(pattern, `${addCSS}${separator} $1`);
+        return content.replace(pattern, `${hideContextMenuItems}${separator} $1`);
     } else {
         return null;
     }

--- a/src/host/polyfills/simpleView.ts
+++ b/src/host/polyfills/simpleView.ts
@@ -76,6 +76,17 @@ export function applySelectTabPatch(content: string) {
         "elements.domProperties",
         "elements.domBreakpoints",
         "elements.eventListeners",
+    	  "network",
+        "network.blocked-urls",
+        "network.search-network-tab",
+        "headers",
+        "preview",
+        "response",
+        "timing",
+        "initiator",
+        "cookies",
+        "eventSource",
+        "webSocketFrames",
         "preferences",
         "workspace",
         "experiments",
@@ -86,8 +97,8 @@ export function applySelectTabPatch(content: string) {
         "Shortcuts",
     ];
 
-    const condition = allowedTabs.map((v) => {
-        return `id !== '${v}'`;
+    const condition = allowedTabs.map((tab) => {
+        return `id !== '${tab}'`;
     }).join(" && ");
 
     const pattern = /selectTab\(id,\s*userGesture,\s*forceFocus\)\s*{/g;
@@ -96,6 +107,141 @@ export function applySelectTabPatch(content: string) {
         return content.replace(
             pattern,
             `selectTab(id, userGesture, forceFocus) { if (${condition}) return false;`);
+    } else {
+        return null;
+    }
+}
+
+export function applyShowTabElement(content: string) {
+    const networkTabs = [
+        "elements",
+        "Styles",
+        "Computed",
+        "accessibility.view",
+        "elements.domProperties",
+        "elements.domBreakpoints",
+        "elements.eventListeners",
+        "network",
+        "network.blocked-urls",
+        "network.search-network-tab",
+        "headers",
+        "preview",
+        "response",
+        "timing",
+        "initiator",
+        "cookies",
+        "eventSource",
+        "webSocketFrames",
+        "preferences",
+        "workspace",
+        "experiments",
+        "blackbox",
+        "devices",
+        "throttling-conditions",
+        "emulation-geolocations",
+        "Shortcuts",
+    ];
+
+    const condition = networkTabs.map((tab) => {
+        return `tab._id !== '${tab}'`;
+    }).join(" && ");
+
+    const pattern = /_showTabElement\(index,\s*tab\)\s*{/g;
+    if (content.match(pattern)) {
+        return content.replace(pattern, `_showTabElement\(index, tab\) { if (${condition}) return false;`);
+    } else {
+        return null;
+    }
+}
+
+export function applyDrawerTabLocationPatch(content: string) {
+    const pattern = /this._showDrawer.bind\s*\(this,\s*false\),\s*'drawer-view',\s*true,\s*true/g;
+    if (content.match(pattern)) {
+        return content.replace(pattern, `this._showDrawer.bind\(this, false\), 'drawer-view', true, true, 'network.blocked-urls'`);
+    } else {
+        return null;
+    }
+}
+
+export function applyMainTabTabLocationPatch(content: string) {
+    const pattern = /InspectorFrontendHostInstance\),\s*'panel',\s*true,\s*true,\s*Root.Runtime.queryParam\('panel'\)/g;
+    if (content.match(pattern)) {
+        return content.replace(pattern, `InspectorFrontendHostInstance\), 'panel', true, true, 'network'`);
+    } else {
+        return null;
+    }
+}
+
+export function applyInspectorCommonCssPatch(content: string, isRelease?: boolean) {
+    const separator = (isRelease ? "\\n" : "\n");
+
+    const hideToolsDropdown =
+    `.tabbed-pane-header-tabs-drop-down-container {
+        display: none !important;
+    }`.replace(/\n/g, separator);
+
+    const hideInspectBtn =
+        `.toolbar-button[aria-label='Select an element in the page to inspect it'] {
+            display: none !important;
+        }`.replace(/\n/g, separator);
+
+    const unHideScreenCastBtn =
+        `.toolbar-button[aria-label='Toggle screencast'] {
+            visibility: visible !important;
+        }`.replace(/\n/g, separator);
+
+    const unHideSearchCloseButton =
+        `.toolbar-button[aria-label='Close'] {
+            visibility: visible !important;
+        }`.replace(/\n/g, separator);
+
+    const topHeaderCSS =
+        hideInspectBtn +
+        hideToolsDropdown +
+        unHideScreenCastBtn +
+        unHideSearchCloseButton;
+
+    const hideMoreToolsBtn =
+        `.toolbar-button[aria-label='More Tools'] {
+            display: none !important;
+        }`.replace(/\n/g, separator);
+
+    const drawerCSS = hideMoreToolsBtn;
+
+    const hideExportHarBtn =
+        `.toolbar-button[aria-label='Export HAR...'] {
+            display: none !important;
+        }`.replace(/\n/g, separator);
+
+    const hidePrettyPrintBtn =
+        `.toolbar-button[aria-label='Pretty print'] {
+            display: none !important;
+        }`.replace(/\n/g, separator);
+
+    const hideSomeContextMenuItems =
+        `.soft-context-menu-separator,
+        .soft-context-menu-item[aria-label='Open in new tab'],
+        .soft-context-menu-item[aria-label='Open in Sources panel'],
+        .soft-context-menu-item[aria-label='Clear browser cache'],
+        .soft-context-menu-item[aria-label='Clear browser cookies'],
+        .soft-context-menu-item[aria-label='Save all as HAR with content'],
+        .soft-context-menu-item[aria-label='Save as...'] {
+            display: none !important;
+        }`.replace(/\n/g, separator);
+
+    const networkCSS =
+        hideExportHarBtn +
+        hidePrettyPrintBtn +
+        hideSomeContextMenuItems;
+
+    const addCSS =
+        topHeaderCSS +
+        drawerCSS +
+        networkCSS;
+
+    const pattern = /(:host-context\(\.platform-mac\)\s*\.monospace,)/g
+    if (content.match(pattern)) {
+        return content.replace(pattern, `${addCSS}${separator} $1`);
     } else {
         return null;
     }

--- a/src/host/polyfills/simpleView.ts
+++ b/src/host/polyfills/simpleView.ts
@@ -67,6 +67,16 @@ export function applyMainViewPatch(content: string) {
     }
 }
 
+export function applyShowElementsTab(content: string) {
+  const pattern = /this\._defaultTab\s*=\s*defaultTab;/;
+
+  if (content.match(pattern)) {
+    return content.replace(pattern, "this._defaultTab = 'elements';")
+  } else {
+    return null;
+  }
+}
+
 export function applySelectTabPatch(content: string) {
     const allowedTabs = [
         "elements",

--- a/src/host/polyfills/simpleView.ts
+++ b/src/host/polyfills/simpleView.ts
@@ -108,6 +108,18 @@ export function applyPersistRequestBlockingTab(content: string) {
     }
 }
 
+export function applySetTabIconPatch(content: string) {
+    // Patching setTabIcon so it does not throw an unhandled promise rejection when hard coded tab names are not in the tablist.
+    // This is needed due to applyAppendTabPatch which removes unused tabs from the tablist.
+    const pattern = /setTabIcon\(id,\s*icon\)\s*{\s*const tab\s*=\s*this\._tabsById\.get\(id\);/;
+
+    if (content.match(pattern)) {
+        return content.replace(pattern, "setTabIcon(id,icon){const tab=this._tabsById.get(id); if(!tab){return;}");
+    } else {
+        return null;
+    }
+}
+
 export function applyAppendTabPatch(content: string) {
     // The appendTab function chooses which tabs to put in the tabbed pane header section
     // showTabElement and selectTab are only called by tabs that have already been appended via appendTab.

--- a/src/host/polyfills/simpleView.ts
+++ b/src/host/polyfills/simpleView.ts
@@ -210,24 +210,6 @@ export function applyInspectorCommonCssPatch(content: string, isRelease?: boolea
     }
 }
 
-export function applyInspectorCommonCssHeaderContentsPatch(content: string, isRelease?: boolean) {
-    const separator = (isRelease ? "\\n" : "\n");
-    const cssHeaderContents =
-        `.main-tabbed-pane .tabbed-pane-header-contents {
-            display: none !important;
-        }`.replace(/\n/g, separator);
-
-    const mainPattern = /(\.main-tabbed-pane\s*\.tabbed-pane-header-contents\s*\{([^\}]*)?\})/g;
-
-    if (content.match(mainPattern)) {
-        return content.replace(
-            mainPattern,
-            cssHeaderContents);
-    } else {
-        return null;
-    }
-}
-
 export function applyInspectorCommonCssRightToolbarPatch(content: string, isRelease?: boolean) {
     const separator = (isRelease ? "\\n" : "\n");
     const cssRightToolbar =

--- a/src/host/polyfills/simpleView.ts
+++ b/src/host/polyfills/simpleView.ts
@@ -71,7 +71,7 @@ export function applyShowElementsTab(content: string) {
   const pattern = /this\._defaultTab\s*=\s*defaultTab;/;
 
   if (content.match(pattern)) {
-    return content.replace(pattern, "this._defaultTab = 'elements';")
+    return content.replace(pattern, "this._defaultTab = 'elements';");
   } else {
     return null;
   }
@@ -86,7 +86,7 @@ export function applyAppendTabPatch(content: string) {
         "elements.domProperties",
         "elements.domBreakpoints",
         "elements.eventListeners",
-    	  "network",
+        "network",
         "network.blocked-urls",
         "network.search-network-tab",
         "headers",
@@ -125,7 +125,8 @@ export function applyAppendTabPatch(content: string) {
 export function applyDrawerTabLocationPatch(content: string) {
     const pattern = /this._showDrawer.bind\s*\(this,\s*false\),\s*'drawer-view',\s*true,\s*true/g;
     if (content.match(pattern)) {
-        return content.replace(pattern, `this._showDrawer.bind\(this, false\), 'drawer-view', true, true, 'network.blocked-urls'`);
+        return content.replace(pattern,
+            `this._showDrawer.bind\(this, false\), 'drawer-view', true, true, 'network.blocked-urls'`);
     } else {
         return null;
     }
@@ -201,7 +202,7 @@ export function applyInspectorCommonCssPatch(content: string, isRelease?: boolea
         drawerCSS +
         networkCSS;
 
-    const pattern = /(:host-context\(\.platform-mac\)\s*\.monospace,)/g
+    const pattern = /(:host-context\(\.platform-mac\)\s*\.monospace,)/g;
     if (content.match(pattern)) {
         return content.replace(pattern, `${addCSS}${separator} $1`);
     } else {

--- a/src/host/polyfills/simpleView.ts
+++ b/src/host/polyfills/simpleView.ts
@@ -109,7 +109,7 @@ export function applyPersistRequestBlockingTab(content: string) {
 }
 
 export function applySetTabIconPatch(content: string) {
-    // Patching setTabIcon so it does not throw an unhandled promise rejection when hard coded tab names are not in the tablist.
+    // Adding undefined check in SetTabIcon so it doesn't throw an error trying to access disabled tabs.
     // This is needed due to applyAppendTabPatch which removes unused tabs from the tablist.
     const pattern = /setTabIcon\(id,\s*icon\)\s*{\s*const tab\s*=\s*this\._tabsById\.get\(id\);/;
 

--- a/src/host/polyfills/simpleView.ts
+++ b/src/host/polyfills/simpleView.ts
@@ -77,7 +77,7 @@ export function applyShowElementsTab(content: string) {
   }
 }
 
-export function applySelectTabPatch(content: string) {
+export function applyAppendTabPatch(content: string) {
     const allowedTabs = [
         "elements",
         "Styles",
@@ -111,54 +111,12 @@ export function applySelectTabPatch(content: string) {
         return `id !== '${tab}'`;
     }).join(" && ");
 
-    const pattern = /selectTab\(id,\s*userGesture,\s*forceFocus\)\s*{/g;
+    const pattern = /appendTab\(id,\s*tabTitle\s*,\s*view,\s*tabTooltip,\s*userGesture,\s*isCloseable,\s*index\)\s*{/;
 
     if (content.match(pattern)) {
         return content.replace(
             pattern,
-            `selectTab(id, userGesture, forceFocus) { if (${condition}) return false;`);
-    } else {
-        return null;
-    }
-}
-
-export function applyShowTabElement(content: string) {
-    const networkTabs = [
-        "elements",
-        "Styles",
-        "Computed",
-        "accessibility.view",
-        "elements.domProperties",
-        "elements.domBreakpoints",
-        "elements.eventListeners",
-        "network",
-        "network.blocked-urls",
-        "network.search-network-tab",
-        "headers",
-        "preview",
-        "response",
-        "timing",
-        "initiator",
-        "cookies",
-        "eventSource",
-        "webSocketFrames",
-        "preferences",
-        "workspace",
-        "experiments",
-        "blackbox",
-        "devices",
-        "throttling-conditions",
-        "emulation-geolocations",
-        "Shortcuts",
-    ];
-
-    const condition = networkTabs.map((tab) => {
-        return `tab._id !== '${tab}'`;
-    }).join(" && ");
-
-    const pattern = /_showTabElement\(index,\s*tab\)\s*{/g;
-    if (content.match(pattern)) {
-        return content.replace(pattern, `_showTabElement\(index, tab\) { if (${condition}) return false;`);
+            `appendTab(id, tabTitle, view, tabTooltip, userGesture, isCloseable, index) { if (${condition}) return;`);
     } else {
         return null;
     }
@@ -185,11 +143,6 @@ export function applyMainTabTabLocationPatch(content: string) {
 export function applyInspectorCommonCssPatch(content: string, isRelease?: boolean) {
     const separator = (isRelease ? "\\n" : "\n");
 
-    const hideToolsDropdown =
-    `.tabbed-pane-header-tabs-drop-down-container {
-        display: none !important;
-    }`.replace(/\n/g, separator);
-
     const hideInspectBtn =
         `.toolbar-button[aria-label='Select an element in the page to inspect it'] {
             display: none !important;
@@ -207,7 +160,6 @@ export function applyInspectorCommonCssPatch(content: string, isRelease?: boolea
 
     const topHeaderCSS =
         hideInspectBtn +
-        hideToolsDropdown +
         unHideScreenCastBtn +
         unHideSearchCloseButton;
 
@@ -279,7 +231,7 @@ export function applyInspectorCommonCssRightToolbarPatch(content: string, isRele
     const separator = (isRelease ? "\\n" : "\n");
     const cssRightToolbar =
         `.tabbed-pane-right-toolbar {
-            display: none !important;
+            visibility: hidden !important;
         }`.replace(/\n/g, separator);
 
     const tabbedPanePattern = /(\.tabbed-pane-right-toolbar\s*\{([^\}]*)?\})/g;


### PR DESCRIPTION
This PR adds the network tool to the devtools extension!  The majority of this change was moving over the various patches and tests unique to the Network tool.

Here are some other notable changes from in this PR:
- Created "applyAppendTabPatch" as the one tabbing patch.  This targets the 'appendTab' function which later funnels into the showTab/selectTab functions that were previously being patched.
- Simplified tests by making variable names consistent and separating tests that were grouped together (some tests has result1, result2, result3...)
- Changed `.tabbed-pane-right-toolbar` patch to be `visibility: hidden` over `display: none` since it was hiding the network search close button and could not reveal when its parent had `display: none`
- Removed `applyInspectorCommonCssHeaderContentsPatch` since it was hiding the header toolbar.  Depending on how we want to expose the Network pane, we can re-add this code


![image](https://user-images.githubusercontent.com/14304598/79489233-d6632100-7fcf-11ea-8a1b-815f7dcbe127.png)
![image](https://user-images.githubusercontent.com/14304598/79489253-db27d500-7fcf-11ea-90cf-9a3c57f55138.png)
The original network extension can be found here: https://github.com/microsoft/vscode-edge-devtools-network