### PR TITLE
Disabling Quick Open Action (CTRL+P)

### DIFF
--- a/postBuildStep.ts
+++ b/postBuildStep.ts
@@ -9,6 +9,7 @@ import { applyContentSecurityPolicyPatch } from "./src/host/polyfills/inspectorC
 import {
     applyAppendTabPatch,
     applyCommonRevealerPatch,
+    applyHandleActionPatch,
     applyDrawerTabLocationPatch,
     applyInspectorCommonContextMenuPatch,
     applyInspectorCommonCssPatch,
@@ -104,7 +105,9 @@ async function patchFilesForWebView(toolsOutDir: string, debugMode: boolean) {
             applyPaddingInlineCssPatch,
         ]);
         await patchFileForWebView("inspector.html", toolsOutDir, true, [applyContentSecurityPolicyPatch]);
-        await patchFileForWebView("ui/InspectorView.js", toolsOutDir, true, [applyDrawerTabLocationPatch]);
+        await patchFileForWebView("ui/InspectorView.js", toolsOutDir, true, [
+            applyHandleActionPatch,
+            applyDrawerTabLocationPatch]);
         await patchFileForWebView("ui/TabbedPane.js", toolsOutDir, true, [
             applyAppendTabPatch,
             applyPersistRequestBlockingTab,
@@ -114,6 +117,8 @@ async function patchFilesForWebView(toolsOutDir: string, debugMode: boolean) {
             applyShowElementsTab,
             applyShowRequestBlockingTab,
         ]);
+        await patchFileForWebView("quick_open/QuickOpen.js", toolsOutDir, true, [applyHandleActionPatch]);
+        await patchFileForWebView("quick_open/CommandMenu.js", toolsOutDir, true, [applyHandleActionPatch]);
     } else {
         // tslint:disable-next-line:no-console
         console.log("Patching files for debug version");
@@ -124,7 +129,9 @@ async function patchFilesForWebView(toolsOutDir: string, debugMode: boolean) {
             applyPaddingInlineCssPatch,
         ]);
         await patchFileForWebView("inspector.html", toolsOutDir, false, [applyContentSecurityPolicyPatch]);
-        await patchFileForWebView("ui/InspectorView.js", toolsOutDir, false, [applyDrawerTabLocationPatch]);
+        await patchFileForWebView("ui/InspectorView.js", toolsOutDir, false, [
+            applyHandleActionPatch,
+            applyDrawerTabLocationPatch]);
         await patchFileForWebView("ui/TabbedPane.js", toolsOutDir, false, [
             applyAppendTabPatch,
             applyPersistRequestBlockingTab,
@@ -134,6 +141,8 @@ async function patchFilesForWebView(toolsOutDir: string, debugMode: boolean) {
             applyShowElementsTab,
             applyShowRequestBlockingTab,
         ]);
+        await patchFileForWebView("quick_open/QuickOpen.js", toolsOutDir, true, [applyHandleActionPatch]);
+        await patchFileForWebView("quick_open/CommandMenu.js", toolsOutDir, true, [applyHandleActionPatch]);
         // Debug file versions
         await patchFileForWebView("ui/UIUtils.js", toolsOutDir, false, [applyUIUtilsPatch]);
         await patchFileForWebView("dom_extension/DOMExtension.js", toolsOutDir, false, [applyCreateElementPatch]);

--- a/postBuildStep.ts
+++ b/postBuildStep.ts
@@ -9,8 +9,8 @@ import { applyContentSecurityPolicyPatch } from "./src/host/polyfills/inspectorC
 import {
     applyAppendTabPatch,
     applyCommonRevealerPatch,
-    applyHandleActionPatch,
     applyDrawerTabLocationPatch,
+    applyHandleActionPatch,
     applyInspectorCommonContextMenuPatch,
     applyInspectorCommonCssPatch,
     applyInspectorCommonCssRightToolbarPatch,

--- a/postBuildStep.ts
+++ b/postBuildStep.ts
@@ -105,9 +105,7 @@ async function patchFilesForWebView(toolsOutDir: string, debugMode: boolean) {
             applyPaddingInlineCssPatch,
         ]);
         await patchFileForWebView("inspector.html", toolsOutDir, true, [applyContentSecurityPolicyPatch]);
-        await patchFileForWebView("ui/InspectorView.js", toolsOutDir, true, [
-            applyHandleActionPatch,
-            applyDrawerTabLocationPatch]);
+        await patchFileForWebView("ui/InspectorView.js", toolsOutDir, true, [applyDrawerTabLocationPatch]);
         await patchFileForWebView("ui/TabbedPane.js", toolsOutDir, true, [
             applyAppendTabPatch,
             applyPersistRequestBlockingTab,
@@ -129,9 +127,7 @@ async function patchFilesForWebView(toolsOutDir: string, debugMode: boolean) {
             applyPaddingInlineCssPatch,
         ]);
         await patchFileForWebView("inspector.html", toolsOutDir, false, [applyContentSecurityPolicyPatch]);
-        await patchFileForWebView("ui/InspectorView.js", toolsOutDir, false, [
-            applyHandleActionPatch,
-            applyDrawerTabLocationPatch]);
+        await patchFileForWebView("ui/InspectorView.js", toolsOutDir, false, [applyDrawerTabLocationPatch]);
         await patchFileForWebView("ui/TabbedPane.js", toolsOutDir, false, [
             applyAppendTabPatch,
             applyPersistRequestBlockingTab,

--- a/src/host/polyfills/simpleView.test.ts
+++ b/src/host/polyfills/simpleView.test.ts
@@ -39,17 +39,9 @@ describe("simpleView", () => {
 
     it("applyHandleActionPatch correctly changes handleAction text", async () => {
         const comparableText = "handleAction(context, actionId) {\n";
-        let fileContents = getTextFromFile("ui/InspectorView.js");
-        // The file was not found, so test that at least the text is being replaced.
-        fileContents = fileContents ? fileContents : comparableText;
-
         const apply = await import("./simpleView");
-        const result = apply.applyHandleActionPatch(fileContents);
-        expect(result).not.toEqual(null);
-        expect(result).toEqual(
-            expect.stringContaining("handleAction(context, actionId) { return false;"));
 
-        fileContents = getTextFromFile("quick_open/QuickOpen.js");
+        let fileContents = getTextFromFile("quick_open/QuickOpen.js");
         // The file was not found, so test that at least the text is being replaced.
         fileContents = fileContents ? fileContents : comparableText;
 

--- a/src/host/polyfills/simpleView.test.ts
+++ b/src/host/polyfills/simpleView.test.ts
@@ -37,16 +37,34 @@ describe("simpleView", () => {
             expect.stringContaining("let reveal = function revealInVSCode(revealable, omitFocus) {"));
     });
 
-    it("applyInspectorViewPatch correctly changes handleAction text", async () => {
+    it("applyHandleActionPatch correctly changes handleAction text", async () => {
         const comparableText = "handleAction(context, actionId) {\n";
         let fileContents = getTextFromFile("ui/InspectorView.js");
         // The file was not found, so test that at least the text is being replaced.
         fileContents = fileContents ? fileContents : comparableText;
 
         const apply = await import("./simpleView");
-        const result = apply.applyInspectorViewHandleActionPatch(fileContents);
+        const result = apply.applyHandleActionPatch(fileContents);
         expect(result).not.toEqual(null);
         expect(result).toEqual(
+            expect.stringContaining("handleAction(context, actionId) { return false;"));
+
+        fileContents = getTextFromFile("quick_open/QuickOpen.js");
+        // The file was not found, so test that at least the text is being replaced.
+        fileContents = fileContents ? fileContents : comparableText;
+
+        const quickOpenResult = apply.applyHandleActionPatch(fileContents);
+        expect(quickOpenResult).not.toEqual(null);
+        expect(quickOpenResult).toEqual(
+            expect.stringContaining("handleAction(context, actionId) { return false;"));
+
+        fileContents = getTextFromFile("quick_open/CommandMenu.js");
+        // The file was not found, so test that at least the text is being replaced.
+        fileContents = fileContents ? fileContents : comparableText;
+
+        const commandMenuResult = apply.applyHandleActionPatch(fileContents);
+        expect(commandMenuResult).not.toEqual(null);
+        expect(commandMenuResult).toEqual(
             expect.stringContaining("handleAction(context, actionId) { return false;"));
     });
 

--- a/src/host/polyfills/simpleView.ts
+++ b/src/host/polyfills/simpleView.ts
@@ -37,7 +37,7 @@ export function applyCommonRevealerPatch(content: string) {
 }
 
 export function applyHandleActionPatch(content: string) {
-    // This patch removes the ability to use the 
+    // This patch removes the ability to use the
     // quick open menu (CTRL + P) and command menu (CTRL + SHIFT + P)
     const pattern = /handleAction\(context,\s*actionId\)\s*{/g;
 

--- a/src/host/polyfills/simpleView.ts
+++ b/src/host/polyfills/simpleView.ts
@@ -38,7 +38,7 @@ export function applyCommonRevealerPatch(content: string) {
 
 // This function is needed for Elements-only version, but we need the drawer
 // for the Request Blocking tool when enabling the Network Panel.
-export function applyInspectorViewHandleActionPatch(content: string) {
+export function applyHandleActionPatch(content: string) {
     // This patch removes the ability to open/close the drawer using 'ESC'
     // and using CTRL + [ or CTRL + ] to navigate between tabs.
     const pattern = /handleAction\(context,\s*actionId\)\s*{/g;

--- a/src/host/polyfills/simpleView.ts
+++ b/src/host/polyfills/simpleView.ts
@@ -36,11 +36,9 @@ export function applyCommonRevealerPatch(content: string) {
     }
 }
 
-// This function is needed for Elements-only version, but we need the drawer
-// for the Request Blocking tool when enabling the Network Panel.
 export function applyHandleActionPatch(content: string) {
-    // This patch removes the ability to open/close the drawer using 'ESC'
-    // and using CTRL + [ or CTRL + ] to navigate between tabs.
+    // This patch removes the ability to use the 
+    // quick open menu (CTRL + P) and command menu (CTRL + SHIFT + P)
     const pattern = /handleAction\(context,\s*actionId\)\s*{/g;
 
     if (content.match(pattern)) {


### PR DESCRIPTION
The Quick Open menu is available via (CTRL + P), but the functionality is disabled in the extension.  This PR disables the quick open command so the menu will not pop up.
![image](https://user-images.githubusercontent.com/14304598/80160153-bc05e600-8581-11ea-892f-28596109439c.png)
