### PR TITLE
Re-disable quick open menu and filter command menu options

### DIFF
--- a/postBuildStep.ts
+++ b/postBuildStep.ts
@@ -122,10 +122,7 @@ async function patchFilesForWebView(toolsOutDir: string) {
         applyRuntimeImportScriptPathPrefixPatch,
     ]);
 
-    await patchFileForWebViewWrapper("ui/ui.js", toolsOutDir, [
-        applyHandleActionPatch,
-    ]);
-    await patchFileForWebViewWrapper("ui/ui.js", toolsOutDir, [
+    await patchFileForWebViewWrapper("quick_open/quick_open.js", toolsOutDir, [
         applyHandleActionPatch,
     ]);
 }

--- a/postBuildStep.ts
+++ b/postBuildStep.ts
@@ -9,8 +9,9 @@ import applyRuntimeImportScriptPathPrefixPatch from "./src/host/polyfills/runtim
 import {
     applyAppendTabPatch,
     applyCommonRevealerPatch,
+    applyCommandMenuPatch,
     applyDrawerTabLocationPatch,
-    applyHandleActionPatch,
+    applyQuickOpenPatch,
     applyInspectorCommonContextMenuPatch,
     applyInspectorCommonCssPatch,
     applyInspectorCommonCssRightToolbarPatch,
@@ -118,7 +119,8 @@ async function patchFilesForWebView(toolsOutDir: string) {
     ]);
 
     await patchFileForWebViewWrapper("quick_open/quick_open.js", toolsOutDir, [
-        applyHandleActionPatch,
+        applyCommandMenuPatch,
+        applyQuickOpenPatch,
     ]);
     await patchFileForWebViewWrapper("browser_debugger/browser_debugger.js", toolsOutDir, [
         applyRemoveBreakOnContextMenuItem,

--- a/src/host/polyfills/simpleView.test.ts
+++ b/src/host/polyfills/simpleView.test.ts
@@ -48,7 +48,21 @@ describe("simpleView", () => {
         const result = apply.applyQuickOpenPatch(fileContents);
         expect(result).not.toEqual(null);
         expect(result).toEqual(
-            expect.stringContaining("handleAction(context, actionId) { return false;switch(actionId){case'quickOpen.show"));
+            expect.stringContaining("handleAction(context, actionId) { actionId = null; switch(actionId)"));
+    });
+
+    it("applyCommandMenuPatch correctly changes attach text for command menu", async () => {
+        const filePath = "quick_open/quick_open.js";
+        const fileContents = getTextFromFile(filePath);
+        if (!fileContents) {
+            throw new Error(`Could not find file: ${filePath}`);
+        }
+
+        const apply = await import("./simpleView");
+        const result = apply.applyCommandMenuPatch(fileContents);
+        expect(result).not.toEqual(null);
+        expect(result).toEqual(
+            expect.stringContaining("this.getApprovedTabs((networkSettings)"));
     });
 
     it("applyInspectorViewPatch correctly changes _showDrawer text", async () => {

--- a/src/host/polyfills/simpleView.test.ts
+++ b/src/host/polyfills/simpleView.test.ts
@@ -37,7 +37,7 @@ describe("simpleView", () => {
             expect.stringContaining("let reveal = function revealInVSCode(revealable, omitFocus) {"));
     });
 
-    it("applyHandleActionPatch correctly changes handleAction text for Quick Open", async () => {
+    it("applyQuickOpenPatch correctly changes handleAction text for Quick Open", async () => {
         const filePath = "quick_open/quick_open.js";
         const fileContents = getTextFromFile(filePath);
         if (!fileContents) {
@@ -45,24 +45,10 @@ describe("simpleView", () => {
         }
 
         const apply = await import("./simpleView");
-        const result = apply.applyHandleActionPatch(fileContents);
+        const result = apply.applyQuickOpenPatch(fileContents);
         expect(result).not.toEqual(null);
         expect(result).toEqual(
             expect.stringContaining("handleAction(context, actionId) { return false;switch(actionId){case'quickOpen.show"));
-    });
-
-    it("applyHandleActionPatch correctly changes handleAction text for Command Menu", async () => {
-        const filePath = "quick_open/quick_open.js";
-        const fileContents = getTextFromFile(filePath);
-        if (!fileContents) {
-            throw new Error(`Could not find file: ${filePath}`);
-        }
-
-        const apply = await import("./simpleView");
-        const result = apply.applyHandleActionPatch(fileContents);
-        expect(result).not.toEqual(null);
-        expect(result).toEqual(
-            expect.stringContaining("handleAction(context, actionId) { return false;InspectorFrontendHost"));
     });
 
     it("applyInspectorViewPatch correctly changes _showDrawer text", async () => {

--- a/src/host/polyfills/simpleView.test.ts
+++ b/src/host/polyfills/simpleView.test.ts
@@ -38,7 +38,7 @@ describe("simpleView", () => {
     });
 
     it("applyHandleActionPatch correctly changes handleAction text for Quick Open", async () => {
-        const filePath = "ui/ui.js";
+        const filePath = "quick_open/quick_open.js";
         const fileContents = getTextFromFile(filePath);
         if (!fileContents) {
             throw new Error(`Could not find file: ${filePath}`);
@@ -48,11 +48,11 @@ describe("simpleView", () => {
         const result = apply.applyHandleActionPatch(fileContents);
         expect(result).not.toEqual(null);
         expect(result).toEqual(
-            expect.stringContaining("handleAction(context, actionId) { return false;"));
+            expect.stringContaining("handleAction(context, actionId) { return false;switch(actionId){case'quickOpen.show"));
     });
 
     it("applyHandleActionPatch correctly changes handleAction text for Command Menu", async () => {
-        const filePath = "ui/ui.js";
+        const filePath = "quick_open/quick_open.js";
         const fileContents = getTextFromFile(filePath);
         if (!fileContents) {
             throw new Error(`Could not find file: ${filePath}`);
@@ -62,7 +62,7 @@ describe("simpleView", () => {
         const result = apply.applyHandleActionPatch(fileContents);
         expect(result).not.toEqual(null);
         expect(result).toEqual(
-            expect.stringContaining("handleAction(context, actionId) { return false;"));
+            expect.stringContaining("handleAction(context, actionId) { return false;InspectorFrontendHost"));
     });
 
     it("applyInspectorViewPatch correctly changes _showDrawer text", async () => {

--- a/src/host/polyfills/simpleView.ts
+++ b/src/host/polyfills/simpleView.ts
@@ -44,8 +44,7 @@ export function applyCommonRevealerPatch(content: string) {
 }
 
 export function applyQuickOpenPatch(content: string) {
-    // This patch removes the ability to use the
-    // quick open menu (CTRL + P)
+    // This patch removes the ability to use the quick open menu (CTRL + P)
     const pattern = /handleAction\(context,actionId\){switch\(actionId\)/;
 
     if (content.match(pattern)) {
@@ -67,12 +66,15 @@ export function applyCommandMenuPatch(content: string) {
     }
 
     const pattern2 = /if\(command.available\(\)\){this\._commands\.push\(command\);}/;
-
     if(content.match(pattern2)) {
-        return content.replace(pattern2, "if(command.available()){if(command.category() !== 'Elements'){continue;} this._commands.push(command);}");
+        return content.replace(pattern2, "if(command.available()){if(command.category() !== 'Elements' || command.title() === 'Show DOM Breakpoints'){continue;} this._commands.push(command);}");
     } else {
         return null;
     }
+}
+
+export function applyCommandMenuFilter(content: string) {
+    return "if( (command.category() !== 'Elements' && command.category() !== 'Network') || (command.category() === 'Network' && approvedTabs.enableNetwork) || command.title() === 'Show DOM Breakpoints') {continue;}";
 }
 
 // This function is needed for Elements-only version, but we need the drawer

--- a/src/host/polyfills/simpleView.ts
+++ b/src/host/polyfills/simpleView.ts
@@ -78,12 +78,10 @@ export function applyCommandMenuPatch(content: string) {
                 condition = condition && category !== 'Network';
               }
               if (!condition) {
-                /** @type {!ActionCommandOptions} */
                 const options = {action, userActionCode: undefined};
                 this._commands.push(CommandMenu.createActionCommand(options));
               }
             }
-      
             for (const command of allCommands) {
               let condition = (command.category() !== 'Elements' || command.title() === 'Show DOM Breakpoints');
               if (networkEnabled) {
@@ -99,10 +97,6 @@ export function applyCommandMenuPatch(content: string) {
     } else {
         return null;
     }
-}
-
-export function applyCommandMenuFilter(content: string) {
-    return "if( (command.category() !== 'Elements' && command.category() !== 'Network') || (command.category() === 'Network' && approvedTabs.enableNetwork) || command.title() === 'Show DOM Breakpoints') {continue;}";
 }
 
 // This function is needed for Elements-only version, but we need the drawer

--- a/src/host/polyfills/simpleView.ts
+++ b/src/host/polyfills/simpleView.ts
@@ -43,14 +43,33 @@ export function applyCommonRevealerPatch(content: string) {
     }
 }
 
-export function applyHandleActionPatch(content: string) {
+export function applyQuickOpenPatch(content: string) {
     // This patch removes the ability to use the
-    // quick open menu (CTRL + P) and command menu (CTRL + SHIFT + P)
-    const pattern = /handleAction\(context,\s*actionId\)\s*{/g;
+    // quick open menu (CTRL + P)
+    const pattern = /handleAction\(context,actionId\){switch\(actionId\)/;
 
     if (content.match(pattern)) {
         return content
-        .replace(pattern, "handleAction(context, actionId) { return false;");
+        .replace(pattern, "handleAction(context, actionId) { actionId = null; switch(actionId)");
+    } else {
+        return null;
+    }
+}
+
+export function applyCommandMenuPatch(content: string) {
+    // This patch modifies the available options in the command menu.
+    const pattern = /action\.category\(\);if\(\!category\)/;
+
+    if(content.match(pattern)) {
+        content = content.replace(pattern, "action.category();if(!category || category !== 'Elements')");
+    } else {
+        return null;
+    }
+
+    const pattern2 = /if\(command.available\(\)\){this\._commands\.push\(command\);}/;
+
+    if(content.match(pattern2)) {
+        return content.replace(pattern2, "if(command.available()){if(command.category() !== 'Elements'){continue;} this._commands.push(command);}");
     } else {
         return null;
     }

--- a/src/host/polyfills/simpleView.ts
+++ b/src/host/polyfills/simpleView.ts
@@ -64,6 +64,7 @@ export function applyCommandMenuPatch(content: string) {
         return null;
     }
 
+    // pattern intended to match logic of CommandMenu.attach()
     const pattern = /for\(const action of actions\){const category=action[\s\S]+this\._commands\.sort\(commandComparator\);/;
     if(content.match(pattern)) {
         return content.replace(pattern, `this.getApprovedTabs((networkSettings) => {


### PR DESCRIPTION
Quick open and command menu should be disabled via this commit: https://github.com/microsoft/vscode-edge-devtools/pull/131

This PR re-disables the Quick open menu, but leaves the command menu available with filtered commands.  The commands will contain the commands from the available tabs (Only Elements commands when Network is disabled and Elements and Network commands when Network is enabled.)

![command-menu](https://user-images.githubusercontent.com/14304598/97610989-d3aba480-19d2-11eb-9cf1-f39ecb10c20d.gif)
