### PR TITLE
Fix pipeline: Adding platform args to download script and adding unzipping bash script

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -23,8 +23,8 @@ steps:
     curl "$output" --output $(Agent.TempDirectory)/edge.zip
   displayName: Downloading Edge Zip (Windows x64)
 - script: |
-    unzip $(Agent.TempDirectory)/edge.zip Microsoft\ Edge\ DevTools_81.0.416.72/src/out/Release/gen/devtools/* -d $(Agent.TempDirectory)/edge
-    unzip $(Agent.TempDirectory)/edge.zip Microsoft\ Edge\ DevTools_81.0.416.72/src/third_party/devtools-frontend/src/front_end/* -d $(Agent.TempDirectory)/edge
+    chmod +rwx scripts/pipelineUnzipEdge.sh
+    ./scripts/pipelineUnzipEdge.sh $(Agent.TempDirectory)/edge.zip $(Agent.TempDirectory)/edge
   displayName: Extracting Relevant Files
 - script: |
     export EDGE_CHROMIUM_PATH=$(Agent.TempDirectory)/edge/src

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -19,12 +19,12 @@ steps:
     npm install
   displayName: 'npm install'
 - script: |
-    output=$(node scripts/retrieveDownloadLink.js)
+    output=$(node scripts/retrieveDownloadLink.js win)
     curl "$output" --output $(Agent.TempDirectory)/edge.zip
-  displayName: Downloading Edge Zip
+  displayName: Downloading Edge Zip (Windows x64)
 - script: |
-    unzip $(Agent.TempDirectory)/edge.zip src/out/Release/gen/devtools/* -d $(Agent.TempDirectory)/edge
-    unzip $(Agent.TempDirectory)/edge.zip src/third_party/devtools-frontend/src/front_end/* -d $(Agent.TempDirectory)/edge
+    unzip $(Agent.TempDirectory)/edge.zip Microsoft\ Edge\ DevTools_81.0.416.72/src/out/Release/gen/devtools/* -d $(Agent.TempDirectory)/edge
+    unzip $(Agent.TempDirectory)/edge.zip Microsoft\ Edge\ DevTools_81.0.416.72/src/third_party/devtools-frontend/src/front_end/* -d $(Agent.TempDirectory)/edge
   displayName: Extracting Relevant Files
 - script: |
     export EDGE_CHROMIUM_PATH=$(Agent.TempDirectory)/edge/src

--- a/scripts/pipelineUnzipEdge.sh
+++ b/scripts/pipelineUnzipEdge.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+{
+    unzip $1 src/out/Release/gen/devtools/* -d $2
+    unzip $1 src/third_party/devtools-frontend/src/front_end/* -d $2
+} || {
+    unzip $1 */src/out/Release/gen/devtools/* -d $2
+    unzip $1 */src/third_party/devtools-frontend/src/front_end/* -d $2
+    mv $2/*/src $2/
+    find $2/. -maxdepth 1 -type d -exec rmdir {} 2>/dev/null \;
+}

--- a/scripts/retrieveDownloadLink.js
+++ b/scripts/retrieveDownloadLink.js
@@ -7,10 +7,6 @@ function fetchJsonFromUrl(url){
 }
 
 function fetchDownloadUrl(platform) {
-  if (!platform) {
-    console.log('Invalid platform');
-    return;
-  }
   const jsonString = fetchJsonFromUrl("https://thirdpartysource.microsoft.com/downloads");
   const jsonObjects = JSON.parse(jsonString);
   for (let object of jsonObjects) {
@@ -22,11 +18,11 @@ function fetchDownloadUrl(platform) {
 
 function retrievePlatform() {
   const arg = process.argv.slice(2)[0];
-  switch (arg) {
-    case 'win':
-      return 'Windows x64';
+  switch (arg.toLowerCase()) {
     case 'mac':
       return 'Mac OS x64';
+    default:
+      return 'Windows x64';
   }
 }
 

--- a/scripts/retrieveDownloadLink.js
+++ b/scripts/retrieveDownloadLink.js
@@ -6,14 +6,29 @@ function fetchJsonFromUrl(url){
   return Httpreq.responseText;
 }
 
-function fetchDownloadUrl() {
+function fetchDownloadUrl(platform) {
+  if (!platform) {
+    console.log('Invalid platform');
+    return;
+  }
   const jsonString = fetchJsonFromUrl("https://thirdpartysource.microsoft.com/downloads");
   const jsonObjects = JSON.parse(jsonString);
   for (let object of jsonObjects) {
-    if (object.product === 'Microsoft Edge DevTools' && object.release === '81.0.416.72') {
+    if (object.product === 'Microsoft Edge DevTools' && object.release === '81.0.416.72' && object.platform === platform) {
       console.log(object.url);
     }
   }
 }
 
-fetchDownloadUrl();
+function retrievePlatform() {
+  const arg = process.argv.slice(2)[0];
+  switch (arg) {
+    case 'win':
+      return 'Windows x64';
+    case 'mac':
+      return 'Mac OS x64';
+  }
+}
+
+const platform = retrievePlatform();
+fetchDownloadUrl(platform);

--- a/scripts/unzipEdge.sh
+++ b/scripts/unzipEdge.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+{
+    unzip $1 src/out/Release/gen/devtools/* -d $2
+    unzip $1 src/out/Release/gen/devtools/*/* -d $2
+    unzip $1 src/third_party/devtools-frontend/src/front_end/*/* -d $2
+    unzip $1 src/third_party/devtools-frontend/src/front_end/*/*/* -d $2
+} || {
+    unzip $1 */src/out/Release/gen/devtools/* -d $2
+    unzip $1 */src/out/Release/gen/devtools/*/* -d $2
+    unzip $1 */src/third_party/devtools-frontend/src/front_end/*/* -d $2
+    unzip $1 */src/third_party/devtools-frontend/src/front_end/*/*/* -d $2
+    mv $2/*/src $2/
+    find $2/. -maxdepth 1 -type d -exec rmdir {} 2>/dev/null \;
+}


### PR DESCRIPTION
# Changes
- updating retrieveDownloadLink to accept an argument for which platform
- Adding scripts for windows users and for the pipeline to easily extract from the .zip file
- unzipEdge.sh works best for Windows users downloading the DevTools .zip
- pipelineUnzipEdge.sh performs the same function with minor changes to work in a linux based environment