### PR TITLE
[Polyfill]: Removing revealable context menu options that link to non-supported tools

### DIFF
--- a/postBuildStep.ts
+++ b/postBuildStep.ts
@@ -19,6 +19,7 @@ import {
     applyMainViewPatch,
     applyPersistRequestBlockingTab,
     applyRemoveBreakOnContextMenuItem,
+    applyRemoveNonSupportedRevealContextMenu,
     applySetTabIconPatch,
     applyShowElementsTab,
     applyShowRequestBlockingTab,
@@ -97,6 +98,9 @@ async function patchFilesForWebView(toolsOutDir: string) {
     ]);
     await patchFileForWebViewWrapper("common/common.js", toolsOutDir, [
         applyCommonRevealerPatch,
+    ]);
+    await patchFileForWebViewWrapper("components/components.js", toolsOutDir, [
+        applyRemoveNonSupportedRevealContextMenu,
     ]);
     await patchFileForWebViewWrapper("elements/elements_module.js", toolsOutDir, [
         applyPaddingInlineCssPatch,

--- a/src/host/polyfills/simpleView.test.ts
+++ b/src/host/polyfills/simpleView.test.ts
@@ -280,4 +280,18 @@ describe("simpleView", () => {
         expect(result).not.toEqual(null);
         expect(result).toEqual(expect.stringContaining(expectedResult));
     });
+
+    it("applyRemoveNonSupportedRevealContextMenu correctly changes text", async () => {
+        const filePath = "components/components.js";
+        const fileContents = getTextFromFile(filePath);
+        if (!fileContents) {
+            throw new Error(`Could not find file: ${filePath}`);
+        }
+
+        const expectedResult = "if(destination === \"Elements panel\")";
+        const apply = await import("./simpleView");
+        const result = apply.applyRemoveNonSupportedRevealContextMenu(fileContents);
+        expect(result).not.toEqual(null);
+        expect(result).toEqual(expect.stringContaining(expectedResult));
+    });
 });

--- a/src/host/polyfills/simpleView.ts
+++ b/src/host/polyfills/simpleView.ts
@@ -346,3 +346,14 @@ export function applyInspectorCommonCssTabSliderPatch(content: string) {
         return null;
     }
 }
+
+export function applyRemoveNonSupportedRevealContextMenu(content: string) {
+    const pattern = /result\.push\({section:'reveal',title:destination.+reveal\(revealable\)}\);/;
+    const match = content.match(pattern);
+    if (match) {
+        const matchedString = match[0];
+        return content.replace(pattern, `if(destination === "Elements panel"){${matchedString}}`);
+    } else {
+        return null;
+    }
+}


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/14304598/97355326-febbba00-1853-11eb-9d7a-0527980293ce.png)

After:
![image](https://user-images.githubusercontent.com/14304598/97355438-24e15a00-1854-11eb-9f49-fd36c6943309.png)

Closes #220