### PR TITLE
Renaming extension from "Microsoft Edge (Chromium) Tools for VSCode" to "Microsoft Edge Tools for VS Code"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@
 ## 1.0.8
 * Downgraded Edge DevTools version to 81.0.416 (Microsoft Edge Stable)
 * Merged Network Tool into the extension - [PR #128](https://github.com/microsoft/vscode-edge-devtools/pull/128)
-* Renaming tool to "Microsoft Edge (Chromium) Tools for VSCode"
+* Renaming tool to "Microsoft Edge Tools for VS Code"
 
 ## 1.0.7
 * Updated to version 82.0.423

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,12 +26,12 @@ Contributions are always welcome! We only ask that you open an issue first so we
     * Check the `download-edge` script output for the command line to set the environment variables for the session
       * Note the command will only set the environment variable for the current session
 * Run `npm run build` or `npm run watch` in '/vscode-edge-devtools'
-* Open the directory in VSCode
+* Open the directory in VS Code
 * Select `Launch Extension` debug configuration
-* Press `F5` to launch the VSCode extension host environment and debug the extension
+* Press `F5` to launch the VS Code extension host environment and debug the extension
 * The extension should appear on the left sidebar.  Click the Edge icon on the sidebar to access the extension.
 
-Here are a list of recommended VSCode extensions to use when developing for vscode-edge-devtools:
+Here are a list of recommended VS Code extensions to use when developing for vscode-edge-devtools:
 * [Code Spell Checker](https://marketplace.visualstudio.com/items?itemName=streetsidesoftware.code-spell-checker)
 * [TSLint](https://marketplace.visualstudio.com/items?itemName=ms-vscode.vscode-typescript-tslint-plugin)
 
@@ -44,7 +44,7 @@ Here are a list of recommended VSCode extensions to use when developing for vsco
 
 ## Legacy Source File Setup
 Use this method if the automated methods fail or if the desired version is not supported by the download script.
-* Download a copy of the Microsoft Edge (Chromium) build from [https://thirdpartysource.microsoft.com](https://thirdpartysource.microsoft.com), current extension version builds from version 84.0.522.63.
+* Download a copy of the Microsoft Edge build from [https://thirdpartysource.microsoft.com](https://thirdpartysource.microsoft.com), current extension version builds from version 84.0.522.63.
   * Note: Download the 'Microsoft Edge DevTools' zip if available in the desired version and platform - it will be much faster.
 * Extract the necessary files from the zip
   * On an administrator prompt execute the following commands (assuming your drive is located at C:\)
@@ -63,7 +63,7 @@ Use this method if the automated methods fail or if the desired version is not s
 ## Testing
 * There are a set of jest tests which can be run with `npm run test`.
 * You may also run `npm run lint` separately to check your code against our tslint rules.
-* Open the directory in VSCode
+* Open the directory in VS Code
 * Select `Launch Tests` debug configuration
 * Press `F5` to attach the debugger and start the tests
 

--- a/README.md
+++ b/README.md
@@ -1,23 +1,23 @@
 
 <h1 align="center">
   <br>
-  VS Code - Microsoft Edge (Chromium) Tools
+  VS Code - Microsoft Edge Tools
   <br>
 </h1>
 
-<h4 align="center">Show the browser's Elements and Network tool inside the VSCode editor and use it to fix styling, layout, and CSS issues with your site.</h4>
+<h4 align="center">Show the browser's Elements and Network tool inside the VS Code editor and use it to fix styling, layout, and CSS issues with your site.</h4>
 
 A VS Code extension that allows you to use the browser's Elements and Network tool from within the editor. The DevTools will connect to an instance of Microsoft Edge giving you the ability to see the runtime HTML structure, alter layout, fix styling issues, and view network requests. All without leaving VS Code.
 
-**Note**: This extension only supports Microsoft Edge (Chromium)
+**Note**: This extension only supports Microsoft Edge
 
-![Microsoft Edge (Chromium) Tools - Demo](demo.gif)
+![Microsoft Edge Tools - Demo](demo.gif)
 
 **Supported Features**
 * Debug configurations for launching Microsoft Edge browser in remote-debugging mode and auto attaching the tools,
 * Side Bar view for listing all the debuggable targets, including tabs, extensions, service workers, etc.
 * Fully featured Elements and Network tool with views for HTML, CSS, accessibility and more.
-* Screen-casting feature to allow you to see your page without leaving VSCode.
+* Screen-casting feature to allow you to see your page without leaving VS Code.
 * Go directly to the line/column for source files in your workspace when clicking on a link or CSS rule inside the Elements tool.
 * Auto attach the Microsoft Edge Tools when you start debugging with the [Debugger for Microsoft Edge](https://marketplace.visualstudio.com/items?itemName=msjsdiag.debugger-for-edge) extension.
 
@@ -25,7 +25,7 @@ A VS Code extension that allows you to use the browser's Elements and Network to
 ## Getting Started
 For use inside VS Code:
 
-1. Install any channel (Canary/Dev/etc.) of [Microsoft Edge (Chromium)](https://aka.ms/edgeinsider).
+1. Install any channel (Canary/Dev/etc.) of [Microsoft Edge](https://aka.ms/edgeinsider).
 1. Install the extension [Microsoft Edge Tools](https://marketplace.visualstudio.com/items?itemName=ms-edgedevtools.vscode-edge-devtools).
 1. Open the folder containing the project you want to work on.
 1. (Optional) Install the [Debugger for Microsoft Edge](https://marketplace.visualstudio.com/items?itemName=msjsdiag.debugger-for-edge) extension.
@@ -100,7 +100,7 @@ To add a new debug configuration, in your `launch.json` add a new debug config w
 ```
 
 #### Other optional launch config fields
-* `browserPath`: The full path to the browser executable that will be launched. If not specified the most stable channel of Microsoft Edge (Chromium) will be launched from the default install location instead.
+* `browserPath`: The full path to the browser executable that will be launched. If not specified the most stable channel of Microsoft Edge will be launched from the default install location instead.
 * `hostname`: By default the extension searches for debuggable instances using `localhost`. If you are hosting your web app on a remote machine you can specify the hostname using this setting.
 * `port`: By default the extension will set the remote-debugging-port to `9222`. Use this option to specify a different port on which to connect.
 * `userDataDir`: Normally, if Microsoft Edge is already running when you start debugging with a launch config, then the new instance won't start in remote debugging mode. So by default, the extension launches Microsoft Edge with a separate user profile in a temp folder. Use this option to set a different path to use, or set to false to launch with your default user profile instead.
@@ -170,12 +170,12 @@ Ionic and gulp-sourcemaps output a sourceRoot of `"/source/"` by default. If you
   * `msedge.exe --remote-debugging-port=9222`
   * Navigate the browser to the desired URL.
 * Attach the Microsoft Edge Tools via a command:
-  * Run the command `Microsoft Edge (Chromium) Tools: Attach to a target`
+  * Run the command `Microsoft Edge Tools: Attach to a target`
   * Select a target from the drop down.
 
 ### Attaching automatically when launching the browser for debugging
 * Install the [Debugger for Microsoft Edge](https://marketplace.visualstudio.com/items?itemName=msjsdiag.debugger-for-edge) extension
-* Setup your `launch.json` configuration to launch and debug Microsoft Edge (Chromium).
+* Setup your `launch.json` configuration to launch and debug Microsoft Edge.
   * See [Debugger for Microsoft Edge Readme.md](https://github.com/microsoft/vscode-edge-debug2/blob/master/README.md).
 * Start Microsoft Edge for debugging.
   * Once debugging has started, the Microsoft Edge Tools will auto attach to the browser (it will keep retrying until the Debugger for Microsoft Edge launch.json config `timeout` value is reached).

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "vscode-edge-devtools",
-    "displayName": "Microsoft Edge (Chromium) Tools for VSCode",
-    "description": "Use the Microsoft Edge (Chromium) Tools from within VS Code to see your site's runtime HTML structure, alter its layout, fix styling issues as well as see your site's network requests.",
+    "displayName": "Microsoft Edge Tools for VS Code",
+    "description": "Use the Microsoft Edge Tools from within VS Code to see your site's runtime HTML structure, alter its layout, fix styling issues as well as see your site's network requests.",
     "version": "1.0.9",
     "license": "SEE LICENSE IN LICENSE",
     "publisher": "ms-edgedevtools",
@@ -88,7 +88,7 @@
             }
         ],
         "configuration": {
-            "title": "Microsoft Edge (Chromium) Tools",
+            "title": "Microsoft Edge Tools",
             "type": "object",
             "properties": {
                 "vscode-edge-devtools.hostname": {
@@ -177,11 +177,11 @@
                         "Canary"
                     ],
                     "enumDescriptions": [
-                        "Microsoft Edge (Chromium) Tools for VSCode will try to open the Microsoft Edge flavors in the following order: Stable, Beta, Dev and Canary",
-                        "Microsoft Edge (Chromium) Tools for VSCode will use Microsoft Edge Stable version",
-                        "Microsoft Edge (Chromium) Tools for VSCode will use Microsoft Edge Beta version",
-                        "Microsoft Edge (Chromium) Tools for VSCode will use Microsoft Edge Dev version",
-                        "Microsoft Edge (Chromium) Tools for VSCode will use Microsoft Edge Canary version"
+                        "Microsoft Edge Tools for VS Code will try to open the Microsoft Edge flavors in the following order: Stable, Beta, Dev and Canary",
+                        "Microsoft Edge Tools for VS Code will use Microsoft Edge Stable version",
+                        "Microsoft Edge Tools for VS Code will use Microsoft Edge Beta version",
+                        "Microsoft Edge Tools for VS Code will use Microsoft Edge Dev version",
+                        "Microsoft Edge Tools for VS Code will use Microsoft Edge Canary version"
                     ]
                 }
             }
@@ -288,11 +288,11 @@
                                     "Canary"
                                 ],
                                 "enumDescriptions": [
-                                    "Microsoft Edge (Chromium) Tools for VSCode will try to open the Microsoft Edge flavors in the following order: Stable, Beta, Dev and Canary",
-                                    "Microsoft Edge (Chromium) Tools for VSCode will use Microsoft Edge Stable version",
-                                    "Microsoft Edge (Chromium) Tools for VSCode will use Microsoft Edge Beta version",
-                                    "Microsoft Edge (Chromium) Tools for VSCode will use Microsoft Edge Dev version",
-                                    "Microsoft Edge (Chromium) Tools for VSCode will use Microsoft Edge Canary version"
+                                    "Microsoft Edge Tools for VS Code will try to open the Microsoft Edge flavors in the following order: Stable, Beta, Dev and Canary",
+                                    "Microsoft Edge Tools for VS Code will use Microsoft Edge Stable version",
+                                    "Microsoft Edge Tools for VS Code will use Microsoft Edge Beta version",
+                                    "Microsoft Edge Tools for VS Code will use Microsoft Edge Dev version",
+                                    "Microsoft Edge Tools for VS Code will use Microsoft Edge Canary version"
                                 ]
                             }
                         }
@@ -370,11 +370,11 @@
                                     "Canary"
                                 ],
                                 "enumDescriptions": [
-                                    "Microsoft Edge (Chromium) Tools for VSCode will try to open the Microsoft Edge flavors in the following order: Stable, Beta, Dev and Canary",
-                                    "Microsoft Edge (Chromium) Tools for VSCode will use Microsoft Edge Stable version",
-                                    "Microsoft Edge (Chromium) Tools for VSCode will use Microsoft Edge Beta version",
-                                    "Microsoft Edge (Chromium) Tools for VSCode will use Microsoft Edge Dev version",
-                                    "Microsoft Edge (Chromium) Tools for VSCode will use Microsoft Edge Canary version"
+                                    "Microsoft Edge Tools for VS Code will try to open the Microsoft Edge flavors in the following order: Stable, Beta, Dev and Canary",
+                                    "Microsoft Edge Tools for VS Code will use Microsoft Edge Stable version",
+                                    "Microsoft Edge Tools for VS Code will use Microsoft Edge Beta version",
+                                    "Microsoft Edge Tools for VS Code will use Microsoft Edge Dev version",
+                                    "Microsoft Edge Tools for VS Code will use Microsoft Edge Canary version"
                                 ]
                             }
                         }
@@ -434,7 +434,7 @@
             "activitybar": [
                 {
                     "id": "vscode-edge-devtools-view",
-                    "title": "Microsoft Edge (Chromium) Tools",
+                    "title": "Microsoft Edge Tools",
                     "icon": "resources/viewIcon.svg"
                 }
             ]

--- a/postBuildStep.ts
+++ b/postBuildStep.ts
@@ -46,14 +46,14 @@ async function copyStaticFiles() {
     const toolsSrcDir =
         `${process.env.EDGE_CHROMIUM_PATH}/third_party/devtools-frontend/src/front_end/`;
     if (!isDirectory(toolsSrcDir)) {
-        throw new Error(`Could not find Microsoft Edge (Chromium) DevTools path at '${toolsSrcDir}'. ` +
+        throw new Error(`Could not find Microsoft Edge DevTools path at '${toolsSrcDir}'. ` +
             "Did you set the EDGE_CHROMIUM_PATH environment variable?");
     }
 
     const toolsGenDir =
         `${process.env.EDGE_CHROMIUM_PATH}/out/${process.env.EDGE_CHROMIUM_OUT_DIR}/gen/devtools/`;
     if (!isDirectory(toolsGenDir)) {
-        throw new Error(`Could not find Microsoft Edge (Chromium) output path at '${toolsGenDir}'. ` +
+        throw new Error(`Could not find Microsoft Edge output path at '${toolsGenDir}'. ` +
             "Did you set the EDGE_CHROMIUM_OUT_DIR environment variable?");
     }
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -43,7 +43,7 @@ export function activate(context: vscode.ExtensionContext) {
     vscode.debug.registerDebugConfigurationProvider(`${SETTINGS_STORE_NAME}.debug`,
         new LaunchDebugProvider(context, telemetryReporter, attach, launch));
 
-    // Register the Microsoft Edge (Chromium) debugger types
+    // Register the Microsoft Edge debugger types
     vscode.debug.registerDebugConfigurationProvider("edge",
         new LaunchDebugProvider(context, telemetryReporter, attach, launch));
     vscode.debug.registerDebugConfigurationProvider("msedge",

--- a/src/host/toolsWebSocket.ts
+++ b/src/host/toolsWebSocket.ts
@@ -9,7 +9,7 @@ interface IMessageEvent {
 
 /**
  * Class used to override the real WebSocket constructor in the webview.
- * This is required as a VSCode webview cannot create a WebSocket connection,
+ * This is required as a VS Code webview cannot create a WebSocket connection,
  * so instead we replace it and forward all messages to/from the extension
  * which is able to create the real websocket connection to the target page.
  */

--- a/src/test/helpers.ts
+++ b/src/test/helpers.ts
@@ -20,8 +20,8 @@ export type Writable<T> = {
 };
 
 /**
- * Create a fake VSCode API object that can be used in tests
- * Since the VSCode API is only available in the extension host you must use this as a virtual mock:
+ * Create a fake VS Code API object that can be used in tests
+ * Since the VS Code API is only available in the extension host you must use this as a virtual mock:
  * E.g. jest.mock("vscode", () => createFakeVSCode(), { virtual: true });
  * Tests can then override the default behavior for their specific scenario by using requireMock:
  * E.g. const mock = await jest.requireMock("vscode"); mock.window.showErrorMessage = () => null;
@@ -72,7 +72,7 @@ export function createFakeVSCode() {
 }
 
 /**
- * Create a fake VSCode extension context that can be used in tests
+ * Create a fake VS Code extension context that can be used in tests
  */
 export function createFakeExtensionContext() {
     return {


### PR DESCRIPTION
- Removing instances of "(Chromium)"
- Adding space between "VS" and "Code"