### PR TITLE
inspectorContentPolicy polyfill refactor

### DIFF
--- a/src/host/polyfills/inspectorContentPolicy.test.ts
+++ b/src/host/polyfills/inspectorContentPolicy.test.ts
@@ -1,18 +1,21 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+import { getTextFromFile } from "../../test/helpers";
 
 describe("inspectorContentPolicy", () => {
     it("applyContentSecurityPolicyPatch correctly changes text", async () => {
+        //const comparableText = "script-src 'self' 'unsafe-eval' <meta name=\"referrer\" content=\"no-referrer\">";
+        let fileContents = getTextFromFile("inspector.html");
+
+        // The file was not found, so test that at least the text is being replaced.
+        fileContents = fileContents ? fileContents : "aaa";
+
         const apply = await import("./inspectorContentPolicy");
-        const result = apply.applyContentSecurityPolicyPatch(
-            `Content-Security-Policy" content="script-src 'self' 'unsafe-eval'"`);
+        const result = apply.applyContentSecurityPolicyPatch(fileContents);
         expect(result).toEqual(
             expect.stringContaining(
-                `Content-Security-Policy" content="script-src vscode-resource: 'self' 'unsafe-eval'"`));
-
-        const result2 = apply.applyContentSecurityPolicyPatch(
-            `<meta name="referrer" content="no-referrer">`);
-        expect(result2).toEqual(
+                `script-src vscode-resource: 'self'`));
+        expect(result).toEqual(
             expect.stringContaining(
                 `<script src="../../host/host.bundle.js"></script>`));
     });

--- a/src/host/polyfills/inspectorContentPolicy.test.ts
+++ b/src/host/polyfills/inspectorContentPolicy.test.ts
@@ -4,11 +4,11 @@ import { getTextFromFile } from "../../test/helpers";
 
 describe("inspectorContentPolicy", () => {
     it("applyContentSecurityPolicyPatch correctly changes text", async () => {
-        //const comparableText = "script-src 'self' 'unsafe-eval' <meta name=\"referrer\" content=\"no-referrer\">";
+        const comparableText = "script-src 'self' 'unsafe-eval' <meta name=\"referrer\" content=\"no-referrer\">";
         let fileContents = getTextFromFile("inspector.html");
 
         // The file was not found, so test that at least the text is being replaced.
-        fileContents = fileContents ? fileContents : "aaa";
+        fileContents = fileContents ? fileContents : comparableText;
 
         const apply = await import("./inspectorContentPolicy");
         const result = apply.applyContentSecurityPolicyPatch(fileContents);

--- a/src/host/polyfills/inspectorContentPolicy.test.ts
+++ b/src/host/polyfills/inspectorContentPolicy.test.ts
@@ -4,11 +4,11 @@ import { getTextFromFile } from "../../test/helpers";
 
 describe("inspectorContentPolicy", () => {
     it("applyContentSecurityPolicyPatch correctly changes text", async () => {
-        const comparableText = "script-src 'self' 'unsafe-eval' <meta name=\"referrer\" content=\"no-referrer\">";
-        let fileContents = getTextFromFile("inspector.html");
-
-        // The file was not found, so test that at least the text is being replaced.
-        fileContents = fileContents ? fileContents : comparableText;
+        const filePath = "inspector.html";
+        const fileContents = getTextFromFile(filePath);
+        if (!fileContents) {
+            throw new Error(`Could not find file: ${filePath}`);
+        }
 
         const apply = await import("./inspectorContentPolicy");
         const result = apply.applyContentSecurityPolicyPatch(fileContents);

--- a/src/host/polyfills/inspectorContentPolicy.ts
+++ b/src/host/polyfills/inspectorContentPolicy.ts
@@ -11,7 +11,7 @@ export function applyContentSecurityPolicyPatch(content: string) {
     }
 
     const metaString = `<meta name="referrer" content="no-referrer">`;
-    if (result.indexOf(metaString) !== -1) {
+    if (result.match(metaString)) {
         return result.replace(metaString, `<script src="../../host/host.bundle.js"></script>`);
     } else {
         return null;

--- a/src/host/polyfills/inspectorContentPolicy.ts
+++ b/src/host/polyfills/inspectorContentPolicy.ts
@@ -10,7 +10,7 @@ export function applyContentSecurityPolicyPatch(content: string) {
         return null;
     }
 
-    const metaString = `<meta name="referrer" content="no-referrer">`
+    const metaString = `<meta name="referrer" content="no-referrer">`;
     if (result.indexOf(metaString) !== -1) {
         return result.replace(metaString, `<script src="../../host/host.bundle.js"></script>`);
     } else {

--- a/src/host/polyfills/inspectorContentPolicy.ts
+++ b/src/host/polyfills/inspectorContentPolicy.ts
@@ -2,12 +2,18 @@
 // Licensed under the MIT License.
 
 export function applyContentSecurityPolicyPatch(content: string) {
-    return content
-        .replace(
-            /script-src\s*'self'/g,
-            `script-src vscode-resource: 'self'`)
-        .replace(
-            `<meta name="referrer" content="no-referrer">`,
-            `<script src="../../host/host.bundle.js"></script>`,
-        );
+    const scriptPattern = /script-src\s*'self'/g;
+    let result;
+    if (content.match(scriptPattern)) {
+        result = content.replace(scriptPattern, `script-src vscode-resource: 'self'`);
+    } else {
+        return null;
+    }
+
+    const metaString = `<meta name="referrer" content="no-referrer">`
+    if (result.indexOf(metaString) !== -1) {
+        return result.replace(metaString, `<script src="../../host/host.bundle.js"></script>`);
+    } else {
+        return null;
+    }
 }


### PR DESCRIPTION
Modifying inspectorContentPolicy polyfill to return null when no text is replaced. Modifying inspectorContentPolicy tests to take code from the source file.