### PR TITLE
Fixing sourceMapPathOverrides description

### DIFF
--- a/package.json
+++ b/package.json
@@ -138,7 +138,7 @@
                 },
                 "vscode-edge-devtools.sourceMapPathOverrides": {
                     "type": "object",
-                    "description": "A set of mappings to override the locations of sourcemaps files.",
+                    "description": "A set of mappings to override the locations of source map files.",
                     "default": {
                         "webpack:///./*": "${webRoot}/*",
                         "webpack:///src/*": "${webRoot}/*",

--- a/package.json
+++ b/package.json
@@ -138,7 +138,7 @@
                 },
                 "vscode-edge-devtools.sourceMapPathOverrides": {
                     "type": "object",
-                    "description": "A set of mappings to override the locations of source maps files.",
+                    "description": "A set of mappings to override the locations of sourcemaps files.",
                     "default": {
                         "webpack:///./*": "${webRoot}/*",
                         "webpack:///src/*": "${webRoot}/*",

--- a/package.json
+++ b/package.json
@@ -138,7 +138,7 @@
                 },
                 "vscode-edge-devtools.sourceMapPathOverrides": {
                     "type": "object",
-                    "description": "A set of mappings for rewriting the locations of source files from what the sourcemap says, to their locations on disk",
+                    "description": "A set of mappings to override the locations of source maps files.",
                     "default": {
                         "webpack:///./*": "${webRoot}/*",
                         "webpack:///src/*": "${webRoot}/*",


### PR DESCRIPTION
**Root cause:**
sourceMapPathOverrides is confusing as it has the same text as pathMapping.

**Fix:**
Provide a more accurate description.