### PR TITLE
Remove DOM Breakpoint tab and context menu option

### DIFF
--- a/postBuildStep.ts
+++ b/postBuildStep.ts
@@ -18,6 +18,7 @@ import {
     applyInspectorCommonNetworkPatch,
     applyMainViewPatch,
     applyPersistRequestBlockingTab,
+    applyRemoveBreakOnContextMenuItem,
     applySetTabIconPatch,
     applyShowElementsTab,
     applyShowRequestBlockingTab,
@@ -128,6 +129,9 @@ async function patchFilesForWebView(toolsOutDir: string) {
     await patchFileForWebViewWrapper("ui/ui.js", toolsOutDir, [
         applyHandleActionPatch,
     ]);
+    await patchFileForWebViewWrapper("browser_debugger/browser_debugger.js", toolsOutDir, [
+        applyRemoveBreakOnContextMenuItem,
+    ])
 }
 
 // This function wraps the patchFileForWebView function to catch any errors thrown, log them

--- a/src/host/polyfills/simpleView.test.ts
+++ b/src/host/polyfills/simpleView.test.ts
@@ -158,7 +158,7 @@ describe("simpleView", () => {
         const result = apply.applyRemoveBreakOnContextMenuItem(fileContents);
         expect(result).not.toEqual(null);
         if (result) {
-            expect(result).toEqual(expect.stringContaining("domDebuggerModel.setDOMBreakpoint(node,type);}}\n}}"));
+            expect(result).not.toEqual(expect.stringContaining("const breakpointsMenu"));
         }
     });
 

--- a/src/host/polyfills/simpleView.test.ts
+++ b/src/host/polyfills/simpleView.test.ts
@@ -147,6 +147,21 @@ describe("simpleView", () => {
         }
     });
 
+    it("applyRemoveBreakOnContextMenuItem correctly changes text", async () => {
+        const filePath = "browser_debugger/browser_debugger.js";
+        const fileContents = getTextFromFile(filePath);
+        if (!fileContents) {
+            throw new Error(`Could not find file: ${filePath}`);
+        }
+
+        const apply = await import("./simpleView");
+        const result = apply.applyRemoveBreakOnContextMenuItem(fileContents);
+        expect(result).not.toEqual(null);
+        if (result) {
+            expect(result).toEqual(expect.stringContaining("domDebuggerModel.setDOMBreakpoint(node,type);}}\n}}"));
+        }
+    });
+
     it("applyShowRequestBlockingTab correctly changes text", async () => {
         const filePath = "ui/ui.js";
         const fileContents = getTextFromFile(filePath);

--- a/src/host/polyfills/simpleView.ts
+++ b/src/host/polyfills/simpleView.ts
@@ -91,7 +91,6 @@ export function applyShowElementsTab(content: string) {
     }
 }
 
-// remove const breakpointsMenu=contextMenu.debugSection().appendSubMenuItem(UIString.UIString('Break on'));for(const key in Protocol.DOMDebugger.DOMBreakpointType){const type=Protocol.DOMDebugger.DOMBreakpointType[key];const label=Sources.DebuggerPausedMessage.BreakpointTypeNouns.get(type);breakpointsMenu.defaultSection().appendCheckboxItem(label,toggleBreakpoint.bind(null,type),domDebuggerModel.hasDOMBreakpoint(node,type));}}
 export function applyRemoveBreakOnContextMenuItem(content: string) {
     const pattern = /const breakpointsMenu=.+hasDOMBreakpoint\(.*\);}/;
     if (content.match(pattern)) {

--- a/src/host/polyfills/simpleView.ts
+++ b/src/host/polyfills/simpleView.ts
@@ -87,7 +87,17 @@ export function applyShowElementsTab(content: string) {
     if (content.match(pattern)) {
         return content.replace(pattern, "this._defaultTab = 'elements';");
     } else {
-    return null;
+        return null;
+    }
+}
+
+// remove const breakpointsMenu=contextMenu.debugSection().appendSubMenuItem(UIString.UIString('Break on'));for(const key in Protocol.DOMDebugger.DOMBreakpointType){const type=Protocol.DOMDebugger.DOMBreakpointType[key];const label=Sources.DebuggerPausedMessage.BreakpointTypeNouns.get(type);breakpointsMenu.defaultSection().appendCheckboxItem(label,toggleBreakpoint.bind(null,type),domDebuggerModel.hasDOMBreakpoint(node,type));}}
+export function applyRemoveBreakOnContextMenuItem(content: string) {
+    const pattern = /const breakpointsMenu=.+hasDOMBreakpoint\(.*\);}/;
+    if (content.match(pattern)) {
+        return content.replace(pattern, "");
+    } else {
+        return null;
     }
 }
 
@@ -134,7 +144,6 @@ export function applyAppendTabPatch(content: string) {
         "Computed",
         "accessibility.view",
         "elements.domProperties",
-        "elements.domBreakpoints",
         "elements.eventListeners",
     ];
 


### PR DESCRIPTION
DOM Breakpoints operate on the sources pane which is not included in the extension.  This PR removes the DOM Breakpoints tab in the Elements side panel and the "Break on" context menu option