### PR TITLE
clears out/tools/frontend folder before copying over files in postBuildStep.ts

### DIFF
--- a/postBuildStep.ts
+++ b/postBuildStep.ts
@@ -62,6 +62,7 @@ async function copyStaticFiles() {
 
     // Copy the devtools to the out directory
     const toolsOutDir = "./out/tools/front_end/";
+    await fse.remove("./out/tools");
     await fse.ensureDir(toolsOutDir);
     await fse.copy(toolsSrcDir, toolsOutDir);
 

--- a/postBuildStep.ts
+++ b/postBuildStep.ts
@@ -62,7 +62,7 @@ async function copyStaticFiles() {
 
     // Copy the devtools to the out directory
     const toolsOutDir = "./out/tools/front_end/";
-    await fse.remove("./out/tools");
+    await fse.remove("./out/tools/front_end/");
     await fse.ensureDir(toolsOutDir);
     await fse.copy(toolsSrcDir, toolsOutDir);
 


### PR DESCRIPTION
We want to make sure that we have a clean directory each time we build.  We want to prevent the case where remnant files from previous versions of Edge cause breaks in the extension experience.