### PR TITLE
Updating Typescript to version 3.8.3

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,7 +20,7 @@ Contributions are always welcome! We only ask that you open an issue first so we
 * On an administrator prompt execute the following commands (assuming your drive is located at C:\)
   * `mkdir c:\edge\src\out\Release\gen\devtools`
   * `mkdir c:\edge\src\third_party\devtools-frontend\src\front_end`
-* Download a copy of the Microsoft Edge (Chromium) build from [https://thirdpartysource.microsoft.com](https://thirdpartysource.microsoft.com)
+* Download a copy of the Microsoft Edge (Chromium) build from [https://thirdpartysource.microsoft.com](https://thirdpartysource.microsoft.com), current extension version builds from version 81.0.416.
 * **Open** the zip file and (inside the zip file) navigate to:
   * `[ZIP_FILE]:\src\third_party\devtools-frontend\src\front_end`
   * copy the contents of the "front_end" folder and paste them into `c:\edge\src\third_party\devtools-frontend\src\front_end`

--- a/package-lock.json
+++ b/package-lock.json
@@ -7186,9 +7186,9 @@
             "dev": true
         },
         "typescript": {
-            "version": "3.5.3",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.5.3.tgz",
-            "integrity": "sha512-ACzBtm/PhXBDId6a6sDJfroT2pOWt/oOnk4/dElG5G33ZL776N3Y6/6bKZJBFpd+b05F3Ct9qDjMeJmRWtE2/g==",
+            "version": "3.8.3",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.8.3.tgz",
+            "integrity": "sha512-MYlEfn5VrLNsgudQTVJeNaQFUAI7DkhnOjdpAp4T+ku1TfQClewlbSuTVHiA+8skNBgaf02TL/kLOvig4y3G8w==",
             "dev": true
         },
         "uc.micro": {

--- a/package.json
+++ b/package.json
@@ -157,6 +157,11 @@
                     "description": "Auto attach the Microsoft Edge Tools extension when you launch a browser with the Debugger For Microsoft Edge debug adapter extension",
                     "default": true
                 },
+                "vscode-edge-devtools.enableNetwork": {
+                    "type": "boolean",
+                    "description": "Enable network panel (requires relaunching extension)",
+                    "default": true
+                },
                 "vscode-edge-devtools.timeout": {
                     "type": "number",
                     "description": "The number of milliseconds that the Microsoft Edge Tools will keep trying to attach the browser before timing out",

--- a/package.json
+++ b/package.json
@@ -452,7 +452,7 @@
         "ts-loader": "6.0.4",
         "ts-node": "8.3.0",
         "tslint": "5.18.0",
-        "typescript": "3.5.3",
+        "typescript": "3.8.3",
         "vsce": "1.75.0",
         "vscode-test": "1.0.2",
         "webpack": "4.36.1",

--- a/src/common/tabSettingsProvider.test.ts
+++ b/src/common/tabSettingsProvider.test.ts
@@ -1,0 +1,34 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+
+import { createFakeVSCode } from "../test/helpers";
+
+// Licensed under the MIT License.
+
+jest.mock("vscode", () => createFakeVSCode(), { virtual: true });
+
+describe("tabSettingsProvider", () => {
+  beforeEach(() => {
+    const mockVSCode = createFakeVSCode();
+    jest.doMock("vscode", () => mockVSCode, { virtual: true });
+    jest.resetModules();
+  });
+
+  describe("GetTabConfiguration", () => {
+    it("test that singleton provides the right instance", async () => {
+      const tsp = await import("../common/tabSettingsProvider");
+      const instance = tsp.TabSettingsProvider.instance;
+      const instanceB = tsp.TabSettingsProvider.instance;
+      expect(instance).not.toEqual(null);
+      expect(instance).toEqual(instanceB);
+    });
+
+    it("test that the right value is retrieved for networkEnabled configuration", async () => {
+      jest.requireMock("vscode");
+      const tsp = await import("../common/tabSettingsProvider");
+      const instance = tsp.TabSettingsProvider.instance;
+      expect(instance).not.toEqual(null);
+      const result = instance.isNetworkEnabled();
+      expect(result).toEqual(true);
+    });
+  });
+});

--- a/src/common/tabSettingsProvider.ts
+++ b/src/common/tabSettingsProvider.ts
@@ -1,0 +1,23 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+import * as vscode from "vscode";
+import { SETTINGS_STORE_NAME } from "../utils";
+
+export class TabSettingsProvider {
+
+  private static singletonInstance: TabSettingsProvider;
+
+  public static get instance() {
+    if (!TabSettingsProvider.singletonInstance) {
+      TabSettingsProvider.singletonInstance = new TabSettingsProvider();
+    }
+
+    return TabSettingsProvider.singletonInstance;
+  }
+
+  public isNetworkEnabled(): boolean {
+    const settings = vscode.workspace.getConfiguration(SETTINGS_STORE_NAME);
+    const networkEnabled: boolean = settings.get("enableNetwork") || false;
+    return networkEnabled;
+  }
+}

--- a/src/common/webviewEvents.ts
+++ b/src/common/webviewEvents.ts
@@ -1,7 +1,8 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-export type WebviewEvent = "getState" | "getUrl" | "openInEditor" | "ready" | "setState" | "telemetry" | "websocket";
+export type WebviewEvent = "getState" | "getUrl" | "openInEditor" | "ready" | "setState" | "telemetry" | "websocket"
+| "getApprovedTabs";
 export const webviewEventNames: WebviewEvent[] = [
     "getState",
     "getUrl",
@@ -10,6 +11,7 @@ export const webviewEventNames: WebviewEvent[] = [
     "setState",
     "telemetry",
     "websocket",
+    "getApprovedTabs",
 ];
 
 export type WebSocketEvent = "open" | "close" | "error" | "message";

--- a/src/devtoolsPanel.test.ts
+++ b/src/devtoolsPanel.test.ts
@@ -466,6 +466,31 @@ describe("devtoolsPanel", () => {
                 expect(mockVsCode.window.showTextDocument).toHaveBeenCalled();
             });
 
+            it("calls getApprovedTabs", async () => {
+                const expectedId = { id: 0 };
+                const expectedState = { enableNetwork: true };
+                (context.workspaceState.get as jest.Mock).mockReturnValue(expectedState);
+
+                const dtp = await import("./devtoolsPanel");
+                dtp.DevToolsPanel.createOrShow(context, mockTelemetry, "", mockRuntimeConfig);
+
+                hookedEvents.get("getApprovedTabs")!(JSON.stringify(expectedId));
+                expect(mockWebviewEvents.encodeMessageForChannel).toHaveBeenCalledWith(
+                    expect.any(Function),
+                    "getApprovedTabs",
+                    {
+                        enableNetwork: expectedState.enableNetwork,
+                        id: expectedId.id,
+                    },
+                );
+
+                // Ensure that the encoded message is actually passed over to the webview
+                const expectedPostedMessage = "encodedMessage";
+                const { callback, thisObj } = getFirstCallback(mockWebviewEvents.encodeMessageForChannel);
+                callback.call(thisObj, expectedPostedMessage);
+                expect(mockPanel.webview.postMessage).toHaveBeenCalledWith(expectedPostedMessage);
+            });
+
             it("shows an error for unmapped urls", async () => {
                 const expectedRequest = {
                     column: 5,

--- a/src/devtoolsPanel.ts
+++ b/src/devtoolsPanel.ts
@@ -1,10 +1,11 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-
 import * as path from "path";
 import * as vscode from "vscode";
 import * as debugCore from "vscode-chrome-debug-core";
 import TelemetryReporter from "vscode-extension-telemetry";
+
+import { TabSettingsProvider } from "./common/tabSettingsProvider";
 import {
     encodeMessageForChannel,
     IOpenEditorData,
@@ -54,6 +55,7 @@ export class DevToolsPanel {
         this.panelSocket.on("websocket", () => this.onSocketMessage());
         this.panelSocket.on("telemetry", (msg) => this.onSocketTelemetry(msg));
         this.panelSocket.on("getState", (msg) => this.onSocketGetState(msg));
+        this.panelSocket.on("getApprovedTabs", (msg) => this.onSocketGetApprovedTabs(msg));
         this.panelSocket.on("setState", (msg) => this.onSocketSetState(msg));
         this.panelSocket.on("getUrl", (msg) => this.onSocketGetUrl(msg));
         this.panelSocket.on("openInEditor", (msg) => this.onSocketOpenInEditor(msg));
@@ -157,6 +159,13 @@ export class DevToolsPanel {
         const { id } = JSON.parse(message) as { id: number };
         const preferences: any = this.context.workspaceState.get(SETTINGS_PREF_NAME) || SETTINGS_PREF_DEFAULTS;
         encodeMessageForChannel((msg) => this.panel.webview.postMessage(msg), "getState", { id, preferences });
+    }
+
+    private onSocketGetApprovedTabs(message: string) {
+        const { id } = JSON.parse(message) as { id: number };
+        encodeMessageForChannel((msg) => this.panel.webview.postMessage(msg), "getApprovedTabs", {
+            enableNetwork: TabSettingsProvider.instance.isNetworkEnabled(),
+            id });
     }
 
     private onSocketSetState(message: string) {

--- a/src/host/polyfills/simpleView.test.ts
+++ b/src/host/polyfills/simpleView.test.ts
@@ -110,13 +110,13 @@ describe("simpleView", () => {
 
     it("applyAppendTabPatch correctly changes text", async () => {
         const apply = await import("./simpleView");
-        const comparableText = "appendTab(id, tabTitle, view, tabTooltip, userGesture, isCloseable, index) {";
+        const comparableText = `appendTab(id, tabTitle, view, tabTooltip, userGesture, isCloseable, index) {}
+        export const Events={}`;
         let fileContents = getTextFromFile("ui/TabbedPane.js");
         fileContents = fileContents ? fileContents : comparableText;
         const result = apply.applyAppendTabPatch(fileContents);
-        expect(result).not.toEqual(null);
         expect(result).toEqual(expect.stringContaining(
-            "appendTab(id, tabTitle, view, tabTooltip, userGesture, isCloseable, index) { if (id"));
+            "appendTabOverride(id, tabTitle, view, tabTooltip, userGesture, isCloseable, index) {"));
     });
 
     it("applyShowElementsTab correctly changes text", async () => {

--- a/src/test/helpers.ts
+++ b/src/test/helpers.ts
@@ -57,7 +57,13 @@ export function createFakeVSCode() {
         },
         workspace: {
             getConfiguration: jest.fn(() => {
-                return { get: (name: string) => "" };
+                return { get: (name: string) => {
+                    if ("enableNetwork" === name) {
+                        return true;
+                    } else {
+                        return "";
+                    }
+                } };
             }),
             onDidChangeConfiguration: jest.fn(),
             openTextDocument: jest.fn().mockResolvedValue(null),


### PR DESCRIPTION
As mentioned in issue https://github.com/microsoft/vscode-edge-devtools/issues/135 when running the `npm run build` command in the repository, I got the errors looking like this:

```
ERROR in /Users/dominikderen/dev/vscode-edge-devtools/node_modules/jest-diff/build/index.d.ts
    [tsl] ERROR in /Users/dominikderen/dev/vscode-edge-devtools/node_modules/jest-diff/build/index.d.ts(10,13)
          TS1005: '=' expected.
```

This seems to be related to `import type` & `export type` keywords in those files. TypeScript added support for those keywords in version 3.8, so I'm proposing updating this repository to use Typescript `3.8.3` by default.