### PR TITLE
Converting from browserPath to browserFlavor

### DIFF
--- a/package.json
+++ b/package.json
@@ -276,11 +276,11 @@
                             "vscode-edge-devtools.browserFlavor": {
                                 "type": "string",
                                 "enum": [
-                                    "default",
-                                    "stable",
-                                    "beta",
-                                    "dev",
-                                    "canary"
+                                    "Default",
+                                    "Stable",
+                                    "Beta",
+                                    "Dev",
+                                    "Canary"
                                 ],
                                 "enumDescriptions": [
                                     "Microsoft Edge (Chromium) Tools for VSCode will try to open the Microsoft Edge flavors in the following order: Stable, Beta, Dev and Canary",
@@ -358,11 +358,11 @@
                             "vscode-edge-devtools.browserFlavor": {
                                 "type": "string",
                                 "enum": [
-                                    "default",
-                                    "stable",
-                                    "beta",
-                                    "dev",
-                                    "canary"
+                                    "Default",
+                                    "Stable",
+                                    "Beta",
+                                    "Dev",
+                                    "Canary"
                                 ],
                                 "enumDescriptions": [
                                     "Microsoft Edge (Chromium) Tools for VSCode will try to open the Microsoft Edge flavors in the following order: Stable, Beta, Dev and Canary",

--- a/package.json
+++ b/package.json
@@ -93,7 +93,7 @@
             "properties": {
                 "vscode-edge-devtools.browserPath": {
                     "type": "string",
-                    "default": null,
+                    "default": "",
                     "description": "The path to the browser to use, rather than searching for the default"
                 },
                 "vscode-edge-devtools.hostname": {

--- a/package.json
+++ b/package.json
@@ -165,11 +165,11 @@
                 "vscode-edge-devtools.browserFlavor": {
                     "type": "string",
                     "enum": [
-                        "default",
-                        "stable",
-                        "beta",
-                        "dev",
-                        "canary"
+                        "Default",
+                        "Stable",
+                        "Beta",
+                        "Dev",
+                        "Canary"
                     ],
                     "enumDescriptions": [
                         "Microsoft Edge (Chromium) Tools for VSCode will try to open the Microsoft Edge flavors in the following order: Stable, Beta, Dev and Canary",

--- a/package.json
+++ b/package.json
@@ -91,11 +91,6 @@
             "title": "Microsoft Edge (Chromium) Tools",
             "type": "object",
             "properties": {
-                "vscode-edge-devtools.browserPath": {
-                    "type": "string",
-                    "default": "",
-                    "description": "The path to the browser to use, rather than searching for the default"
-                },
                 "vscode-edge-devtools.hostname": {
                     "type": "string",
                     "default": "localhost",
@@ -166,6 +161,23 @@
                     "type": "number",
                     "description": "The number of milliseconds that the Microsoft Edge Tools will keep trying to attach the browser before timing out",
                     "default": 10000
+                },
+                "vscode-edge-devtools.browserFlavor": {
+                    "type": "string",
+                    "enum": [
+                        "default",
+                        "stable",
+                        "beta",
+                        "dev",
+                        "canary"
+                    ],
+                    "enumDescriptions": [
+                        "Microsoft Edge (Chromium) Tools for VSCode will try to open the Microsoft Edge flavors in the following order: Stable, Beta, Dev and Canary",
+                        "Microsoft Edge (Chromium) Tools for VSCode will use Microsoft Edge Stable version",
+                        "Microsoft Edge (Chromium) Tools for VSCode will use Microsoft Edge Beta version",
+                        "Microsoft Edge (Chromium) Tools for VSCode will use Microsoft Edge Dev version",
+                        "Microsoft Edge (Chromium) Tools for VSCode will use Microsoft Edge Canary version"
+                    ]
                 }
             }
         },
@@ -210,11 +222,6 @@
                                 "description": "File path to launch",
                                 "default": "${workspaceFolder}/index.html"
                             },
-                            "browserPath": {
-                                "type": "string",
-                                "description": "Absolute path to the browser instance to launch",
-                                "default": ""
-                            },
                             "hostname": {
                                 "type": "string",
                                 "default": "localhost",
@@ -265,6 +272,23 @@
                                 "type": "boolean",
                                 "description": "Use JavaScript source maps (if they exist)",
                                 "default": true
+                            },
+                            "vscode-edge-devtools.browserFlavor": {
+                                "type": "string",
+                                "enum": [
+                                    "default",
+                                    "stable",
+                                    "beta",
+                                    "dev",
+                                    "canary"
+                                ],
+                                "enumDescriptions": [
+                                    "Microsoft Edge (Chromium) Tools for VSCode will try to open the Microsoft Edge flavors in the following order: Stable, Beta, Dev and Canary",
+                                    "Microsoft Edge (Chromium) Tools for VSCode will use Microsoft Edge Stable version",
+                                    "Microsoft Edge (Chromium) Tools for VSCode will use Microsoft Edge Beta version",
+                                    "Microsoft Edge (Chromium) Tools for VSCode will use Microsoft Edge Dev version",
+                                    "Microsoft Edge (Chromium) Tools for VSCode will use Microsoft Edge Canary version"
+                                ]
                             }
                         }
                     },
@@ -280,11 +304,6 @@
                                 "description": "File path to launch.",
                                 "default": "${workspaceFolder}/index.html"
                             },
-                            "browserPath": {
-                                "type": "string",
-                                "description": "Absolute path to the browser instance to launch.",
-                                "default": ""
-                            },
                             "hostname": {
                                 "type": "string",
                                 "default": "localhost",
@@ -335,6 +354,23 @@
                                 "type": "boolean",
                                 "description": "Use JavaScript source maps (if they exist)",
                                 "default": true
+                            },
+                            "vscode-edge-devtools.browserFlavor": {
+                                "type": "string",
+                                "enum": [
+                                    "default",
+                                    "stable",
+                                    "beta",
+                                    "dev",
+                                    "canary"
+                                ],
+                                "enumDescriptions": [
+                                    "Microsoft Edge (Chromium) Tools for VSCode will try to open the Microsoft Edge flavors in the following order: Stable, Beta, Dev and Canary",
+                                    "Microsoft Edge (Chromium) Tools for VSCode will use Microsoft Edge Stable version",
+                                    "Microsoft Edge (Chromium) Tools for VSCode will use Microsoft Edge Beta version",
+                                    "Microsoft Edge (Chromium) Tools for VSCode will use Microsoft Edge Dev version",
+                                    "Microsoft Edge (Chromium) Tools for VSCode will use Microsoft Edge Canary version"
+                                ]
                             }
                         }
                     }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -188,8 +188,9 @@ export async function launch(context: vscode.ExtensionContext, launchUrl?: strin
             telemetryReporter.sendTelemetryEvent("command/launch/error/browser_not_found", telemetryProps);
             vscode.window.showErrorMessage(
                 "Microsoft Edge could not be found. " +
-                "Ensure you have installed Microsoft Edge, " +
-                "or try specifying a custom path via the 'browserPath' setting.");
+                "Ensure you have installed Microsoft Edge " +
+                "and that you have selected 'default' or the appropriate version of Microsoft Edge " +
+                "in the extension settings panel.");
             return;
         } else {
             // Here we grab the last part of the path (using either forward or back slashes to account for mac/win),

--- a/src/utils.test.ts
+++ b/src/utils.test.ts
@@ -375,7 +375,7 @@ describe("utils", () => {
             expect(result5.userDataDir).toEqual(expect.stringContaining("vscode-edge-devtools-userdatadir_"));
 
             // No folder if they use a browser path
-            const result6 = utils.getRemoteEndpointSettings({ browserFlavor: "stable" });
+            const result6 = utils.getRemoteEndpointSettings({ browserFlavor: "Stable" });
             expect(result6.userDataDir).toEqual("");
         });
     });
@@ -529,7 +529,7 @@ describe("utils", () => {
             });
             vscodeMock.workspace.getConfiguration.mockImplementationOnce(() => {
                 return {
-                    get: (name: string) => "canary",
+                    get: (name: string) => "Canary",
                 };
             });
             expect(await utils.getBrowserPath()).toEqual(expect.stringMatching(matchingRegex));
@@ -538,7 +538,7 @@ describe("utils", () => {
             os.platform.mockReturnValue("linux");
             vscodeMock.workspace.getConfiguration.mockImplementationOnce(() => {
                 return {
-                    get: (name: string) => "dev",
+                    get: (name: string) => "Dev",
                 };
             });
             fse.pathExists.mockClear();

--- a/src/utils.test.ts
+++ b/src/utils.test.ts
@@ -306,7 +306,7 @@ describe("utils", () => {
 
         it("uses user config", async () => {
             const config = {
-                browserPath: "default",
+                browserPath: "Default",
                 hostname: "someHost",
                 port: 9999,
                 url: "url",

--- a/src/utils.test.ts
+++ b/src/utils.test.ts
@@ -469,7 +469,7 @@ describe("utils", () => {
 
         it("returns the custom path or empty string", async () => {
             const config = {
-                browserFlavor: "default" as BrowserFlavor,
+                browserFlavor: "Default" as BrowserFlavor,
             };
             os.platform.mockReturnValue("win32");
 
@@ -483,7 +483,7 @@ describe("utils", () => {
         });
 
         it("returns the settings path", async () => {
-            const expectedFlavor = "default";
+            const expectedFlavor = "Default";
             const expectedPath = "C:\\Program Files (x86)\\Microsoft\\Edge\\Application\\msedge.exe";
             const configMock = {
                 get: (name: string) => expectedFlavor,
@@ -506,7 +506,7 @@ describe("utils", () => {
             os.platform.mockReturnValue("win32");
             vscodeMock.workspace.getConfiguration.mockImplementationOnce(() => {
                 return {
-                    get: (name: string) => "default",
+                    get: (name: string) => "Default",
                 };
             });
             fse.pathExists.mockImplementation((customPath) => {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -209,7 +209,7 @@ export function getRemoteEndpointSettings(config: Partial<IUserConfig> = {}): ID
     // We generate a temp directory if the user opted in explicitly with 'true' (which is the default),
     // Or if it is not defined and they are not using a custom browser path (such as electron).
     // This matches the behavior of the chrome and edge debug extensions.
-    const browserPathSet = config.browserFlavor !== "Default";
+    const browserPathSet = config.browserFlavor || "Default";
     let userDataDir: string | boolean | undefined;
     if (typeof config.userDataDir !== "undefined") {
         userDataDir = config.userDataDir;
@@ -220,7 +220,7 @@ export function getRemoteEndpointSettings(config: Partial<IUserConfig> = {}): ID
         }
     }
 
-    if (userDataDir === true || (typeof userDataDir === "undefined" && browserPathSet)) {
+    if (userDataDir === true || (typeof userDataDir === "undefined" && browserPathSet === "Default")) {
         // Generate a temp directory
         userDataDir = path.join(os.tmpdir(), `vscode-edge-devtools-userdatadir_${port}`);
     } else if (!userDataDir) {
@@ -266,11 +266,9 @@ export async function getBrowserPath(config: Partial<IUserConfig> = {}): Promise
     switch (getPlatform()) {
         case "Windows": {
            return await verifyFlavorPath(flavor, "Windows");
-           break;
         }
         case "OSX": {
             return await verifyFlavorPath(flavor, "OSX");
-            break;
         }
     }
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -14,6 +14,16 @@ import TelemetryReporter from "vscode-extension-telemetry";
 import packageJson from "../package.json";
 import DebugTelemetryReporter from "./debugTelemetryReporter";
 
+export type BrowserFlavor = "default" | "stable" | "beta" | "dev" | "canary";
+
+interface IBrowserPath {
+    windows: {
+        primary: string;
+        secondary: string;
+    };
+    osx: string;
+}
+
 export interface IDevToolsSettings {
     hostname: string;
     port: number;
@@ -26,7 +36,7 @@ export interface IDevToolsSettings {
 export interface IUserConfig {
     url: string;
     urlFilter: string;
-    browserPath: string;
+    browserFlavor: BrowserFlavor;
     hostname: string;
     port: number;
     useHttps: boolean;
@@ -79,22 +89,7 @@ export const SETTINGS_DEFAULT_ATTACH_TIMEOUT: number = 10000;
 export const SETTINGS_DEFAULT_ATTACH_INTERVAL: number = 200;
 
 const WIN_APP_DATA = process.env.LOCALAPPDATA || "/";
-const WIN_MSEDGE_PATHS = [
-    "C:\\Program Files (x86)\\Microsoft\\Edge\\Application\\msedge.exe",        // Stable
-    path.join(WIN_APP_DATA, "Microsoft\\Edge\\Application\\msedge.exe"),        // Stable localappdata
-    "C:\\Program Files (x86)\\Microsoft\\Edge Beta\\Application\\msedge.exe",   // Beta
-    path.join(WIN_APP_DATA, "Microsoft\\Edge Beta\\Application\\msedge.exe"),   // Beta localappdata
-    "C:\\Program Files (x86)\\Microsoft\\Edge Dev\\Application\\msedge.exe",    // Dev
-    path.join(WIN_APP_DATA, "Microsoft\\Edge Dev\\Application\\msedge.exe"),    // Dev localappdata
-    "C:\\Program Files (x86)\\Microsoft\\Edge SxS\\Application\\msedge.exe",    // Canary
-    path.join(WIN_APP_DATA, "Microsoft\\Edge SxS\\Application\\msedge.exe"),    // Canary localappdata
-];
-const OSX_MSEDGE_PATHS = [
-    "/Applications/Microsoft Edge.app/Contents/MacOS/Microsoft Edge",
-    "/Applications/Microsoft Edge Beta.app/Contents/MacOS/Microsoft Edge Beta",
-    "/Applications/Microsoft Edge Dev.app/Contents/MacOS/Microsoft Edge Dev",
-    "/Applications/Microsoft Edge Canary.app/Contents/MacOS/Microsoft Edge Canary",
-];
+const msEdgeBrowserMapping: Map<BrowserFlavor, IBrowserPath> = new Map();
 
 export interface IRemoteTargetJson {
     [index: string]: string;
@@ -214,7 +209,7 @@ export function getRemoteEndpointSettings(config: Partial<IUserConfig> = {}): ID
     // We generate a temp directory if the user opted in explicitly with 'true' (which is the default),
     // Or if it is not defined and they are not using a custom browser path (such as electron).
     // This matches the behavior of the chrome and edge debug extensions.
-    const browserPath = config.browserPath || settings.get("browserPath") || "";
+    const browserPathSet = config.browserFlavor !== "default";
     let userDataDir: string | boolean | undefined;
     if (typeof config.userDataDir !== "undefined") {
         userDataDir = config.userDataDir;
@@ -225,7 +220,7 @@ export function getRemoteEndpointSettings(config: Partial<IUserConfig> = {}): ID
         }
     }
 
-    if (userDataDir === true || (typeof userDataDir === "undefined" && !browserPath)) {
+    if (userDataDir === true || (typeof userDataDir === "undefined" && browserPathSet)) {
         // Generate a temp directory
         userDataDir = path.join(os.tmpdir(), `vscode-edge-devtools-userdatadir_${port}`);
     } else if (!userDataDir) {
@@ -261,32 +256,25 @@ export function getPlatform(): Platform {
 }
 
 /**
- * Get the path to the first valid browser for the current session
- * The search order is: launchConfig > vscode setting > platform default
- * For each platform the order is: stable > beta > dev > canary
- * For windows we will try: program files > local app data
+ * Gets the browser path for the specified browser flavor.
  * @param config The settings specified by a launch config, if any
  */
-export async function getBrowserPath(config: Partial<IUserConfig> = {}) {
+export async function getBrowserPath(config: Partial<IUserConfig> = {}): Promise<string> {
     const settings = vscode.workspace.getConfiguration(SETTINGS_STORE_NAME);
-    const browserPath = config.browserPath || settings.get("browserPath") || "";
+    const flavor: BrowserFlavor | undefined = config.browserFlavor || settings.get("browserFlavor");
 
-    if (!browserPath) {
-        const platform = getPlatform();
-        const searchPaths = platform === "Windows" ? WIN_MSEDGE_PATHS :
-            platform === "OSX" ? OSX_MSEDGE_PATHS :
-                [];
-
-        // Find the first one that exists
-        for (const p of searchPaths) {
-            if (await fse.pathExists(p)) {
-                return p;
-            }
+    switch (getPlatform()) {
+        case "Windows": {
+           return await verifyFlavorPath(flavor, "Windows");
+           break;
+        }
+        case "OSX": {
+            return await verifyFlavorPath(flavor, "OSX");
+            break;
         }
     }
 
-    // Only return it if it exists
-    return (await fse.pathExists(browserPath) ? browserPath : "");
+    return "";
 }
 
 /**
@@ -451,3 +439,80 @@ export function applyPathMapping(
 
     return sourcePath;
 }
+
+/**
+ * Verifies and returns if the browser for the current session exists in the
+ * desired flavor and platform. Providing a "default" flavor will scan for the
+ * first browser available in the following order:
+ * stable > beta > dev > canary
+ * For windows it will try: program files > local app data
+ * @param flavor the desired browser flavor
+ * @param platform the desired platform
+ * @returns a promise with the path to the browser or an empty string if not found.
+ */
+async function verifyFlavorPath(flavor: BrowserFlavor | undefined, platform: Platform): Promise<string> {
+    let item = msEdgeBrowserMapping.get(flavor || "default");
+    if (!item) {
+        // if no flavor is specified search for any path present.
+        for (item of msEdgeBrowserMapping.values()) {
+            const result = await findFlavorPath(item);
+            if (result) {
+                return result;
+            }
+        }
+    }
+
+    return await findFlavorPath(item);
+
+    // Verifies if the path existis in disk.
+    async function findFlavorPath(browserPath: IBrowserPath | undefined) {
+        if (!browserPath) {
+            return "";
+        }
+
+        if (await fse.pathExists(browserPath.windows.primary) &&
+            (platform === "Windows" || flavor === "default")) {
+            return browserPath.windows.primary;
+        } else if (await fse.pathExists(browserPath.windows.secondary) &&
+            (platform === "Windows" || flavor === "default")) {
+            return browserPath.windows.secondary;
+        } else if (await fse.pathExists(browserPath.osx) &&
+            (platform === "OSX" || flavor === "default")) {
+            return browserPath.osx;
+        }
+
+        return "";
+    }
+}
+
+(function initialize() {
+    // insertion order matters.
+    msEdgeBrowserMapping.set("stable", {
+        osx: "/Applications/Microsoft Edge.app/Contents/MacOS/Microsoft Edge",
+        windows: {
+            primary: "C:\\Program Files (x86)\\Microsoft\\Edge\\Application\\msedge.exe",
+            secondary: path.join(WIN_APP_DATA, "Microsoft\\Edge\\Application\\msedge.exe"),
+        },
+    });
+    msEdgeBrowserMapping.set("beta", {
+        osx: "/Applications/Microsoft Edge Beta.app/Contents/MacOS/Microsoft Edge Beta",
+        windows: {
+            primary: "C:\\Program Files (x86)\\Microsoft\\Edge Beta\\Application\\msedge.exe",
+            secondary: path.join(WIN_APP_DATA, "Microsoft\\Edge Beta\\Application\\msedge.exe"),
+        },
+    });
+    msEdgeBrowserMapping.set("dev", {
+        osx: "/Applications/Microsoft Edge Dev.app/Contents/MacOS/Microsoft Edge Dev",
+        windows: {
+            primary: "C:\\Program Files (x86)\\Microsoft\\Edge Dev\\Application\\msedge.exe",
+            secondary: path.join(WIN_APP_DATA, "Microsoft\\Edge Dev\\Application\\msedge.exe"),
+        },
+    });
+    msEdgeBrowserMapping.set("canary", {
+        osx: "/Applications/Microsoft Edge Canary.app/Contents/MacOS/Microsoft Edge Canary",
+        windows: {
+            primary: "C:\\Program Files (x86)\\Microsoft\\Edge SxS\\Application\\msedge.exe",
+            secondary: path.join(WIN_APP_DATA, "Microsoft\\Edge SxS\\Application\\msedge.exe"),
+        },
+    });
+})();

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -14,7 +14,7 @@ import TelemetryReporter from "vscode-extension-telemetry";
 import packageJson from "../package.json";
 import DebugTelemetryReporter from "./debugTelemetryReporter";
 
-export type BrowserFlavor = "default" | "stable" | "beta" | "dev" | "canary";
+export type BrowserFlavor = "Default" | "Stable" | "Beta" | "Dev" | "Canary";
 
 interface IBrowserPath {
     windows: {
@@ -209,7 +209,7 @@ export function getRemoteEndpointSettings(config: Partial<IUserConfig> = {}): ID
     // We generate a temp directory if the user opted in explicitly with 'true' (which is the default),
     // Or if it is not defined and they are not using a custom browser path (such as electron).
     // This matches the behavior of the chrome and edge debug extensions.
-    const browserPathSet = config.browserFlavor !== "default";
+    const browserPathSet = config.browserFlavor !== "Default";
     let userDataDir: string | boolean | undefined;
     if (typeof config.userDataDir !== "undefined") {
         userDataDir = config.userDataDir;
@@ -451,7 +451,7 @@ export function applyPathMapping(
  * @returns a promise with the path to the browser or an empty string if not found.
  */
 async function verifyFlavorPath(flavor: BrowserFlavor | undefined, platform: Platform): Promise<string> {
-    let item = msEdgeBrowserMapping.get(flavor || "default");
+    let item = msEdgeBrowserMapping.get(flavor || "Default");
     if (!item) {
         // if no flavor is specified search for any path present.
         for (item of msEdgeBrowserMapping.values()) {
@@ -471,13 +471,13 @@ async function verifyFlavorPath(flavor: BrowserFlavor | undefined, platform: Pla
         }
 
         if (await fse.pathExists(browserPath.windows.primary) &&
-            (platform === "Windows" || flavor === "default")) {
+            (platform === "Windows" || flavor === "Default")) {
             return browserPath.windows.primary;
         } else if (await fse.pathExists(browserPath.windows.secondary) &&
-            (platform === "Windows" || flavor === "default")) {
+            (platform === "Windows" || flavor === "Default")) {
             return browserPath.windows.secondary;
         } else if (await fse.pathExists(browserPath.osx) &&
-            (platform === "OSX" || flavor === "default")) {
+            (platform === "OSX" || flavor === "Default")) {
             return browserPath.osx;
         }
 
@@ -487,28 +487,28 @@ async function verifyFlavorPath(flavor: BrowserFlavor | undefined, platform: Pla
 
 (function initialize() {
     // insertion order matters.
-    msEdgeBrowserMapping.set("stable", {
+    msEdgeBrowserMapping.set("Stable", {
         osx: "/Applications/Microsoft Edge.app/Contents/MacOS/Microsoft Edge",
         windows: {
             primary: "C:\\Program Files (x86)\\Microsoft\\Edge\\Application\\msedge.exe",
             secondary: path.join(WIN_APP_DATA, "Microsoft\\Edge\\Application\\msedge.exe"),
         },
     });
-    msEdgeBrowserMapping.set("beta", {
+    msEdgeBrowserMapping.set("Beta", {
         osx: "/Applications/Microsoft Edge Beta.app/Contents/MacOS/Microsoft Edge Beta",
         windows: {
             primary: "C:\\Program Files (x86)\\Microsoft\\Edge Beta\\Application\\msedge.exe",
             secondary: path.join(WIN_APP_DATA, "Microsoft\\Edge Beta\\Application\\msedge.exe"),
         },
     });
-    msEdgeBrowserMapping.set("dev", {
+    msEdgeBrowserMapping.set("Dev", {
         osx: "/Applications/Microsoft Edge Dev.app/Contents/MacOS/Microsoft Edge Dev",
         windows: {
             primary: "C:\\Program Files (x86)\\Microsoft\\Edge Dev\\Application\\msedge.exe",
             secondary: path.join(WIN_APP_DATA, "Microsoft\\Edge Dev\\Application\\msedge.exe"),
         },
     });
-    msEdgeBrowserMapping.set("canary", {
+    msEdgeBrowserMapping.set("Canary", {
         osx: "/Applications/Microsoft Edge Canary.app/Contents/MacOS/Microsoft Edge Canary",
         windows: {
             primary: "C:\\Program Files (x86)\\Microsoft\\Edge SxS\\Application\\msedge.exe",


### PR DESCRIPTION
This PR removes the _browserPath setting_ and creates a _browser flavor combo box_ for a similar purpose.

![image](https://user-images.githubusercontent.com/43078681/82618496-1a75b280-9b88-11ea-875c-0f86ce1392e3.png)

**Current Behavior:**
The user can specify (via a input box) the path to a browser version, when no path is specified the extension searches for stable > beta > dev > canary (in that order) until an existing version is found on disk.

**New Behavior**
When default is selected, extension will keep current behavior, otherwise it will use the version specified by the user. 

Test are also modified to use a specific flavor instead of a custom path.
