### PR TITLE
Add attach action to context menu

### DIFF
--- a/package.json
+++ b/package.json
@@ -372,6 +372,10 @@
                     "group": "inline"
                 },
                 {
+                    "command": "vscode-edge-devtools-view.attach",
+                    "when": "view == vscode-edge-devtools-view.targets && viewItem == cdpTarget"
+                },
+                {
                     "command": "vscode-edge-devtools-view.copyItem",
                     "when": "view == vscode-edge-devtools-view.targets && viewItem == cdpTargetProperty",
                     "group": "2_contextMenu"


### PR DESCRIPTION
This PR fixes an issue where the "Attach and open Elements" button in the target list is inaccessible to screen reader users. It visually appears as part of the target treeitem when hovered or focused, but is not read out by screen readers and there's no indication that a button has appeared to tab to. The button is defined in package.json and created by the target list TreeView, so it isn't feasible to reparent it or add aria to help expose it to screen readers.
![image](https://user-images.githubusercontent.com/7309729/79781247-0ec96e80-82f2-11ea-841f-a24907b7e254.png)

Since TreeView is a common extension point, there's another Microsoft extension that has had to address this issue--the WSL extension, which solved the problem by putting the action in the context menu as well: 
![image](https://user-images.githubusercontent.com/7309729/79781636-9f07b380-82f2-11ea-9478-de4fa683e4b1.png)
This way, users can access the button functionality by opening the context menu, rather than by tabbing to a button that their screen reader has not announced to them. This PR mimics the WSL extension's solution by putting the attach action in the context menu:
![image](https://user-images.githubusercontent.com/7309729/79781883-0e7da300-82f3-11ea-864e-f92d304cc2d9.png)
