### PR TITLE
[Contributing]: Removing environment variable from setup process

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,9 +22,6 @@ Contributions are always welcome! We only ask that you open an issue first so we
     * If this step fails, see [Legacy Source File Setup](#legacy-source-file-setup)
     * See [Building with different Edge versions](#building-with-different-edge-versions) to target other versions of Edge
   * The files will be saved at `\vscode-edge-debug\out\edge`
-  * Set the `EDGE_CHROMIUM_PATH` environment variable to `[PATH_TO_EXTENSION]\vscode-edge-devtools\scripts\out\edge\src` and the `EDGE_CHROMIUM_OUT_DIR` environment variable to `Release`
-    * Check the `download-edge` script output for the command line to set the environment variables for the session
-      * Note the command will only set the environment variable for the current session
 * Run `npm run build` or `npm run watch` in '/vscode-edge-devtools'
 * Open the directory in VS Code
 * Select `Launch Extension` debug configuration
@@ -56,9 +53,6 @@ Use this method if the automated methods fail or if the desired version is not s
   * **Open** the zip file and (inside the zip file) navigate to:
     * `[COMPRESSED_FILE]\src\out\Release\gen\devtools`
     * copy the contents of the "devtools" folder and paste them into `[PATH_TO_EXTENSION]/vscode-edge-devtools/out/edge/src/out/Release/gen/devtools`
-* Set the `EDGE_CHROMIUM_PATH` environment variable to `[PATH_TO_EXTENSION]\vscode-edge-devtools\out\edge\src` and `EDGE_CHROMIUM_OUT_DIR` environment variable to `Release`
-    * **Windows**: `set EDGE_CHROMIUM_PATH=[PATH_TO_EXTENSION]\vscode-edge-devtools\out\edge\src&&set EDGE_CHROMIUM_OUT_DIR=Release`
-    * **Mac/Linux**: `export EDGE_CHROMIUM_PATH=[PATH_TO_EXTENSION]/vscode-edge-devtools/out/edge/src&&export EDGE_CHROMIUM_OUT_DIR=Release`
 
 ## Testing
 * There are a set of jest tests which can be run with `npm run test`.

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -23,18 +23,12 @@ jobs:
       npm run download-edge
     displayName: Downloading And Extracting Edge Zip (Windows x64)
   - script: |
-      export EDGE_CHROMIUM_PATH=$(Build.Repository.LocalPath)/out/edge/src
-      export EDGE_CHROMIUM_OUT_DIR=Release
       npm run build
     displayName: Building
   - script: |
-      export EDGE_CHROMIUM_PATH=$(Build.Repository.LocalPath)/out/edge/src
-      export EDGE_CHROMIUM_OUT_DIR=Release
       npm run test
     displayName: Linting and Testing
   - script: |
-      export EDGE_CHROMIUM_PATH=$(Build.Repository.LocalPath)/out/edge/src
-      export EDGE_CHROMIUM_OUT_DIR=Release
       npm run package
     displayName: Creating .vsix
   - task: CopyFiles@2
@@ -60,18 +54,12 @@ jobs:
       npm run download-edge
     displayName: Downloading And Extracting Edge Zip (Windows x64)
   - script: |
-      export EDGE_CHROMIUM_PATH=$(Build.Repository.LocalPath)/out/edge/src
-      export EDGE_CHROMIUM_OUT_DIR=Release
       npm run build
     displayName: Building
   - script: |
-      export EDGE_CHROMIUM_PATH=$(Build.Repository.LocalPath)/out/edge/src
-      export EDGE_CHROMIUM_OUT_DIR=Release
       npm run test
     displayName: Linting and Testing
   - script: |
-      export EDGE_CHROMIUM_PATH=$(Build.Repository.LocalPath)/out/edge/src
-      export EDGE_CHROMIUM_OUT_DIR=Release
       npm run package
     displayName: Creating .vsix
   - task: CopyFiles@2
@@ -97,18 +85,12 @@ jobs:
       npm run download-edge
     displayName: Downloading And Extracting Edge Zip (Windows x64)
   - script: |
-      set EDGE_CHROMIUM_PATH=$(Build.Repository.LocalPath)/out/edge/src
-      set EDGE_CHROMIUM_OUT_DIR=Release
       npm run build
     displayName: Building
   - script: |
-      set EDGE_CHROMIUM_PATH=$(Build.Repository.LocalPath)/out/edge/src
-      set EDGE_CHROMIUM_OUT_DIR=Release
       npm run test
     displayName: Linting and Testing
   - script: |
-      set EDGE_CHROMIUM_PATH=$(Build.Repository.LocalPath)/out/edge/src
-      set EDGE_CHROMIUM_OUT_DIR=Release
       npm run package
     displayName: Creating .vsix
   - task: CopyFiles@2

--- a/postBuildStep.ts
+++ b/postBuildStep.ts
@@ -39,7 +39,7 @@ async function copyStaticFiles() {
     await fse.ensureDir(commonOutDir);
     await copyFile(commonSrcDir, commonOutDir, "styles.css");
 
-    const dirName = __dirname.replace('\\', '/');
+    const dirName = __dirname.replace(/\\/g, '/');
     const sourceFilesPath = dirName + '/out/edge/src';
 
     const toolsSrcDir =

--- a/postBuildStep.ts
+++ b/postBuildStep.ts
@@ -39,25 +39,21 @@ async function copyStaticFiles() {
     await fse.ensureDir(commonOutDir);
     await copyFile(commonSrcDir, commonOutDir, "styles.css");
 
-    const dirName = __dirname.replace(/\\/g, '/');
-    const sourceFilesPath = dirName + '/out/edge/src';
+    const sourceFilesPath = path.normalize(__dirname + '/out/edge/src');
 
-    const toolsSrcDir =
-        `${sourceFilesPath}/third_party/devtools-frontend/src/front_end/`;
+    const toolsSrcDir = path.normalize(`${sourceFilesPath}/third_party/devtools-frontend/src/front_end/`);
     if (!isDirectory(toolsSrcDir)) {
         throw new Error(`Could not find Microsoft Edge DevTools path at '${toolsSrcDir}'. ` +
             "Did you run the 'npm run download-edge' script?");
     }
 
-    const toolsGenDir =
-        `${sourceFilesPath}/out/Release/gen/devtools/`;
+    const toolsGenDir = path.normalize(`${sourceFilesPath}/out/Release/gen/devtools/`);
     if (!isDirectory(toolsGenDir)) {
         throw new Error(`Could not find Microsoft Edge output path at '${toolsGenDir}'. ` +
             "Did you run the 'npm run download-edge' script?");
     }
 
-    const toolsResDir =
-        `${sourceFilesPath}/out/Release/resources/inspector/`;
+    const toolsResDir = path.normalize(`${sourceFilesPath}/out/Release/resources/inspector/`);
 
     // Copy the devtools to the out directory
     const toolsOutDir = "./out/tools/front_end/";

--- a/postBuildStep.ts
+++ b/postBuildStep.ts
@@ -39,27 +39,25 @@ async function copyStaticFiles() {
     await fse.ensureDir(commonOutDir);
     await copyFile(commonSrcDir, commonOutDir, "styles.css");
 
-    // Must set environment variables EDGE_CHROMIUM_PATH and EDGE_CHROMIUM_OUT_DIR
-    // E.g. set EDGE_CHROMIUM_PATH=F:/git/Edge/src
-    //      set EDGE_CHROMIUM_OUT_DIR=Release
-    // See CONTRIBUTING.md for more details
+    const dirName = __dirname.replace('\\', '/');
+    const sourceFilesPath = dirName + '/out/edge/src';
 
     const toolsSrcDir =
-        `${process.env.EDGE_CHROMIUM_PATH}/third_party/devtools-frontend/src/front_end/`;
+        `${sourceFilesPath}/third_party/devtools-frontend/src/front_end/`;
     if (!isDirectory(toolsSrcDir)) {
         throw new Error(`Could not find Microsoft Edge DevTools path at '${toolsSrcDir}'. ` +
-            "Did you set the EDGE_CHROMIUM_PATH environment variable?");
+            "Did you run the 'npm run download-edge' script?");
     }
 
     const toolsGenDir =
-        `${process.env.EDGE_CHROMIUM_PATH}/out/${process.env.EDGE_CHROMIUM_OUT_DIR}/gen/devtools/`;
+        `${sourceFilesPath}/out/Release/gen/devtools/`;
     if (!isDirectory(toolsGenDir)) {
         throw new Error(`Could not find Microsoft Edge output path at '${toolsGenDir}'. ` +
-            "Did you set the EDGE_CHROMIUM_OUT_DIR environment variable?");
+            "Did you run the 'npm run download-edge' script?");
     }
 
     const toolsResDir =
-        `${process.env.EDGE_CHROMIUM_PATH}/out/${process.env.EDGE_CHROMIUM_OUT_DIR}/resources/inspector/`;
+        `${sourceFilesPath}/out/Release/resources/inspector/`;
 
     // Copy the devtools to the out directory
     const toolsOutDir = "./out/tools/front_end/";

--- a/scripts/downloadAndExtractEdge.js
+++ b/scripts/downloadAndExtractEdge.js
@@ -50,7 +50,7 @@ function retrievePlatform() {
 
 function removeLastDirectory(filepath) {
     const splitChar = isWindows ? '\\' : '/';
-    var arr = filepath.split(splitChar);
+    const arr = filepath.split(splitChar);
     arr.pop();
     return( arr.join(splitChar) );
 }

--- a/scripts/downloadAndExtractEdge.js
+++ b/scripts/downloadAndExtractEdge.js
@@ -69,16 +69,14 @@ async function downloadZipFile(downloadUrl) {
       fs.unlink('edge.zip', () => {} );
       let dirName = __dirname;
       if (isWindows) {
-        flipSlashDirName = dirName.replace(/\//g, '\\');
+        const flipSlashDirName = dirName.replace(/\//g, '\\');
+        console.log(dirName);
         const rootPath = removeLastDirectory(flipSlashDirName);
         console.log('Edge files extracted to: ' + rootPath + '\\out\\edge\n');
-        console.log('Run this in cmd to set env variables: "set EDGE_CHROMIUM_PATH=' + rootPath + '\\out\\edge\\src&&set EDGE_CHROMIUM_OUT_DIR=Release"\n');
       } else {
         const rootPath = removeLastDirectory(dirName);
         console.log('Edge files extracted to: ' + rootPath + '/out/edge');
-        console.log('Run this in terminal to set env variables: "export EDGE_CHROMIUM_PATH=' + rootPath + '/out/edge/src&&export EDGE_CHROMIUM_OUT_DIR=Release"\n');
       }
-      console.log('*Note: this command only sets the environment variables for this session.');
     });
   });
 }

--- a/scripts/downloadAndExtractEdge.js
+++ b/scripts/downloadAndExtractEdge.js
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 const TARGET_VERSION = '84.0.522.63';
 const targetVersionMap = new Map([
   ['83', '83.0.478.45'],
@@ -49,10 +52,10 @@ function retrievePlatform() {
 }
 
 function removeLastDirectory(filepath) {
-    const splitChar = isWindows ? '\\' : '/';
-    const arr = filepath.split(splitChar);
-    arr.pop();
-    return( arr.join(splitChar) );
+  const splitChar = isWindows ? '\\' : '/';
+  const arr = filepath.split(splitChar);
+  arr.pop();
+  return( arr.join(splitChar) );
 }
 
 async function downloadZipFile(downloadUrl) {
@@ -70,7 +73,6 @@ async function downloadZipFile(downloadUrl) {
       let dirName = __dirname;
       if (isWindows) {
         const flipSlashDirName = dirName.replace(/\//g, '\\');
-        console.log(dirName);
         const rootPath = removeLastDirectory(flipSlashDirName);
         console.log('Edge files extracted to: ' + rootPath + '\\out\\edge\n');
       } else {

--- a/src/test/helpers.ts
+++ b/src/test/helpers.ts
@@ -149,7 +149,7 @@ export function getTextFromFile(uri: string) {
 
     const toolsGenDir =
         `${sourceFilesPath}/out/Release/gen/devtools/`;
-    const filePath = `${toolsGenDir}${uri}`;
+    const filePath = path.normalize(`${toolsGenDir}${uri}`);
     if (fs.existsSync(filePath)) {
         return fs.readFileSync(filePath, "utf8");
     }

--- a/src/test/helpers.ts
+++ b/src/test/helpers.ts
@@ -142,7 +142,8 @@ export function getFirstCallback(mock: jest.Mock, callbackArgIndex: number = 0):
  * @param uri The uri relative to the 'gen' folder.
  */
 export function getTextFromFile(uri: string) {
-    const dirName = __dirname.replace('\\', '/');
+    // Changing from C:\[vscode_directory]\src\test to C:/[vscode_directory]
+    const dirName = removeLastTwoDirectories(__dirname.replace(/\\/g, '/'));
     const sourceFilesPath = dirName + '/out/edge/src';
 
     const toolsGenDir =
@@ -153,4 +154,14 @@ export function getTextFromFile(uri: string) {
     }
 
     return null;
+}
+
+/**
+ * @param filepath
+ */
+function removeLastTwoDirectories(filepath: string) {
+    const arr = filepath.split('/');
+    arr.pop();
+    arr.pop();
+    return( arr.join('/') );
 }

--- a/src/test/helpers.ts
+++ b/src/test/helpers.ts
@@ -143,8 +143,8 @@ export function getFirstCallback(mock: jest.Mock, callbackArgIndex: number = 0):
  * @param uri The uri relative to the 'gen' folder.
  */
 export function getTextFromFile(uri: string) {
-    // Changing from C:\[vscode_directory]\src\test to C:/[vscode_directory]
-    const dirName = removeLastTwoDirectories(path.normalize(__dirname));
+    // Grabbing the vscode-edge-devtools root directory path
+    const dirName = removeLastTwoDirectories(__dirname);
     const sourceFilesPath = dirName + '/out/edge/src';
 
     const toolsGenDir =
@@ -163,5 +163,5 @@ export function getTextFromFile(uri: string) {
 function removeLastTwoDirectories(filepath: string) {
     const arr = filepath.split(path.sep);
     arr.splice(-2);
-    return path.join(...arr);
+    return arr.join(path.sep);
 }

--- a/src/test/helpers.ts
+++ b/src/test/helpers.ts
@@ -139,11 +139,14 @@ export function getFirstCallback(mock: jest.Mock, callbackArgIndex: number = 0):
 
 /**
  * Returns the contents of the specified file, if the file is not found returns null
- * @param uri The uri relative to the 'gen' folder specified in EDGE_CHROMIUM_PATH environment variable.
+ * @param uri The uri relative to the 'gen' folder.
  */
 export function getTextFromFile(uri: string) {
+    const dirName = __dirname.replace('\\', '/');
+    const sourceFilesPath = dirName + '/out/edge/src';
+
     const toolsGenDir =
-        `${process.env.EDGE_CHROMIUM_PATH}/out/${process.env.EDGE_CHROMIUM_OUT_DIR}/gen/devtools/`;
+        `${sourceFilesPath}/out/Release/gen/devtools/`;
     const filePath = `${toolsGenDir}${uri}`;
     if (fs.existsSync(filePath)) {
         return fs.readFileSync(filePath, "utf8");

--- a/src/test/helpers.ts
+++ b/src/test/helpers.ts
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import fs from "fs";
+import path from "path";
 import { ExtensionContext } from "vscode";
 import TelemetryReporter from "vscode-extension-telemetry";
 
@@ -143,7 +144,7 @@ export function getFirstCallback(mock: jest.Mock, callbackArgIndex: number = 0):
  */
 export function getTextFromFile(uri: string) {
     // Changing from C:\[vscode_directory]\src\test to C:/[vscode_directory]
-    const dirName = removeLastTwoDirectories(__dirname.replace(/\\/g, '/'));
+    const dirName = removeLastTwoDirectories(path.normalize(__dirname));
     const sourceFilesPath = dirName + '/out/edge/src';
 
     const toolsGenDir =
@@ -160,8 +161,7 @@ export function getTextFromFile(uri: string) {
  * @param filepath
  */
 function removeLastTwoDirectories(filepath: string) {
-    const arr = filepath.split('/');
-    arr.pop();
-    arr.pop();
-    return( arr.join('/') );
+    const arr = filepath.split(path.sep);
+    arr.splice(-2);
+    return path.join(...arr);
 }


### PR DESCRIPTION
Since we are storing the Edge files within the vscode-edge-devtools directory, we no longer need environment variables and can use relative pathing.  This PR removes the need for `EDGE_CHROMIUM_PATH` and `EDGE_CHROMIUM_OUT_DIR` environment variables.