### PR TITLE
Fixing 'Couldn't attach to ...' bug

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -122,9 +122,7 @@ export async function attach(
                 if (matchedTargets && matchedTargets.length > 0 && matchedTargets[0].webSocketDebuggerUrl) {
                     const actualTarget = fixRemoteWebSocket(hostname, port, matchedTargets[0] as any);
                     targetWebsocketUrl = actualTarget.webSocketDebuggerUrl;
-                }
-
-                if (!useRetry) {
+                } else if (!useRetry) {
                     vscode.window.showErrorMessage(`Couldn't attach to ${attachUrl}.`);
                 }
             }


### PR DESCRIPTION
Fixing bug where this warning consistently pops up:
![image](https://user-images.githubusercontent.com/14304598/80030386-fa75a500-849c-11ea-96c8-83c1b8253080.png)

This was implemented in [this PR supporting Debugger for Microsoft Edge compatibility](https://github.com/microsoft/vscode-edge-devtools/commit/eec060f343ecabfd55bab9a11267292fb2fd479d).

Before, the code was 
```
if (matches && matches.length > 0 && matches[0].detail) {
    targetWebsocketUrl = matches[0].detail;
} else {
    vscode.window.showErrorMessage('Couldn't attach to ${attachUrl}.');
}
```

It got changed to

```
if (matchedTargets && matchedTargets.length > 0 && matchedTargets[0].webSocketDebuggerUrl) {
    const actualTarget = fixRemoteWebSocket(hostname, port, matchedTargets[0] as any);
    targetWebsocketUrl = actualTarget.webSocketDebuggerUrl;
}
if (!useRetry) {
    vscode.window.showErrorMessage(`Couldn't attach to ${attachUrl}.`);
}
```

This PR adds the else logic back in