### PR TITLE
Fixes default value for Browser Path

### DIFF
--- a/package.json
+++ b/package.json
@@ -93,7 +93,7 @@
             "properties": {
                 "vscode-edge-devtools.browserPath": {
                     "type": "string",
-                    "default": null,
+                    "default": "",
                     "description": "The path to the browser to use, rather than searching for the default"
                 },
                 "vscode-edge-devtools.hostname": {


### PR DESCRIPTION
**Root Cause:**
The default value for browserPath setting is wrong as null is not a valid value.

**Fix:**
Changing it to empty string. I verified that the path that uses this already considers empty === not set

Before:
![image](https://user-images.githubusercontent.com/43078681/82386109-946f3580-99e8-11ea-99d1-2228b4dfaa1f.png)

After:
![image](https://user-images.githubusercontent.com/43078681/82386166-a18c2480-99e8-11ea-90b0-49635a459216.png)
