### PR TITLE
Fixing openEditor in simpleView.ts polyfill

### DIFF
--- a/src/host/polyfills/simpleView.test.ts
+++ b/src/host/polyfills/simpleView.test.ts
@@ -15,9 +15,7 @@ describe("simpleView", () => {
         };
         const mockOpen = jest.fn();
         (global as any).InspectorFrontendHost = {
-            InspectorFrontendHostInstance: {
                 openInEditor: mockOpen,
-            },
         };
 
         await apply.revealInVSCode(expected, expected.omitFocus);

--- a/src/host/polyfills/simpleView.ts
+++ b/src/host/polyfills/simpleView.ts
@@ -1,6 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-
+import { IDevToolsWindow } from "../host";
 import ToolsHost from "../toolsHost";
 
 declare var InspectorFrontendHost: {
@@ -17,7 +17,8 @@ interface IRevealable {
 
 export function revealInVSCode(revealable: IRevealable | undefined, omitFocus: boolean) {
     if (revealable && revealable.uiSourceCode && revealable.uiSourceCode._url) {
-        InspectorFrontendHost.InspectorFrontendHostInstance.openInEditor(
+        // using Devtools legacy mode.
+        (self as any as IDevToolsWindow).InspectorFrontendHost.openInEditor(
             revealable.uiSourceCode._url,
             revealable.lineNumber,
             revealable.columnNumber,


### PR DESCRIPTION
This PR allows users to click on the mapped files and get the file open in vscode (broken behavior)

**Root cause:**
OpenEditor got broken due to changes in the InspectorHost module on the Devtools side.

**Fix:**
InspectorHost in no longer a global, instead it should be accessed through the legacy mechanism, which maps InspectorHost.Instance() to InspectorHost.

