### PR TITLE
[Pipeline]: Adding Mac job to the pipeline

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -60,18 +60,18 @@ jobs:
       npm run download-edge
     displayName: Downloading And Extracting Edge Zip (Windows x64)
   - script: |
-      export EDGE_CHROMIUM_PATH=$(Build.Repository.LocalPath)/out/edge/src
-      export EDGE_CHROMIUM_OUT_DIR=Release
+      set EDGE_CHROMIUM_PATH=$(Build.Repository.LocalPath)/out/edge/src
+      set EDGE_CHROMIUM_OUT_DIR=Release
       npm run build
     displayName: Building
   - script: |
-      export EDGE_CHROMIUM_PATH=$(Build.Repository.LocalPath)/out/edge/src
-      export EDGE_CHROMIUM_OUT_DIR=Release
+      set EDGE_CHROMIUM_PATH=$(Build.Repository.LocalPath)/out/edge/src
+      set EDGE_CHROMIUM_OUT_DIR=Release
       npm run test
     displayName: Linting and Testing
   - script: |
-      export EDGE_CHROMIUM_PATH=$(Build.Repository.LocalPath)/out/edge/src
-      export EDGE_CHROMIUM_OUT_DIR=Release
+      set EDGE_CHROMIUM_PATH=$(Build.Repository.LocalPath)/out/edge/src
+      set EDGE_CHROMIUM_OUT_DIR=Release
       npm run package
     displayName: Creating .vsix
   - task: CopyFiles@2

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -38,10 +38,10 @@ jobs:
       npm run package
     displayName: Creating .vsix
   - task: CopyFiles@2
-    displayName: 'Copy Files to: $(Build.ArtifactStagingDirectory)'
+    displayName: 'Copy Files to: $(Build.ArtifactStagingDirectory)/mac_drop'
     inputs:
       Contents: '*.vsix'
-      TargetFolder: '$(Build.ArtifactStagingDirectory)'
+      TargetFolder: '$(Build.ArtifactStagingDirectory)/mac_drop'
   - task: PublishBuildArtifacts@1
     displayName: 'Publish Artifact: drop'
 - job: Windows
@@ -75,9 +75,9 @@ jobs:
       npm run package
     displayName: Creating .vsix
   - task: CopyFiles@2
-    displayName: 'Copy Files to: $(Build.ArtifactStagingDirectory)'
+    displayName: 'Copy Files to: $(Build.ArtifactStagingDirectory)/win_drop'
     inputs:
       Contents: '*.vsix'
-      TargetFolder: '$(Build.ArtifactStagingDirectory)'
+      TargetFolder: '$(Build.ArtifactStagingDirectory)/win_drop'
   - task: PublishBuildArtifacts@1
     displayName: 'Publish Artifact: drop'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -6,40 +6,78 @@
 trigger:
 - master
 
-pool:
-  vmImage: 'ubuntu-latest'
-
-steps:
-- checkout: self
-- task: NodeTool@0
-  inputs:
-    versionSpec: '10.x'
-  displayName: Install Node.js
-- script: |
-    npm install
-  displayName: Install Dependencies
-- script: |
-    npm run download-edge
-  displayName: Downloading And Extracting Edge Zip (Windows x64)
-- script: |
-    export EDGE_CHROMIUM_PATH=$(Build.Repository.LocalPath)/out/edge/src
-    export EDGE_CHROMIUM_OUT_DIR=Release
-    npm run build
-  displayName: Building
-- script: |
-    export EDGE_CHROMIUM_PATH=$(Build.Repository.LocalPath)/out/edge/src
-    export EDGE_CHROMIUM_OUT_DIR=Release
-    npm run test
-  displayName: Linting and Testing
-- script: |
-    export EDGE_CHROMIUM_PATH=$(Build.Repository.LocalPath)/out/edge/src
-    export EDGE_CHROMIUM_OUT_DIR=Release
-    npm run package
-  displayName: Creating .vsix
-- task: CopyFiles@2
-  displayName: 'Copy Files to: $(Build.ArtifactStagingDirectory)'
-  inputs:
-    Contents: '*.vsix'
-    TargetFolder: '$(Build.ArtifactStagingDirectory)'
-- task: PublishBuildArtifacts@1
-  displayName: 'Publish Artifact: drop'
+jobs:
+- job: MacOS
+  pool:
+    vmImage: 'macOs-latest'
+  steps:
+  - checkout: self
+  - task: NodeTool@0
+    inputs:
+      versionSpec: '10.x'
+    displayName: Install Node.js
+  - script: |
+      npm install
+    displayName: Install Dependencies
+  - script: |
+      npm run download-edge
+    displayName: Downloading And Extracting Edge Zip (Windows x64)
+  - script: |
+      export EDGE_CHROMIUM_PATH=$(Build.Repository.LocalPath)/out/edge/src
+      export EDGE_CHROMIUM_OUT_DIR=Release
+      npm run build
+    displayName: Building
+  - script: |
+      export EDGE_CHROMIUM_PATH=$(Build.Repository.LocalPath)/out/edge/src
+      export EDGE_CHROMIUM_OUT_DIR=Release
+      npm run test
+    displayName: Linting and Testing
+  - script: |
+      export EDGE_CHROMIUM_PATH=$(Build.Repository.LocalPath)/out/edge/src
+      export EDGE_CHROMIUM_OUT_DIR=Release
+      npm run package
+    displayName: Creating .vsix
+  - task: CopyFiles@2
+    displayName: 'Copy Files to: $(Build.ArtifactStagingDirectory)'
+    inputs:
+      Contents: '*.vsix'
+      TargetFolder: '$(Build.ArtifactStagingDirectory)'
+  - task: PublishBuildArtifacts@1
+    displayName: 'Publish Artifact: drop'
+- job: Windows
+  pool:
+    vmImage: 'windows-latest'
+  steps:
+  - checkout: self
+  - task: NodeTool@0
+    inputs:
+      versionSpec: '10.x'
+    displayName: Install Node.js
+  - script: |
+      npm install
+    displayName: Install Dependencies
+  - script: |
+      npm run download-edge
+    displayName: Downloading And Extracting Edge Zip (Windows x64)
+  - script: |
+      export EDGE_CHROMIUM_PATH=$(Build.Repository.LocalPath)/out/edge/src
+      export EDGE_CHROMIUM_OUT_DIR=Release
+      npm run build
+    displayName: Building
+  - script: |
+      export EDGE_CHROMIUM_PATH=$(Build.Repository.LocalPath)/out/edge/src
+      export EDGE_CHROMIUM_OUT_DIR=Release
+      npm run test
+    displayName: Linting and Testing
+  - script: |
+      export EDGE_CHROMIUM_PATH=$(Build.Repository.LocalPath)/out/edge/src
+      export EDGE_CHROMIUM_OUT_DIR=Release
+      npm run package
+    displayName: Creating .vsix
+  - task: CopyFiles@2
+    displayName: 'Copy Files to: $(Build.ArtifactStagingDirectory)'
+    inputs:
+      Contents: '*.vsix'
+      TargetFolder: '$(Build.ArtifactStagingDirectory)'
+  - task: PublishBuildArtifacts@1
+    displayName: 'Publish Artifact: drop'


### PR DESCRIPTION
This PR separates Mac and Windows runs in the pipeline.  They download separate zip files and publish the .vsix artifacts to different artifact folders.  An example run can be found [here](https://dev.azure.com/edgedevtools/vscode-edge-devtools-ci/_build/results?buildId=372&view=logs&j=a5e52b91-c83f-5429-4a68-c246fc63a4f7)