### PR TITLE
Renaming Extension to "Microsoft Edge (Chromium) Tools for VSCode" + Changelog Update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 1.0.8
+* Downgraded Edge DevTools version to 81.0.416 (Microsoft Edge Stable)
+* Merged Network Tool into the extension - [PR #128](https://github.com/microsoft/vscode-edge-devtools/pull/128)
+* Renaming tool to "Microsoft Edge (Chromium) Tools for VSCode"
+
 ## 1.0.7
 * Updated to version 82.0.423
 * Fixing issue with Styles panel links

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 
 <h1 align="center">
   <br>
-  VS Code - DevTools for Microsoft Edge (Chromium)
+  VS Code - Microsoft Edge (Chromium) Tools
   <br>
 </h1>
 
@@ -11,7 +11,7 @@ A VS Code extension that allows you to use the browser's Elements and Network to
 
 **Note**: This extension only supports Microsoft Edge (Chromium)
 
-![DevTools for Microsoft Edge - Demo](demo.gif)
+![Microsoft Edge (Chromium) Tools - Demo](demo.gif)
 
 **Supported Features**
 * Debug configurations for launching Microsoft Edge browser in remote-debugging mode and auto attaching the tools,
@@ -19,14 +19,14 @@ A VS Code extension that allows you to use the browser's Elements and Network to
 * Fully featured Elements and Network tool with views for HTML, CSS, accessibility and more.
 * Screen-casting feature to allow you to see your page without leaving VSCode.
 * Go directly to the line/column for source files in your workspace when clicking on a link or CSS rule inside the Elements tool.
-* Auto attach the DevTools when you start debugging with the [Debugger for Microsoft Edge](https://marketplace.visualstudio.com/items?itemName=msjsdiag.debugger-for-edge) extension.
+* Auto attach the Microsoft Edge Tools when you start debugging with the [Debugger for Microsoft Edge](https://marketplace.visualstudio.com/items?itemName=msjsdiag.debugger-for-edge) extension.
 
 # Using the Extension
 ## Getting Started
 For use inside VS Code:
 
 1. Install any channel (Canary/Dev/etc.) of [Microsoft Edge (Chromium)](https://aka.ms/edgeinsider).
-1. Install the extension [DevTools for Microsoft Edge](https://marketplace.visualstudio.com/items?itemName=ms-edgedevtools.vscode-edge-devtools).
+1. Install the extension [Microsoft Edge Tools](https://marketplace.visualstudio.com/items?itemName=ms-edgedevtools.vscode-edge-devtools).
 1. Open the folder containing the project you want to work on.
 1. (Optional) Install the [Debugger for Microsoft Edge](https://marketplace.visualstudio.com/items?itemName=msjsdiag.debugger-for-edge) extension.
 
@@ -36,7 +36,7 @@ The extension operates in two modes - it can launch an instance of Microsoft Edg
 ### Opening source files from the Elements tool
 One of the features of the Elements extension is that it can show you what file applied the styles and event handlers for a given node.
 
-![DevTools for Microsoft Edge - Links](links.png)
+![Microsoft Edge Tools - Links](links.png)
 
 The source files for these applied styles and attached event handlers appear in the form of links to a url specified by the browser. Clicking on one will attempt to open that file inside the VS Code editor window. Correctly mapping these runtime locations to actual files on disk that are part of your current workspace, may require you to enable source maps as part of your build environment.
 
@@ -67,7 +67,7 @@ With source maps enabled, you may also need to configure the extension settings/
 
 
 ### Debug Configuration
-You can launch the DevTools for Microsoft Edge extension like you would a debugger, by using a `launch.json` config file. However, DevTools for Microsoft Edge isn't a debugger and so any breakpoints set in VS Code won't be hit, you can of course use a different debug extension instead and attach the DevTools for Microsoft Edge extension once debugging has started.
+You can launch the Microsoft Edge Tools extension like you would a debugger, by using a `launch.json` config file. However, Microsoft Edge Tools isn't a debugger and so any breakpoints set in VS Code won't be hit, you can of course use a different debug extension instead and attach the Microsoft Edge Tools extension once debugging has started.
 
 To add a new debug configuration, in your `launch.json` add a new debug config with the following parameters:
 
@@ -85,13 +85,13 @@ To add a new debug configuration, in your `launch.json` add a new debug config w
         {
             "type": "vscode-edge-devtools.debug",
             "request": "launch",
-            "name": "Launch Microsoft Edge and open the DevTools",
+            "name": "Launch Microsoft Edge and open the Edge DevTools",
             "file": "${workspaceFolder}/index.html"
         },
         {
             "type": "vscode-edge-devtools.debug",
             "request": "attach",
-            "name": "Attach to Microsoft Edge and open the DevTools",
+            "name": "Attach to Microsoft Edge and open the Edge DevTools",
             "url": "http://localhost:8000/",
             "webRoot": "${workspaceFolder}/out"
         }
@@ -109,7 +109,7 @@ To add a new debug configuration, in your `launch.json` add a new debug config w
 * `pathMapping`: This property takes a mapping of URL paths to local paths, to give you more flexibility in how URLs are resolved to local files. `"webRoot": "${workspaceFolder}"` is just shorthand for a pathMapping like `{ "/": "${workspaceFolder}" }`.
 * `sourceMapPathOverrides`: A mapping of source paths from the sourcemap, to the locations of these sources on disk. See [Sourcemaps](#sourcemaps) for more information
 * `urlFilter`: A string that can contain wildcards that will be used for finding a browser target, for example, "localhost:*/app" will match either "http://localhost:123/app" or "http://localhost:456/app", but not "https://stackoverflow.com". This property will only be used if `url` and `file` are not specified.
-* `timeout`: The number of milliseconds that the DevTools will keep trying to attach to the browser before timing out. Defaults to 10000ms.
+* `timeout`: The number of milliseconds that the Microsoft Edge Tools will keep trying to attach to the browser before timing out. Defaults to 10000ms.
 
 #### Sourcemaps
 The elements tool uses sourcemaps to correctly open original source files when you click links in the UI, but sometimes the sourcemaps aren't generated properly and overrides are needed. In the config we support `sourceMapPathOverrides`, a mapping of source paths from the sourcemap, to the locations of these sources on disk. Useful when the sourcemap isn't accurate or can't be fixed in the build process.
@@ -160,17 +160,17 @@ Ionic and gulp-sourcemaps output a sourceRoot of `"/source/"` by default. If you
 
 ### Launching the browser via the side bar view
 * Start Microsoft Edge via the side bar
-  * Click the `DevTools for Microsoft Edge` view in the side bar.
+  * Click the `Microsoft Edge Tools` view in the side bar.
   * Click the `Open a new tab` icon to launch the browser (if it isn't open yet) and open a new tab.
-* Attach the DevTools via the side bar view
-  * Click the `Attach` icon next to the tab to open the DevTools.
+* Attach the Microsoft Edge Tools via the side bar view
+  * Click the `Attach` icon next to the tab to open the Microsoft Edge Tools.
 
 ### Launching the browser manually
 * Start Microsoft Edge with remote-debugging enabled on port 9222:
   * `msedge.exe --remote-debugging-port=9222`
   * Navigate the browser to the desired URL.
-* Attach the DevTools via a command:
-  * Run the command `DevTools for Microsoft Edge: Attach to a target`
+* Attach the Microsoft Edge Tools via a command:
+  * Run the command `Microsoft Edge (Chromium) Tools: Attach to a target`
   * Select a target from the drop down.
 
 ### Attaching automatically when launching the browser for debugging
@@ -178,7 +178,7 @@ Ionic and gulp-sourcemaps output a sourceRoot of `"/source/"` by default. If you
 * Setup your `launch.json` configuration to launch and debug Microsoft Edge (Chromium).
   * See [Debugger for Microsoft Edge Readme.md](https://github.com/microsoft/vscode-edge-debug2/blob/master/README.md).
 * Start Microsoft Edge for debugging.
-  * Once debugging has started, the DevTools will auto attach to the browser (it will keep retrying until the Debugger for Microsoft Edge launch.json config `timeout` value is reached).
+  * Once debugging has started, the Microsoft Edge Tools will auto attach to the browser (it will keep retrying until the Debugger for Microsoft Edge launch.json config `timeout` value is reached).
   * This auto attach functionality can be disabled via the `vscode-edge-devtools.autoAttachViaDebuggerForEdge` VS Code setting.
 
 # Contributing

--- a/README.md
+++ b/README.md
@@ -1,32 +1,32 @@
 
 <h1 align="center">
   <br>
-  VS Code - Elements for Microsoft Edge (Chromium)
+  VS Code - DevTools for Microsoft Edge (Chromium)
   <br>
 </h1>
 
-<h4 align="center">Show the browser's Elements tool inside the VSCode editor and use it to fix styling, layout, and CSS issues with your site.</h4>
+<h4 align="center">Show the browser's Elements and Network tool inside the VSCode editor and use it to fix styling, layout, and CSS issues with your site.</h4>
 
-A VS Code extension that allows you to use the browser's Elements tool from within the editor. The Elements tool will connect to an instance of Microsoft Edge giving you the ability to see the runtime HTML structure, alter layout, and fix styling issues. All without leaving VS Code.
+A VS Code extension that allows you to use the browser's Elements and Network tool from within the editor. The DevTools will connect to an instance of Microsoft Edge giving you the ability to see the runtime HTML structure, alter layout, fix styling issues, and view network requests. All without leaving VS Code.
 
 **Note**: This extension only supports Microsoft Edge (Chromium)
 
-![Elements for Microsoft Edge - Demo](demo.gif)
+![DevTools for Microsoft Edge - Demo](demo.gif)
 
 **Supported Features**
 * Debug configurations for launching Microsoft Edge browser in remote-debugging mode and auto attaching the tools,
 * Side Bar view for listing all the debuggable targets, including tabs, extensions, service workers, etc.
-* Fully featured Elements tool with views for HTML, CSS, accessibility and more.
+* Fully featured Elements and Network tool with views for HTML, CSS, accessibility and more.
 * Screen-casting feature to allow you to see your page without leaving VSCode.
 * Go directly to the line/column for source files in your workspace when clicking on a link or CSS rule inside the Elements tool.
-* Auto attach the Elements tool when you start debugging with the [Debugger for Microsoft Edge](https://marketplace.visualstudio.com/items?itemName=msjsdiag.debugger-for-edge) extension.
+* Auto attach the DevTools when you start debugging with the [Debugger for Microsoft Edge](https://marketplace.visualstudio.com/items?itemName=msjsdiag.debugger-for-edge) extension.
 
 # Using the Extension
 ## Getting Started
 For use inside VS Code:
 
 1. Install any channel (Canary/Dev/etc.) of [Microsoft Edge (Chromium)](https://aka.ms/edgeinsider).
-1. Install the extension [Elements for Microsoft Edge](https://marketplace.visualstudio.com/items?itemName=ms-edgedevtools.vscode-edge-devtools).
+1. Install the extension [DevTools for Microsoft Edge](https://marketplace.visualstudio.com/items?itemName=ms-edgedevtools.vscode-edge-devtools).
 1. Open the folder containing the project you want to work on.
 1. (Optional) Install the [Debugger for Microsoft Edge](https://marketplace.visualstudio.com/items?itemName=msjsdiag.debugger-for-edge) extension.
 
@@ -36,7 +36,7 @@ The extension operates in two modes - it can launch an instance of Microsoft Edg
 ### Opening source files from the Elements tool
 One of the features of the Elements extension is that it can show you what file applied the styles and event handlers for a given node.
 
-![Elements for Microsoft Edge - Links](links.png)
+![DevTools for Microsoft Edge - Links](links.png)
 
 The source files for these applied styles and attached event handlers appear in the form of links to a url specified by the browser. Clicking on one will attempt to open that file inside the VS Code editor window. Correctly mapping these runtime locations to actual files on disk that are part of your current workspace, may require you to enable source maps as part of your build environment.
 
@@ -67,7 +67,7 @@ With source maps enabled, you may also need to configure the extension settings/
 
 
 ### Debug Configuration
-You can launch the Elements for Microsoft Edge extension like you would a debugger, by using a `launch.json` config file. However, Elements for Microsoft Edge isn't a debugger and so any breakpoints set in VS Code won't be hit, you can of course use a different debug extension instead and attach the Elements for Microsoft Edge extension once debugging has started.
+You can launch the DevTools for Microsoft Edge extension like you would a debugger, by using a `launch.json` config file. However, DevTools for Microsoft Edge isn't a debugger and so any breakpoints set in VS Code won't be hit, you can of course use a different debug extension instead and attach the DevTools for Microsoft Edge extension once debugging has started.
 
 To add a new debug configuration, in your `launch.json` add a new debug config with the following parameters:
 
@@ -85,13 +85,13 @@ To add a new debug configuration, in your `launch.json` add a new debug config w
         {
             "type": "vscode-edge-devtools.debug",
             "request": "launch",
-            "name": "Launch Microsoft Edge and open the Elements tool",
+            "name": "Launch Microsoft Edge and open the DevTools",
             "file": "${workspaceFolder}/index.html"
         },
         {
             "type": "vscode-edge-devtools.debug",
             "request": "attach",
-            "name": "Attach to Microsoft Edge and open the Elements tool",
+            "name": "Attach to Microsoft Edge and open the DevTools",
             "url": "http://localhost:8000/",
             "webRoot": "${workspaceFolder}/out"
         }
@@ -109,7 +109,7 @@ To add a new debug configuration, in your `launch.json` add a new debug config w
 * `pathMapping`: This property takes a mapping of URL paths to local paths, to give you more flexibility in how URLs are resolved to local files. `"webRoot": "${workspaceFolder}"` is just shorthand for a pathMapping like `{ "/": "${workspaceFolder}" }`.
 * `sourceMapPathOverrides`: A mapping of source paths from the sourcemap, to the locations of these sources on disk. See [Sourcemaps](#sourcemaps) for more information
 * `urlFilter`: A string that can contain wildcards that will be used for finding a browser target, for example, "localhost:*/app" will match either "http://localhost:123/app" or "http://localhost:456/app", but not "https://stackoverflow.com". This property will only be used if `url` and `file` are not specified.
-* `timeout`: The number of milliseconds that the Elements tool will keep trying to attach to the browser before timing out. Defaults to 10000ms.
+* `timeout`: The number of milliseconds that the DevTools will keep trying to attach to the browser before timing out. Defaults to 10000ms.
 
 #### Sourcemaps
 The elements tool uses sourcemaps to correctly open original source files when you click links in the UI, but sometimes the sourcemaps aren't generated properly and overrides are needed. In the config we support `sourceMapPathOverrides`, a mapping of source paths from the sourcemap, to the locations of these sources on disk. Useful when the sourcemap isn't accurate or can't be fixed in the build process.
@@ -160,17 +160,17 @@ Ionic and gulp-sourcemaps output a sourceRoot of `"/source/"` by default. If you
 
 ### Launching the browser via the side bar view
 * Start Microsoft Edge via the side bar
-  * Click the `Elements for Microsoft Edge` view in the side bar.
+  * Click the `DevTools for Microsoft Edge` view in the side bar.
   * Click the `Open a new tab` icon to launch the browser (if it isn't open yet) and open a new tab.
-* Attach the Elements tool via the side bar view
-  * Click the `Attach` icon next to the tab to open the Elements tool.
+* Attach the DevTools via the side bar view
+  * Click the `Attach` icon next to the tab to open the DevTools.
 
 ### Launching the browser manually
 * Start Microsoft Edge with remote-debugging enabled on port 9222:
   * `msedge.exe --remote-debugging-port=9222`
   * Navigate the browser to the desired URL.
-* Attach the Elements tool via a command:
-  * Run the command `Elements for Microsoft Edge: Attach to a target`
+* Attach the DevTools via a command:
+  * Run the command `DevTools for Microsoft Edge: Attach to a target`
   * Select a target from the drop down.
 
 ### Attaching automatically when launching the browser for debugging
@@ -178,7 +178,7 @@ Ionic and gulp-sourcemaps output a sourceRoot of `"/source/"` by default. If you
 * Setup your `launch.json` configuration to launch and debug Microsoft Edge (Chromium).
   * See [Debugger for Microsoft Edge Readme.md](https://github.com/microsoft/vscode-edge-debug2/blob/master/README.md).
 * Start Microsoft Edge for debugging.
-  * Once debugging has started, the Elements tools will auto attach to the browser (it will keep retrying until the Debugger for Microsoft Edge launch.json config `timeout` value is reached).
+  * Once debugging has started, the DevTools will auto attach to the browser (it will keep retrying until the Debugger for Microsoft Edge launch.json config `timeout` value is reached).
   * This auto attach functionality can be disabled via the `vscode-edge-devtools.autoAttachViaDebuggerForEdge` VS Code setting.
 
 # Contributing

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ For use inside VS Code:
 The extension operates in two modes - it can launch an instance of Microsoft Edge navigated to your app, or it can attach to a running instance of Microsoft Edge. Both modes requires you to be serving your web application from local web server, which is started from either a VS Code task or from your command-line. Using the `url` parameter you simply tell VS Code which URL to either open or launch in the browser.
 
 ### Opening source files from the Elements tool
-One of the features of the Elements extension is that it can show you what file applied the styles and event handlers for a given node.
+One of the features of the Elements tool is that it can show you what file applied the styles and event handlers for a given node.
 
 ![Microsoft Edge Tools - Links](links.png)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "vscode-edge-devtools",
-    "version": "1.0.7",
+    "version": "1.0.8",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "vscode-edge-devtools",
-    "displayName": "DevTools for Microsoft Edge (Chromium)",
-    "description": "Use the Microsoft Edge (Chromium) DevTools from within VS Code to see your site's runtime HTML structure, alter its layout, fix styling issues as well as see your site's network requests.",
+    "displayName": "Microsoft Edge (Chromium) Tools for VSCode",
+    "description": "Use the Microsoft Edge (Chromium) Tools from within VS Code to see your site's runtime HTML structure, alter its layout, fix styling issues as well as see your site's network requests.",
     "version": "1.0.7",
     "license": "SEE LICENSE IN LICENSE",
     "publisher": "ms-edgedevtools",
@@ -47,16 +47,16 @@
             {
                 "command": "vscode-edge-devtools.attach",
                 "title": "Attach to a target",
-                "category": "DevTools for Microsoft Edge"
+                "category": "Microsoft Edge Tools"
             },
             {
                 "command": "vscode-edge-devtools.launch",
                 "title": "Launch Edge and then attach to a target",
-                "category": "DevTools for Microsoft Edge"
+                "category": "Microsoft Edge Tools"
             },
             {
                 "command": "vscode-edge-devtools-view.launch",
-                "category": "DevTools for Microsoft Edge",
+                "category": "Microsoft Edge Tools",
                 "title": "Open a new tab",
                 "icon": {
                     "light": "resources/light/launch.svg",
@@ -65,7 +65,7 @@
             },
             {
                 "command": "vscode-edge-devtools-view.refresh",
-                "category": "DevTools for Microsoft Edge",
+                "category": "Microsoft Edge Tools",
                 "title": "Refresh Targets",
                 "icon": {
                     "light": "resources/light/refresh.svg",
@@ -74,8 +74,8 @@
             },
             {
                 "command": "vscode-edge-devtools-view.attach",
-                "category": "DevTools for Microsoft Edge",
-                "title": "Attach and open DevTools",
+                "category": "Microsoft Edge Tools",
+                "title": "Attach and open Microsoft Edge Tools",
                 "icon": {
                     "light": "resources/light/attach.svg",
                     "dark": "resources/dark/attach.svg"
@@ -83,12 +83,12 @@
             },
             {
                 "command": "vscode-edge-devtools-view.copyItem",
-                "category": "DevTools for Microsoft Edge",
+                "category": "Microsoft Edge Tools",
                 "title": "Copy Value"
             }
         ],
         "configuration": {
-            "title": "DevTools for Microsoft Edge",
+            "title": "Microsoft Edge (Chromium) Tools",
             "type": "object",
             "properties": {
                 "vscode-edge-devtools.browserPath": {
@@ -154,12 +154,12 @@
                 },
                 "vscode-edge-devtools.autoAttachViaDebuggerForEdge": {
                     "type": "boolean",
-                    "description": "Auto attach the DevTools for Microsoft Edge extension when you launch a browser with the Debugger For Microsoft Edge debug adapter extension",
+                    "description": "Auto attach the Microsoft Edge Tools extension when you launch a browser with the Debugger For Microsoft Edge debug adapter extension",
                     "default": true
                 },
                 "vscode-edge-devtools.timeout": {
                     "type": "number",
-                    "description": "The number of milliseconds that the DevTools will keep trying to attach the browser before timing out",
+                    "description": "The number of milliseconds that the Microsoft Edge Tools will keep trying to attach the browser before timing out",
                     "default": 10000
                 }
             }
@@ -167,26 +167,26 @@
         "debuggers": [
             {
                 "type": "vscode-edge-devtools.debug",
-                "label": "DevTools for Microsoft Edge",
+                "label": "Microsoft Edge Tools",
                 "configurationSnippets": [
                     {
-                        "label": "DevTools for Microsoft Edge: Launch",
+                        "label": "Microsoft Edge Tools: Launch",
                         "description": "Launch Microsoft Edge to a URL",
                         "body": {
                             "type": "vscode-edge-devtools.debug",
                             "request": "launch",
-                            "name": "Launch Microsoft Edge and open the DevTools",
+                            "name": "Launch Microsoft Edge and open the Edge DevTools",
                             "url": "http://localhost:8080",
                             "webRoot": "^\"${2:\\${workspaceFolder\\}}\""
                         }
                     },
                     {
-                        "label": "DevTools for Microsoft Edge: Attach",
+                        "label": "Microsoft Edge Tools: Attach",
                         "description": "Attach to an instance of Microsoft Edge already in debug mode",
                         "body": {
                             "type": "vscode-edge-devtools.debug",
                             "request": "attach",
-                            "name": "Attach to Microsoft Edge and open the DevTools",
+                            "name": "Attach to Microsoft Edge and open the Edge DevTools",
                             "url": "http://localhost:8080",
                             "webRoot": "^\"${2:\\${workspaceFolder\\}}\""
                         }
@@ -388,7 +388,7 @@
             "activitybar": [
                 {
                     "id": "vscode-edge-devtools-view",
-                    "title": "DevTools for Microsoft Edge",
+                    "title": "Microsoft Edge (Chromium) Tools",
                     "icon": "resources/viewIcon.svg"
                 }
             ]

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "vscode-edge-devtools",
-    "displayName": "Elements for Microsoft Edge (Chromium)",
-    "description": "Use the Microsoft Edge (Chromium) Elements tool from within VS Code to see your site's runtime HTML structure, alter its layout, and fix styling issues.",
+    "displayName": "DevTools for Microsoft Edge (Chromium)",
+    "description": "Use the Microsoft Edge (Chromium) DevTools from within VS Code to see your site's runtime HTML structure, alter its layout, fix styling issues as well as see your site's network requests.",
     "version": "1.0.7",
     "license": "SEE LICENSE IN LICENSE",
     "publisher": "ms-edgedevtools",
@@ -21,6 +21,8 @@
     "keywords": [
         "browser",
         "elements",
+        "network",
+        "devtools",
         "styling",
         "css",
         "dom"
@@ -45,16 +47,16 @@
             {
                 "command": "vscode-edge-devtools.attach",
                 "title": "Attach to a target",
-                "category": "Elements for Microsoft Edge"
+                "category": "DevTools for Microsoft Edge"
             },
             {
                 "command": "vscode-edge-devtools.launch",
                 "title": "Launch Edge and then attach to a target",
-                "category": "Elements for Microsoft Edge"
+                "category": "DevTools for Microsoft Edge"
             },
             {
                 "command": "vscode-edge-devtools-view.launch",
-                "category": "Elements for Microsoft Edge",
+                "category": "DevTools for Microsoft Edge",
                 "title": "Open a new tab",
                 "icon": {
                     "light": "resources/light/launch.svg",
@@ -63,7 +65,7 @@
             },
             {
                 "command": "vscode-edge-devtools-view.refresh",
-                "category": "Elements for Microsoft Edge",
+                "category": "DevTools for Microsoft Edge",
                 "title": "Refresh Targets",
                 "icon": {
                     "light": "resources/light/refresh.svg",
@@ -72,8 +74,8 @@
             },
             {
                 "command": "vscode-edge-devtools-view.attach",
-                "category": "Elements for Microsoft Edge",
-                "title": "Attach and open Elements",
+                "category": "DevTools for Microsoft Edge",
+                "title": "Attach and open DevTools",
                 "icon": {
                     "light": "resources/light/attach.svg",
                     "dark": "resources/dark/attach.svg"
@@ -81,12 +83,12 @@
             },
             {
                 "command": "vscode-edge-devtools-view.copyItem",
-                "category": "Elements for Microsoft Edge",
+                "category": "DevTools for Microsoft Edge",
                 "title": "Copy Value"
             }
         ],
         "configuration": {
-            "title": "Elements for Microsoft Edge",
+            "title": "DevTools for Microsoft Edge",
             "type": "object",
             "properties": {
                 "vscode-edge-devtools.browserPath": {
@@ -152,12 +154,12 @@
                 },
                 "vscode-edge-devtools.autoAttachViaDebuggerForEdge": {
                     "type": "boolean",
-                    "description": "Auto attach the Elements for Microsoft Edge extension when you launch a browser with the Debugger For Microsoft Edge debug adapter extension",
+                    "description": "Auto attach the DevTools for Microsoft Edge extension when you launch a browser with the Debugger For Microsoft Edge debug adapter extension",
                     "default": true
                 },
                 "vscode-edge-devtools.timeout": {
                     "type": "number",
-                    "description": "The number of milliseconds that the Elements tool will keep trying to attach the browser before timing out",
+                    "description": "The number of milliseconds that the DevTools will keep trying to attach the browser before timing out",
                     "default": 10000
                 }
             }
@@ -165,26 +167,26 @@
         "debuggers": [
             {
                 "type": "vscode-edge-devtools.debug",
-                "label": "Elements for Microsoft Edge",
+                "label": "DevTools for Microsoft Edge",
                 "configurationSnippets": [
                     {
-                        "label": "Elements for Microsoft Edge: Launch",
+                        "label": "DevTools for Microsoft Edge: Launch",
                         "description": "Launch Microsoft Edge to a URL",
                         "body": {
                             "type": "vscode-edge-devtools.debug",
                             "request": "launch",
-                            "name": "Launch Microsoft Edge and open the Elements tool",
+                            "name": "Launch Microsoft Edge and open the DevTools",
                             "url": "http://localhost:8080",
                             "webRoot": "^\"${2:\\${workspaceFolder\\}}\""
                         }
                     },
                     {
-                        "label": "Elements for Microsoft Edge: Attach",
+                        "label": "DevTools for Microsoft Edge: Attach",
                         "description": "Attach to an instance of Microsoft Edge already in debug mode",
                         "body": {
                             "type": "vscode-edge-devtools.debug",
                             "request": "attach",
-                            "name": "Attach to Microsoft Edge and open the Elements tool",
+                            "name": "Attach to Microsoft Edge and open the DevTools",
                             "url": "http://localhost:8080",
                             "webRoot": "^\"${2:\\${workspaceFolder\\}}\""
                         }
@@ -386,7 +388,7 @@
             "activitybar": [
                 {
                     "id": "vscode-edge-devtools-view",
-                    "title": "Elements for Microsoft Edge",
+                    "title": "DevTools for Microsoft Edge",
                     "icon": "resources/viewIcon.svg"
                 }
             ]

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "vscode-edge-devtools",
     "displayName": "Microsoft Edge (Chromium) Tools for VSCode",
     "description": "Use the Microsoft Edge (Chromium) Tools from within VS Code to see your site's runtime HTML structure, alter its layout, fix styling issues as well as see your site's network requests.",
-    "version": "1.0.7",
+    "version": "1.0.8",
     "license": "SEE LICENSE IN LICENSE",
     "publisher": "ms-edgedevtools",
     "preview": true,

--- a/src/devtoolsPanel.ts
+++ b/src/devtoolsPanel.ts
@@ -191,7 +191,7 @@ export class DevToolsPanel {
         const { column, line, url, ignoreTabChanges } = JSON.parse(message) as IOpenEditorData;
 
         // If we don't want to force focus to the doc and doing so would cause a tab switch ignore it.
-        // This is because just starting to edit a style in the Elements tool with call openInEditor
+        // This is because just starting to edit a style in the DevTools with call openInEditor
         // but if we switch vs code tab the edit will be cancelled.
         if (ignoreTabChanges && this.panel.viewColumn === vscode.ViewColumn.One) {
             return;

--- a/src/devtoolsPanel.ts
+++ b/src/devtoolsPanel.ts
@@ -191,7 +191,7 @@ export class DevToolsPanel {
         const { column, line, url, ignoreTabChanges } = JSON.parse(message) as IOpenEditorData;
 
         // If we don't want to force focus to the doc and doing so would cause a tab switch ignore it.
-        // This is because just starting to edit a style in the DevTools with call openInEditor
+        // This is because just starting to edit a style in the Microsoft Edge Tools with call openInEditor
         // but if we switch vs code tab the edit will be cancelled.
         if (ignoreTabChanges && this.panel.viewColumn === vscode.ViewColumn.One) {
             return;

--- a/src/launchDebugProvider.ts
+++ b/src/launchDebugProvider.ts
@@ -41,7 +41,7 @@ export default class LaunchDebugProvider implements vscode.DebugConfigurationPro
         folder: vscode.WorkspaceFolder | undefined,
         token?: vscode.CancellationToken): vscode.ProviderResult<vscode.DebugConfiguration[]> {
         return Promise.resolve([{
-            name: "Launch Microsoft Edge and open the DevTools",
+            name: "Launch Microsoft Edge and open the Edge DevTools",
             request: "launch",
             type: `${SETTINGS_STORE_NAME}.debug`,
             url: "http://localhost:8080",

--- a/src/launchDebugProvider.ts
+++ b/src/launchDebugProvider.ts
@@ -41,7 +41,7 @@ export default class LaunchDebugProvider implements vscode.DebugConfigurationPro
         folder: vscode.WorkspaceFolder | undefined,
         token?: vscode.CancellationToken): vscode.ProviderResult<vscode.DebugConfiguration[]> {
         return Promise.resolve([{
-            name: "Launch Microsoft Edge and open the Elements tool",
+            name: "Launch Microsoft Edge and open the DevTools",
             request: "launch",
             type: `${SETTINGS_STORE_NAME}.debug`,
             url: "http://localhost:8080",

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -55,7 +55,7 @@ export const SETTINGS_DEFAULT_USE_HTTPS = false;
 export const SETTINGS_DEFAULT_HOSTNAME = "localhost";
 export const SETTINGS_DEFAULT_PORT = 9222;
 export const SETTINGS_DEFAULT_URL = "about:blank";
-export const SETTINGS_WEBVIEW_NAME = "DevTools";
+export const SETTINGS_WEBVIEW_NAME = "Edge DevTools";
 export const SETTINGS_PREF_NAME = "devtools-preferences";
 export const SETTINGS_PREF_DEFAULTS = {
     screencastEnabled: false,

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -55,7 +55,7 @@ export const SETTINGS_DEFAULT_USE_HTTPS = false;
 export const SETTINGS_DEFAULT_HOSTNAME = "localhost";
 export const SETTINGS_DEFAULT_PORT = 9222;
 export const SETTINGS_DEFAULT_URL = "about:blank";
-export const SETTINGS_WEBVIEW_NAME = "Elements";
+export const SETTINGS_WEBVIEW_NAME = "DevTools";
 export const SETTINGS_PREF_NAME = "devtools-preferences";
 export const SETTINGS_PREF_DEFAULTS = {
     screencastEnabled: false,


### PR DESCRIPTION
With the addition of the Network tool from [PR 128](https://github.com/microsoft/vscode-edge-devtools/pull/128), the extension is being renamed from ""Elements for Microsoft Edge (Chromium)"" to "Microsoft Edge (Chromium) Tools for VSCode."

This PR targets the usages of the extension name in the README, config files, package.json and other files.

![image](https://user-images.githubusercontent.com/14304598/80832767-1e726e00-8ba2-11ea-88e3-86dcae8cd90f.png)

### Renaming the official extension name to "Microsoft Edge (Chromium) Tools for VSCode"
- Using "Edge DevTools" in more informal cases where appropriate
- "Launch Microsoft Edge and open the Edge DevTools"  here -https://github.com/microsoft/vscode-edge-devtools/pull/134/files#diff-04c6e90faac2675aa89e2176d2eec7d8L88
- Title in the extension tab - https://github.com/microsoft/vscode-edge-devtools/pull/134/files#diff-e1495d267619047a7cca5cfe8f692729R58​​​​​​​
- Generally using "Microsoft Edge Tools" when referring to the extension in a sentence - https://github.com/microsoft/vscode-edge-devtools/pull/134/files#diff-b9cfc7f2cdf78a7f4b91a753d10865a2R157
- Using "Microsoft Edge (Chromium) Tools" in titles - https://github.com/microsoft/vscode-edge-devtools/pull/134/files#diff-b9cfc7f2cdf78a7f4b91a753d10865a2R91

### Changelog update
- Addresses rename, version downgrade and merged network tool - https://github.com/microsoft/vscode-edge-devtools/pull/134/files#diff-4ac32a78649ca5bdd8e0ba38b7006a1eR1

​​​​​​​​​​​​​​
