### PR TITLE
Implement workaround for copy functionality for Mac

### DIFF
--- a/src/common/webviewEvents.ts
+++ b/src/common/webviewEvents.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 export type WebviewEvent = "getState" | "getUrl" | "openInEditor" | "ready" | "setState" | "telemetry" | "websocket"
-| "getApprovedTabs";
+| "getApprovedTabs" | "keyObject";
 export const webviewEventNames: WebviewEvent[] = [
     "getState",
     "getUrl",
@@ -12,6 +12,7 @@ export const webviewEventNames: WebviewEvent[] = [
     "telemetry",
     "websocket",
     "getApprovedTabs",
+    "keyObject",
 ];
 
 export type WebSocketEvent = "open" | "close" | "error" | "message";

--- a/src/common/webviewEvents.ts
+++ b/src/common/webviewEvents.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 export type WebviewEvent = "getState" | "getUrl" | "openInEditor" | "ready" | "setState" | "telemetry" | "websocket"
-| "getApprovedTabs" | "keyObject";
+| "getApprovedTabs" | "copyText";
 export const webviewEventNames: WebviewEvent[] = [
     "getState",
     "getUrl",
@@ -12,7 +12,7 @@ export const webviewEventNames: WebviewEvent[] = [
     "telemetry",
     "websocket",
     "getApprovedTabs",
-    "keyObject",
+    "copyText",
 ];
 
 export type WebSocketEvent = "open" | "close" | "error" | "message";

--- a/src/devtoolsPanel.ts
+++ b/src/devtoolsPanel.ts
@@ -60,6 +60,7 @@ export class DevToolsPanel {
         this.panelSocket.on("getUrl", (msg) => this.onSocketGetUrl(msg));
         this.panelSocket.on("openInEditor", (msg) => this.onSocketOpenInEditor(msg));
         this.panelSocket.on("close", () => this.onSocketClose());
+        this.panelSocket.on("keyObject", (msg) => this.onKeyPress(msg));
 
         // Handle closing
         this.panel.onDidDispose(() => {
@@ -104,6 +105,10 @@ export class DevToolsPanel {
                 break;
         }
         encodeMessageForChannel((msg) => this.panel.webview.postMessage(msg), "websocket", { event: e, message });
+    }
+
+    private onKeyPress(message: string) {
+        // const telemetry: TelemetryData = JSON.parse(message);
     }
 
     private onSocketReady() {
@@ -251,6 +256,7 @@ export class DevToolsPanel {
         this.panel.webview.html = this.getHtmlForWebview();
     }
 
+    // potentially add keydown to the webview here.
     private getHtmlForWebview() {
         const htmlPath = vscode.Uri.file(path.join(this.extensionPath, "out/tools/front_end", "inspector.html"));
         const htmlUri = this.panel.webview.asWebviewUri(htmlPath);

--- a/src/devtoolsPanel.ts
+++ b/src/devtoolsPanel.ts
@@ -60,7 +60,7 @@ export class DevToolsPanel {
         this.panelSocket.on("getUrl", (msg) => this.onSocketGetUrl(msg));
         this.panelSocket.on("openInEditor", (msg) => this.onSocketOpenInEditor(msg));
         this.panelSocket.on("close", () => this.onSocketClose());
-        this.panelSocket.on("keyObject", (msg) => this.onKeyPress(msg));
+        this.panelSocket.on("copyText", (msg) => this.onCopy(msg));
 
         // Handle closing
         this.panel.onDidDispose(() => {
@@ -107,9 +107,8 @@ export class DevToolsPanel {
         encodeMessageForChannel((msg) => this.panel.webview.postMessage(msg), "websocket", { event: e, message });
     }
 
-    private onKeyPress(message: string) {
-        console.log(message);
-        // const telemetry: TelemetryData = JSON.parse(message);
+    private onCopy(message: string) {
+        vscode.env.clipboard.writeText(message);
     }
 
     private onSocketReady() {
@@ -285,11 +284,6 @@ export class DevToolsPanel {
             <body>
                 <iframe id="host" frameBorder="0" src="${htmlUri}?ws=trueD&experiments=true&edgeThemes=true"></iframe>
             </body>
-            <script>
-            window.addEventListener("message", (e) => {
-                window.dispatchEvent(new KeyboardEvent('keydown', JSON.parse(e.data)));
-            }, false);
-            </script>
             </html>
             `;
     }

--- a/src/devtoolsPanel.ts
+++ b/src/devtoolsPanel.ts
@@ -108,6 +108,7 @@ export class DevToolsPanel {
     }
 
     private onKeyPress(message: string) {
+        console.log(message);
         // const telemetry: TelemetryData = JSON.parse(message);
     }
 
@@ -284,6 +285,11 @@ export class DevToolsPanel {
             <body>
                 <iframe id="host" frameBorder="0" src="${htmlUri}?ws=trueD&experiments=true&edgeThemes=true"></iframe>
             </body>
+            <script>
+            window.addEventListener("message", (e) => {
+                window.dispatchEvent(new KeyboardEvent('keydown', JSON.parse(e.data)));
+            }, false);
+            </script>
             </html>
             `;
     }

--- a/src/host/host.ts
+++ b/src/host/host.ts
@@ -61,18 +61,11 @@ export function initialize(dtWindow: IDevToolsWindow) {
     });
 
     dtWindow.addEventListener("keydown", (e) => {
-        const obj = {
-            altKey: e.altKey,
-            code: e.code,
-            ctrlKey: e.ctrlKey,
-            isComposing: e.isComposing,
-            key: e.key,
-            location: e.location,
-            metaKey: e.metaKey,
-            repeat: e.repeat,
-            shiftKey: e.shiftKey
+        if (e.metaKey && e.code === "KeyC") {
+            const selection = dtWindow.getSelection();
+            if (selection) {
+                dtWindow.InspectorFrontendHost.copyText(selection.toString());
+            }
         }
-        window.parent.postMessage( JSON.stringify(obj), '*');
-        dtWindow.InspectorFrontendHost.sendKeyObject(obj);
     });
 }

--- a/src/host/host.ts
+++ b/src/host/host.ts
@@ -59,4 +59,20 @@ export function initialize(dtWindow: IDevToolsWindow) {
 
         dtWindow.importScriptPathPrefix = dtWindow.importScriptPathPrefix.replace("null", "vscode-webview-resource:");
     });
+
+    dtWindow.addEventListener("keydown", (e) => {
+        window.parent.dispatchEvent(new KeyboardEvent('keydown', e));
+        // const obj = {
+        //     altKey: e.altKey,
+        //     code: e.code,
+        //     ctrlKey: e.ctrlKey,
+        //     isComposing: e.isComposing,
+        //     key: e.key,
+        //     location: e.location,
+        //     metaKey: e.metaKey,
+        //     repeat: e.repeat,
+        //     shiftKey: e.shiftKey
+        // }
+        // dtWindow.InspectorFrontendHost.sendKeyObject(obj);
+    });
 }

--- a/src/host/host.ts
+++ b/src/host/host.ts
@@ -61,18 +61,18 @@ export function initialize(dtWindow: IDevToolsWindow) {
     });
 
     dtWindow.addEventListener("keydown", (e) => {
-        window.parent.dispatchEvent(new KeyboardEvent('keydown', e));
-        // const obj = {
-        //     altKey: e.altKey,
-        //     code: e.code,
-        //     ctrlKey: e.ctrlKey,
-        //     isComposing: e.isComposing,
-        //     key: e.key,
-        //     location: e.location,
-        //     metaKey: e.metaKey,
-        //     repeat: e.repeat,
-        //     shiftKey: e.shiftKey
-        // }
-        // dtWindow.InspectorFrontendHost.sendKeyObject(obj);
+        const obj = {
+            altKey: e.altKey,
+            code: e.code,
+            ctrlKey: e.ctrlKey,
+            isComposing: e.isComposing,
+            key: e.key,
+            location: e.location,
+            metaKey: e.metaKey,
+            repeat: e.repeat,
+            shiftKey: e.shiftKey
+        }
+        window.parent.postMessage( JSON.stringify(obj), '*');
+        dtWindow.InspectorFrontendHost.sendKeyObject(obj);
     });
 }

--- a/src/host/toolsHost.ts
+++ b/src/host/toolsHost.ts
@@ -86,8 +86,9 @@ export default class ToolsHost {
         encodeMessageForChannel((msg) => window.parent.postMessage(msg, "*"), "getApprovedTabs", {id});
     }
 
-    public sendKeyObject(keyObject: Object) {
-        encodeMessageForChannel((msg) => window.parent.postMessage(msg, "*"), "keyObject", keyObject);
+    public copyText(copyText: string) {
+        const message = `copyText:${copyText}`;
+        window.parent.postMessage(message,"*");
     }
 
     public onMessageFromChannel(e: WebviewEvent, args: string): boolean {

--- a/src/host/toolsHost.ts
+++ b/src/host/toolsHost.ts
@@ -86,6 +86,10 @@ export default class ToolsHost {
         encodeMessageForChannel((msg) => window.parent.postMessage(msg, "*"), "getApprovedTabs", {id});
     }
 
+    public sendKeyObject(keyObject: Object) {
+        encodeMessageForChannel((msg) => window.parent.postMessage(msg, "*"), "keyObject", keyObject);
+    }
+
     public onMessageFromChannel(e: WebviewEvent, args: string): boolean {
         switch (e) {
             case "getState": {


### PR DESCRIPTION
Currently, the mac meta key is not being propagated out of the DevTools iframe.  This PR contains a workaround where the selected text is written to the keyboard when the DevTools iframe registers a MetaKey + C keypress.