### PR TITLE
[Scripts]: Adding script to extract from full edge zip

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,7 +23,7 @@ Contributions are always welcome! We only ask that you open an issue first so we
   * Set the `EDGE_CHROMIUM_PATH` environment variable to `[PATH_TO_EXTENSION]\vscode-edge-devtools\scripts\out\edge\src` and the `EDGE_CHROMIUM_OUT_DIR` environment variable to `Release`
     * Check the `download-edge` script output for the command line to set the environment variables for the session
       * Note the command will only set the environment variable for the current session
-  * If this step fails or if you want to use a different version of the Edge DevTools, look at the [Legacy Source File Setup](#legacy-source-file-setup)
+  * If this step fails or if you want to use a different version of the Edge DevTools, look at the [Using Different Edge Versions](#using-different-edge-versions)
 * Run `npm run build` or `npm run watch` in '/vscode-edge-devtools'
 * Open the directory in VSCode
 * Select `Launch Extension` debug configuration
@@ -34,8 +34,19 @@ Here are a list of recommended VSCode extensions to use when developing for vsco
 * [Code Spell Checker](https://marketplace.visualstudio.com/items?itemName=streetsidesoftware.code-spell-checker)
 * [TSLint](https://marketplace.visualstudio.com/items?itemName=ms-vscode.vscode-typescript-tslint-plugin)
 
+## Using Different Edge Versions
+* Download a copy of the Microsoft Edge (Chromium) build from [https://thirdpartysource.microsoft.com](https://thirdpartysource.microsoft.com) with the desired version
+* Use the `legacyExtractEdge.js` script to extract from the downloaded zip file:
+  * run `node scripts/legacyExtractEdge.js [ZIP_PATH]` which will extract the needed files to `\vscode-edge-debug\out\edge`.
+  * Set the `EDGE_CHROMIUM_PATH` environment variable to `[PATH_TO_EXTENSION]\vscode-edge-devtools\scripts\out\edge\src` and the `EDGE_CHROMIUM_OUT_DIR` environment variable to `Release`.
+* Run `npm run build` or `npm run watch` in '/vscode-edge-devtools'
+* Open the directory in VSCode
+* Select `Launch Extension` debug configuration
+* Press `F5` to launch the VSCode extension host environment and debug the extension
+* The extension should appear on the left sidebar.  Click the Edge icon on the sidebar to access the extension.
+
 ## Legacy Source File Setup
-Use this method if the automated method fails or if building with a version of Edge other than the currently supported version.
+Use this method if the automated methods fail
 * Download a copy of the Microsoft Edge (Chromium) build from [https://thirdpartysource.microsoft.com](https://thirdpartysource.microsoft.com), current extension version builds from version 83.0.478.45.
   * Note: Download the 'Microsoft Edge DevTools' zip if available in the desired version and platform - it will be much faster.
 * Extract the necessary files from the zip

--- a/scripts/legacyExtractEdge.js
+++ b/scripts/legacyExtractEdge.js
@@ -1,0 +1,23 @@
+async function createDevToolsZip(file) {
+    const mkdirp = require('mkdirp');
+    const fs = require('fs-extra');
+    const unzipper = require('unzipper');
+    await fs.remove('out/edge');
+    fs.createReadStream(file)
+    .pipe(unzipper.Parse())
+    .on('entry', function (entry) {
+        if (entry.path.includes('src/out/Release/gen/devtools') || entry.path.includes('src/third_party/devtools-frontend/src/front_end')) {
+            console.log('Extracting file ' + entry.path);
+            if (entry.path.includes('.')) {
+                entry.pipe(fs.createWriteStream('out/edge/' + entry.path));
+            } else {
+                mkdirp.sync('out/edge/' + entry.path);
+            }
+        } else {
+            entry.autodrain();
+        }
+    });
+}
+
+const file = process.argv.slice(2)[0];
+createDevToolsZip(file);


### PR DESCRIPTION
This helps improve workflow for targeting different versions.  How the script works is that given a full Edge zip, the script will unzip the necessary files to the `vscode-edge-devtools/out/edge/src` directory.

This PR also changes the `Contributing.md` to use the `extractEdgeFromFullZip.js` script for targeting different versions instead of the legacy steps.  Legacy method use case now limited to only if the scripts break.