### PR TITLE
Updating Typescript to version 3.8.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7186,9 +7186,9 @@
             "dev": true
         },
         "typescript": {
-            "version": "3.5.3",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.5.3.tgz",
-            "integrity": "sha512-ACzBtm/PhXBDId6a6sDJfroT2pOWt/oOnk4/dElG5G33ZL776N3Y6/6bKZJBFpd+b05F3Ct9qDjMeJmRWtE2/g==",
+            "version": "3.8.3",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.8.3.tgz",
+            "integrity": "sha512-MYlEfn5VrLNsgudQTVJeNaQFUAI7DkhnOjdpAp4T+ku1TfQClewlbSuTVHiA+8skNBgaf02TL/kLOvig4y3G8w==",
             "dev": true
         },
         "uc.micro": {

--- a/package.json
+++ b/package.json
@@ -452,7 +452,7 @@
         "ts-loader": "6.0.4",
         "ts-node": "8.3.0",
         "tslint": "5.18.0",
-        "typescript": "3.5.3",
+        "typescript": "3.8.3",
         "vsce": "1.75.0",
         "vscode-test": "1.0.2",
         "webpack": "4.36.1",


### PR DESCRIPTION
As mentioned in issue #135 when running the npm run build command in the repository, I got the errors looking like this:

```
ERROR in /Users/dominikderen/dev/vscode-edge-devtools/node_modules/jest-diff/build/index.d.ts
    [tsl] ERROR in /Users/dominikderen/dev/vscode-edge-devtools/node_modules/jest-diff/build/index.d.ts(10,13)
          TS1005: '=' expected.
```

This seems to be related to import type & export type keywords in those files. TypeScript added support for those keywords in version 3.8, so I'm proposing updating this repository to use Typescript 3.8.3 by default.