### PR TITLE
Implementing listeners for mac meta key

### DIFF
--- a/src/host/host.ts
+++ b/src/host/host.ts
@@ -59,4 +59,27 @@ export function initialize(dtWindow: IDevToolsWindow) {
 
         dtWindow.importScriptPathPrefix = dtWindow.importScriptPathPrefix.replace("null", "vscode-webview-resource:");
     });
+
+    dtWindow.addEventListener("keydown", (e) => {
+        if (e.metaKey) {
+            if (e.code === "KeyC") {
+                dtWindow.document.execCommand("copy");
+            }
+            if (e.code === "KeyX") {
+                dtWindow.document.execCommand("cut");
+            }
+            if (e.code === "KeyV") {
+                dtWindow.document.execCommand("paste");
+            }
+            if (e.code === "KeyA") {
+                dtWindow.document.execCommand("selectAll");
+            }
+            if (e.code === "KeyZ") {
+                dtWindow.document.execCommand("undo");
+            }
+            if (e.code === "KeyY") {
+                dtWindow.document.execCommand("redo");
+            }
+        }
+    });
 }


### PR DESCRIPTION
Mac meta key (command key) is not propagated out of the DevTools IFrame.  This change creates a keydown listener inside the iframe to execute shortcut commands using the meta key.

Functionalities include:
- copy ( meta + C )
- cut ( meta + X )
- paste ( meta + V )
- select all ( meta + A )
- undo ( meta + Z )
- redo ( meta + Y )