### PR TITLE
Removing debug mode.

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -16,21 +16,6 @@
             ],
             "preLaunchTask": "npm: build"
         },
-	{
-            "name": "Launch Extension (Development mode)",
-            "type": "extensionHost",
-            "request": "launch",
-            "runtimeExecutable": "${execPath}",
-            "args": [
-                "--extensionDevelopmentPath=${workspaceFolder}"
-            ],
-            "stopOnEntry": false,
-            "sourceMaps": true,
-            "outFiles": [
-                "${workspaceFolder}/out/**/*.js"
-            ],
-            "preLaunchTask": "npm: build-debug"
-        },
         {
             "name": "Debug postbuild step",
             "type": "node",

--- a/postBuildStep.ts
+++ b/postBuildStep.ts
@@ -31,7 +31,7 @@ async function copyFile(srcDir: string, outDir: string, name: string) {
     );
 }
 
-async function copyStaticFiles(debugMode: boolean) {
+async function copyStaticFiles() {
     // Copy the static css file to the out directory
     const commonSrcDir = "./src/common/";
     const commonOutDir = "./out/common/";
@@ -40,7 +40,7 @@ async function copyStaticFiles(debugMode: boolean) {
 
     // Must set environment variables EDGE_CHROMIUM_PATH and EDGE_CHROMIUM_OUT_DIR
     // E.g. set EDGE_CHROMIUM_PATH=F:/git/Edge/src
-    //      set EDGE_CHROMIUM_OUT_DIR=debug_x64
+    //      set EDGE_CHROMIUM_OUT_DIR=Release
     // See CONTRIBUTING.md for more details
 
     const toolsSrcDir =
@@ -80,125 +80,74 @@ async function copyStaticFiles(debugMode: boolean) {
     }
 
     // Patch older versions of the webview with our workarounds
-    await patchFilesForWebView(toolsOutDir, debugMode);
+    await patchFilesForWebView(toolsOutDir);
 }
 
-async function patchFilesForWebView(toolsOutDir: string, debugMode: boolean) {
-    // Release file versions
-    if (!debugMode) {
-        // tslint:disable-next-line:no-console
-        console.log("Patching files for release version");
-        await patchFileForWebViewWrapper("shell.js", toolsOutDir, true, [
-            applyInspectorCommonContextMenuPatch,
-            applyInspectorCommonCssRightToolbarPatch,
-            applyInspectorCommonCssPatch,
-            applyInspectorCommonNetworkPatch,
-            applyInspectorCommonCssTabSliderPatch,
-        ]);
-        await patchFileForWebViewWrapper("main/main.js", toolsOutDir, true, [
-            applyMainViewPatch,
-        ]);
-        await patchFileForWebViewWrapper("elements/elements.js", toolsOutDir, true, [
-            applySetupTextSelectionPatch,
-        ]);
-        await patchFileForWebViewWrapper("common/common.js", toolsOutDir, true, [
-            applyCommonRevealerPatch,
-        ]);
-        await patchFileForWebViewWrapper("elements/elements_module.js", toolsOutDir, true, [
-            applyPaddingInlineCssPatch,
-        ]);
-        await patchFileForWebViewWrapper("inspector.html", toolsOutDir, true, [
-            applyContentSecurityPolicyPatch,
-        ]);
-        await patchFileForWebViewWrapper("ui/ui.js", toolsOutDir, true, [
-            applyDrawerTabLocationPatch,
-            applyAppendTabPatch,
-            applyPersistRequestBlockingTab,
-            applySetTabIconPatch,
-            applyShowElementsTab,
-            applyShowRequestBlockingTab,
-        ]);
+async function patchFilesForWebView(toolsOutDir: string) {
+    // tslint:disable-next-line:no-console
+    console.log("Patching files.");
+    await patchFileForWebViewWrapper("shell.js", toolsOutDir, [
+        applyInspectorCommonContextMenuPatch,
+        applyInspectorCommonCssRightToolbarPatch,
+        applyInspectorCommonCssPatch,
+        applyInspectorCommonNetworkPatch,
+        applyInspectorCommonCssTabSliderPatch,
+    ]);
+    await patchFileForWebViewWrapper("main/main.js", toolsOutDir, [
+        applyMainViewPatch,
+    ]);
+    await patchFileForWebViewWrapper("elements/elements.js", toolsOutDir, [
+        applySetupTextSelectionPatch,
+    ]);
+    await patchFileForWebViewWrapper("common/common.js", toolsOutDir, [
+        applyCommonRevealerPatch,
+    ]);
+    await patchFileForWebViewWrapper("elements/elements_module.js", toolsOutDir, [
+        applyPaddingInlineCssPatch,
+    ]);
+    await patchFileForWebViewWrapper("inspector.html", toolsOutDir, [
+        applyContentSecurityPolicyPatch,
+    ]);
+    await patchFileForWebViewWrapper("ui/ui.js", toolsOutDir, [
+        applyDrawerTabLocationPatch,
+        applyAppendTabPatch,
+        applyPersistRequestBlockingTab,
+        applySetTabIconPatch,
+        applyShowElementsTab,
+        applyShowRequestBlockingTab,
+    ]);
 
-        await patchFileForWebViewWrapper("root/root.js", toolsOutDir, true, [
-            applyRuntimeImportScriptPathPrefixPatch,
-        ]);
+    await patchFileForWebViewWrapper("root/root.js", toolsOutDir, [
+        applyRuntimeImportScriptPathPrefixPatch,
+    ]);
 
-        await patchFileForWebViewWrapper("ui/ui.js", toolsOutDir, true, [
-            applyHandleActionPatch,
-        ]);
-        await patchFileForWebViewWrapper("ui/ui.js", toolsOutDir, true, [
-            applyHandleActionPatch,
-        ]);
-    } else {
-        // tslint:disable-next-line:no-console
-        console.log("Patching files for debug version");
-        await patchFileForWebViewWrapper("main/main.js", toolsOutDir, false, [
-            applyMainViewPatch,
-        ]);
-        await patchFileForWebViewWrapper("common/common.js", toolsOutDir, false, [
-            applyCommonRevealerPatch,
-        ]);
-        await patchFileForWebViewWrapper("elements/elements_module.js", toolsOutDir, false, [
-            applyPaddingInlineCssPatch,
-        ]);
-        await patchFileForWebViewWrapper("inspector.html", toolsOutDir, false, [
-            applyContentSecurityPolicyPatch,
-        ]);
-        await patchFileForWebViewWrapper("ui/ui.js", toolsOutDir, false, [
-            applyDrawerTabLocationPatch,
-            applyAppendTabPatch,
-            applyPersistRequestBlockingTab,
-            applySetTabIconPatch,
-            applyShowElementsTab,
-            applyShowRequestBlockingTab,
-        ]);
-        await patchFileForWebViewWrapper("quick_open/QuickOpen.js", toolsOutDir, true, [
-            applyHandleActionPatch,
-        ]);
-        await patchFileForWebViewWrapper("quick_open/CommandMenu.js", toolsOutDir, true, [
-            applyHandleActionPatch,
-        ]);
-        // Debug file versions
-        await patchFileForWebViewWrapper("elements/ElementsPanel.js", toolsOutDir, false, [
-            applySetupTextSelectionPatch,
-        ]);
-        await patchFileForWebViewWrapper("themes/base.css", toolsOutDir, false, [
-            applyInspectorCommonContextMenuPatch,
-            applyInspectorCommonCssPatch,
-            applyInspectorCommonNetworkPatch,
-            applyInspectorCommonCssRightToolbarPatch,
-            applyInspectorCommonCssTabSliderPatch,
-        ]);
-        await patchFileForWebViewWrapper("elements/elementsTreeOutline.css", toolsOutDir, false, [
-            applyPaddingInlineCssPatch,
-        ]);
-        await patchFileForWebViewWrapper("elements/stylesSectionTree.css", toolsOutDir, false, [
-            applyPaddingInlineCssPatch,
-        ]);
-    }
+    await patchFileForWebViewWrapper("ui/ui.js", toolsOutDir, [
+        applyHandleActionPatch,
+    ]);
+    await patchFileForWebViewWrapper("ui/ui.js", toolsOutDir, [
+        applyHandleActionPatch,
+    ]);
 }
 
 // This function wraps the patchFileForWebView function to catch any errors thrown, log them
 // and return with an exit code of 1.
 // Returning the exit code of 1 will ensure that the Azure Pipeline will fail when patching fails.
 async function patchFileForWebViewWrapper(
-  filename: string,
-  dir: string,
-  isRelease: boolean,
-  patches: Array<(content: string, isRelease?: boolean) => string | null>) {
-  await patchFileForWebView(filename, dir, isRelease, patches)
-      .catch((errorMessage) => {
-        // tslint:disable-next-line:no-console
-        console.error(errorMessage);
-        process.exit(1);
-      });
+    filename: string,
+    dir: string,
+    patches: Array<(content: string) => string | null>) {
+    await patchFileForWebView(filename, dir, patches)
+        .catch((errorMessage) => {
+            // tslint:disable-next-line:no-console
+            console.error(errorMessage);
+            process.exit(1);
+        });
 }
 
 async function patchFileForWebView(
     filename: string,
     dir: string,
-    isRelease: boolean,
-    patches: Array<(content: string, isRelease?: boolean) => string | null>) {
+    patches: Array<(content: string) => string | null>) {
     const file = path.join(dir, filename);
 
     if (!await fse.pathExists(file)) {
@@ -211,7 +160,7 @@ async function patchFileForWebView(
 
     // Apply each patch in order
     patches.forEach((patchFunction) => {
-        const patchResult: string | null = patchFunction(content, isRelease);
+        const patchResult: string | null = patchFunction(content);
         if (patchResult) {
             content = patchResult;
         } else {
@@ -233,16 +182,11 @@ function isDirectory(fullPath: string) {
 }
 
 function main() {
-    let debugMode = false;
-    if (process.argv && process.argv.length === 3 && process.argv[2] === "debug") {
-        debugMode = true;
-    }
-
-    copyStaticFiles(debugMode)
+    copyStaticFiles()
         .catch((errorMessage) => {
-          // tslint:disable-next-line:no-console
-          console.error(errorMessage);
-          process.exit(1);
+            // tslint:disable-next-line:no-console
+            console.error(errorMessage);
+            process.exit(1);
         });
 }
 

--- a/src/host/polyfills/cssPaddingInline.test.ts
+++ b/src/host/polyfills/cssPaddingInline.test.ts
@@ -12,8 +12,10 @@ describe("cssPaddingInline", () => {
 
         const apply = await import("./cssPaddingInline");
         const result = apply.default(fileContents);
+        const expectedResult =
+        ".elements-disclosure .gutter-container {\\n        display: none !important;\\n    }";
         expect(result).toEqual(
-            expect.stringContaining(".elements-disclosure .gutter-container {\n        display: none !important;"));
+            expect.stringContaining(expectedResult));
     });
 
     it("applyPaddingInlineCssPatch correctly changes padding-inline-start text", async () => {

--- a/src/host/polyfills/cssPaddingInline.ts
+++ b/src/host/polyfills/cssPaddingInline.ts
@@ -1,8 +1,8 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-export default function applyPaddingInlineCssPatch(content: string, isRelease?: boolean) {
-    const separator = (isRelease ? "\\n" : "\n");
+export default function applyPaddingInlineCssPatch(content: string) {
+    const separator = "\\n";
     const cssHeaderContents =
     `.elements-disclosure .gutter-container {
         display: none !important;

--- a/src/host/polyfills/simpleView.test.ts
+++ b/src/host/polyfills/simpleView.test.ts
@@ -190,25 +190,6 @@ describe("simpleView", () => {
 
         const apply = await import("./simpleView");
         const result = apply.applyInspectorCommonCssPatch(fileContents);
-
-        // If this part of the css was correctly applied to the file, the rest of the css will be there as well.
-        const expectedString =
-            ".toolbar-button[aria-label='Toggle screencast'] {\n            visibility: visible !important;";
-        expect(result).not.toEqual(null);
-        if (result) {
-            expect(result).toEqual(expect.stringContaining(expectedString));
-        }
-    });
-
-    it("applyInspectorCommonCssPatch correctly changes text (release)", async () => {
-        const filePath = "shell.js";
-        const fileContents = getTextFromFile(filePath);
-        if (!fileContents) {
-            throw new Error(`Could not find file: ${filePath}`);
-        }
-
-        const apply = await import("./simpleView");
-        const result = apply.applyInspectorCommonCssPatch(fileContents, true);
         // If this part of the css was correctly applied to the file, the rest of the css will be there as well.
         const expectedString =
             ".toolbar-button[aria-label='Toggle screencast'] {\\n            visibility: visible !important;";
@@ -228,25 +209,6 @@ describe("simpleView", () => {
 
         const apply = await import("./simpleView");
         const result = apply.applyInspectorCommonNetworkPatch(fileContents);
-
-        // If this part of the css was correctly applied to the file, the rest of the css will be there as well.
-        const expectedString =
-            ".toolbar-button[aria-label='Export HAR...'] {\n            display: none !important;";
-        expect(result).not.toEqual(null);
-        if (result) {
-            expect(result).toEqual(expect.stringContaining(expectedString));
-        }
-    });
-
-    it("applyInspectorCommonNetworkPatch correctly changes text (release)", async () => {
-        const filePath = "shell.js";
-        const fileContents = getTextFromFile(filePath);
-        if (!fileContents) {
-            throw new Error(`Could not find file: ${filePath}`);
-        }
-
-        const apply = await import("./simpleView");
-        const result = apply.applyInspectorCommonNetworkPatch(fileContents, true);
         // If this part of the css was correctly applied to the file, the rest of the css will be there as well.
         const expectedString =
             ".toolbar-button[aria-label='Export HAR...'] {\\n            display: none !important;";
@@ -266,25 +228,6 @@ describe("simpleView", () => {
 
         const apply = await import("./simpleView");
         const result = apply.applyInspectorCommonContextMenuPatch(fileContents);
-
-        // If this part of the css was correctly applied to the file, the rest of the css will be there as well.
-        const expectedString =
-            ".soft-context-menu-item[aria-label='Save as...'] {\n            display: none !important;";
-        expect(result).not.toEqual(null);
-        if (result) {
-            expect(result).toEqual(expect.stringContaining(expectedString));
-        }
-    });
-
-    it("applyInspectorCommonContextMenuPatch correctly changes text (release)", async () => {
-        const filePath = "shell.js";
-        const fileContents = getTextFromFile(filePath);
-        if (!fileContents) {
-            throw new Error(`Could not find file: ${filePath}`);
-        }
-
-        const apply = await import("./simpleView");
-        const result = apply.applyInspectorCommonContextMenuPatch(fileContents, true);
         // If this part of the css was correctly applied to the file, the rest of the css will be there as well.
         const expectedString =
             ".soft-context-menu-item[aria-label='Save as...'] {\\n            display: none !important;";
@@ -293,22 +236,6 @@ describe("simpleView", () => {
         if (result) {
             expect(result).toEqual(expect.stringContaining(expectedString));
         }
-    });
-
-    it("applyInspectorCommonCssRightToolbarPatch correctly changes tabbed-pane-right-toolbar (release)", async () => {
-        const filePath = "shell.js";
-        const fileContents = getTextFromFile(filePath);
-        if (!fileContents) {
-            throw new Error(`Could not find file: ${filePath}`);
-        }
-
-        const expectedResult = `.tabbed-pane-right-toolbar {
-            visibility: hidden !important;
-        }`;
-        const apply = await import("./simpleView");
-        const result = apply.applyInspectorCommonCssRightToolbarPatch(fileContents);
-        expect(result).not.toEqual(null);
-        expect(result).toEqual(expect.stringContaining(expectedResult));
     });
 
     it("applyInspectorCommonCssRightToolbarPatch correctly changes tabbed-pane-right-toolbar", async () => {
@@ -321,22 +248,7 @@ describe("simpleView", () => {
         const expectedResult =
             ".tabbed-pane-right-toolbar {\\n            visibility: hidden !important;\\n        }";
         const apply = await import("./simpleView");
-        const result = apply.applyInspectorCommonCssRightToolbarPatch(fileContents, true);
-        expect(result).not.toEqual(null);
-        expect(result).toEqual(expect.stringContaining(expectedResult));
-    });
-
-    it("applyInspectorCommonCssTabSliderPatch correctly changes tabbed-pane-tab-slider (release)", async () => {
-        const filePath = "shell.js";
-        const fileContents = getTextFromFile(filePath);
-        if (!fileContents) {
-            throw new Error(`Could not find file: ${filePath}`);
-        }
-
-        const expectedResult =
-            ".tabbed-pane-tab-slider {\\n            display: none !important;\\n        }";
-        const apply = await import("./simpleView");
-        const result = apply.applyInspectorCommonCssTabSliderPatch(fileContents, true);
+        const result = apply.applyInspectorCommonCssRightToolbarPatch(fileContents);
         expect(result).not.toEqual(null);
         expect(result).toEqual(expect.stringContaining(expectedResult));
     });
@@ -348,9 +260,8 @@ describe("simpleView", () => {
             throw new Error(`Could not find file: ${filePath}`);
         }
 
-        const expectedResult = `.tabbed-pane-tab-slider {
-            display: none !important;
-        }`;
+        const expectedResult =
+            ".tabbed-pane-tab-slider {\\n            display: none !important;\\n        }";
         const apply = await import("./simpleView");
         const result = apply.applyInspectorCommonCssTabSliderPatch(fileContents);
         expect(result).not.toEqual(null);

--- a/src/host/polyfills/simpleView.ts
+++ b/src/host/polyfills/simpleView.ts
@@ -220,9 +220,9 @@ export function applyDrawerTabLocationPatch(content: string) {
     }
 }
 
-export function applyInspectorCommonCssPatch(content: string, isRelease?: boolean) {
+export function applyInspectorCommonCssPatch(content: string) {
     // Hides the more tools button in the drawer and reveals the screen cast button.
-    const separator = (isRelease ? "\\n" : "\n");
+    const separator = "\\n";
 
     const hideMoreToolsBtn =
         `.toolbar-button[aria-label='More Tools'] {
@@ -246,9 +246,9 @@ export function applyInspectorCommonCssPatch(content: string, isRelease?: boolea
     }
 }
 
-export function applyInspectorCommonNetworkPatch(content: string, isRelease?: boolean) {
+export function applyInspectorCommonNetworkPatch(content: string) {
     // Hides export HAR button and pretty print button and reveals the Network search close button in the Network Panel.
-    const separator = (isRelease ? "\\n" : "\n");
+    const separator = "\\n";
 
     const hideExportHarBtn =
         `.toolbar-button[aria-label='Export HAR...'] {
@@ -279,9 +279,9 @@ export function applyInspectorCommonNetworkPatch(content: string, isRelease?: bo
     }
 }
 
-export function applyInspectorCommonContextMenuPatch(content: string, isRelease?: boolean) {
+export function applyInspectorCommonContextMenuPatch(content: string) {
     // Hides certain context menu items from elements in the Network Panel.
-    const separator = (isRelease ? "\\n" : "\n");
+    const separator = "\\n";
 
     const hideContextMenuItems =
         `.soft-context-menu-separator,
@@ -302,8 +302,8 @@ export function applyInspectorCommonContextMenuPatch(content: string, isRelease?
     }
 }
 
-export function applyInspectorCommonCssRightToolbarPatch(content: string, isRelease?: boolean) {
-    const separator = (isRelease ? "\\n" : "\n");
+export function applyInspectorCommonCssRightToolbarPatch(content: string) {
+    const separator = "\\n";
     const cssRightToolbar =
         `.tabbed-pane-right-toolbar {
             visibility: hidden !important;
@@ -320,8 +320,8 @@ export function applyInspectorCommonCssRightToolbarPatch(content: string, isRele
     }
 }
 
-export function applyInspectorCommonCssTabSliderPatch(content: string, isRelease?: boolean) {
-    const separator = (isRelease ? "\\n" : "\n");
+export function applyInspectorCommonCssTabSliderPatch(content: string) {
+    const separator = "\\n";
     const cssTabSlider =
         `.tabbed-pane-tab-slider {
             display: none !important;


### PR DESCRIPTION
Currently there is a configuration named "debug mode" which targets the source files of the Edge Chromium repo (not the output files). This was done to enable coding with the Devtools source files. Unfortunately this created a dependency to the source files itself (requiring the full 2gb file). This PR removes this dependency, any changes required on Devtools should be done in Devtools repo or patched through a "polyfill"

Addresses #169