### PR TITLE
[Update]: Upgrading Edge DevTools version to 85.0.564.40

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 1.1.2
+* Bumping Edge Devtools version from 84.0.522.63 to 85.0.564.40 - [PR #234](https://github.com/microsoft/vscode-edge-devtools/pull/234)
+* Included Debugger for Microsoft Edge as a dependency - [PR #233](https://github.com/microsoft/vscode-edge-devtools/pull/233)
+* Implemented settings option to change extension themes - [PR #229](https://github.com/microsoft/vscode-edge-devtools/pull/229)
+
 ## 1.1.1
 * Adding support for Linux - [PR #225](https://github.com/microsoft/vscode-edge-devtools/pull/225)
 * Fixing command key shortcuts for Mac users - [PR #223](https://github.com/microsoft/vscode-edge-devtools/pull/223)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## 1.1.2
-* Bumping Edge Devtools version from 84.0.522.63 to 85.0.564.40 - [PR #234](https://github.com/microsoft/vscode-edge-devtools/pull/234)
+* Bumping Edge Devtools version from 84.0.522.63 to 85.0.564.40 - [PR #235](https://github.com/microsoft/vscode-edge-devtools/pull/235)
 * Included Debugger for Microsoft Edge as a dependency - [PR #233](https://github.com/microsoft/vscode-edge-devtools/pull/233)
 * Implemented settings option to change extension themes - [PR #229](https://github.com/microsoft/vscode-edge-devtools/pull/229)
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -41,7 +41,7 @@ Here are a list of recommended VS Code extensions to use when developing for vsc
 
 ## Legacy Source File Setup
 Use this method if the automated methods fail or if the desired version is not supported by the download script.
-* Download a copy of the Microsoft Edge build from [https://thirdpartysource.microsoft.com](https://thirdpartysource.microsoft.com), current extension version builds from version 84.0.522.63.
+* Download a copy of the Microsoft Edge build from [https://thirdpartysource.microsoft.com](https://thirdpartysource.microsoft.com), current extension version builds from version 85.0.564.40.
   * Note: Download the 'Microsoft Edge DevTools' zip if available in the desired version and platform - it will be much faster.
 * Extract the necessary files from the zip
   * On an administrator prompt execute the following commands (assuming your drive is located at C:\)

--- a/postBuildStep.ts
+++ b/postBuildStep.ts
@@ -10,6 +10,7 @@ import {
     applyAppendTabPatch,
     applyCommonRevealerPatch,
     applyCommandMenuPatch,
+    applyDefaultTabPatch,
     applyDrawerTabLocationPatch,
     applyQuickOpenPatch,
     applyInspectorCommonContextMenuPatch,
@@ -22,8 +23,8 @@ import {
     applyPersistRequestBlockingTab,
     applyRemoveBreakOnContextMenuItem,
     applyRemoveNonSupportedRevealContextMenu,
+    applyRemovePreferencePatch,
     applySetTabIconPatch,
-    applyShowElementsTab,
     applyShowRequestBlockingTab,
     applyThemePatch,
 } from "./src/host/polyfills/simpleView";
@@ -109,15 +110,18 @@ async function patchFilesForWebView(toolsOutDir: string) {
     await patchFileForWebViewWrapper("elements/elements_module.js", toolsOutDir, [
         applyPaddingInlineCssPatch,
     ]);
+    await patchFileForWebViewWrapper("host/host.js", toolsOutDir, [
+        applyRemovePreferencePatch,
+    ]);
     await patchFileForWebViewWrapper("inspector.html", toolsOutDir, [
         applyContentSecurityPolicyPatch,
     ]);
     await patchFileForWebViewWrapper("ui/ui.js", toolsOutDir, [
-        applyDrawerTabLocationPatch,
         applyAppendTabPatch,
+        applyDefaultTabPatch,
+        applyDrawerTabLocationPatch,
         applyPersistRequestBlockingTab,
         applySetTabIconPatch,
-        applyShowElementsTab,
         applyShowRequestBlockingTab,
     ]);
     await patchFileForWebViewWrapper("root/root.js", toolsOutDir, [

--- a/scripts/downloadAndExtractEdge.js
+++ b/scripts/downloadAndExtractEdge.js
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-const TARGET_VERSION = '84.0.522.63';
+const TARGET_VERSION = '85.0.564.40';
 const targetVersionMap = new Map([
   ['83', '83.0.478.45'],
   ['84', '84.0.522.63'],

--- a/src/host/polyfills/simpleView.test.ts
+++ b/src/host/polyfills/simpleView.test.ts
@@ -132,21 +132,6 @@ describe("simpleView", () => {
             "appendTabOverride(id, tabTitle, view, tabTooltip, userGesture, isCloseable, index) {"));
     });
 
-    it("applyShowElementsTab correctly changes text", async () => {
-        const filePath = "ui/ui.js";
-        const fileContents = getTextFromFile(filePath);
-        if (!fileContents) {
-            throw new Error(`Could not find file: ${filePath}`);
-        }
-
-        const apply = await import("./simpleView");
-        const result = apply.applyShowElementsTab(fileContents);
-        expect(result).not.toEqual(null);
-        if (result) {
-            expect(result).toEqual(expect.stringContaining("this._defaultTab = 'elements';"));
-        }
-    });
-
     it("applyRemoveBreakOnContextMenuItem correctly changes text", async () => {
         const filePath = "browser_debugger/browser_debugger.js";
         const fileContents = getTextFromFile(filePath);
@@ -324,5 +309,33 @@ describe("simpleView", () => {
         expect(result).not.toEqual(null);
         expect(result).toEqual(expect.stringContaining(expectedResult));
         expect(result).toEqual(expect.stringContaining(expectedResult2));
+    });
+
+    it("applyDefaultTabPatch correctly modifies text to prevent usage of TabbedLocation._defaultTab", async () => {
+        const filePath = "ui/ui.js";
+        const fileContents = getTextFromFile(filePath);
+        if (!fileContents) {
+            throw new Error(`Could not find file: ${filePath}`);
+        }
+
+        const expectedResult = "this._defaultTab=undefined;";
+        const apply = await import("./simpleView");
+        const result = apply.applyDefaultTabPatch(fileContents);
+        expect(result).not.toEqual(null);
+        expect(result).toEqual(expect.stringContaining(expectedResult));
+    });
+
+    it("applyRemovePreferencePatch correctly modifes host.js to ignore localStorage deletion", async () => {
+        const filePath = "host/host.js";
+        const fileContents = getTextFromFile(filePath);
+        if (!fileContents) {
+            throw new Error(`Could not find file: ${filePath}`);
+        }
+
+        const expectedResult = "removePreference(name){return;}";
+        const apply = await import("./simpleView");
+        const result = apply.applyRemovePreferencePatch(fileContents);
+        expect(result).not.toEqual(null);
+        expect(result).toEqual(expect.stringContaining(expectedResult));
     });
 });

--- a/src/host/polyfills/simpleView.ts
+++ b/src/host/polyfills/simpleView.ts
@@ -123,18 +123,6 @@ export function applyMainViewPatch(content: string) {
     }
 }
 
-export function applyShowElementsTab(content: string) {
-    // This tab sets the Elements tool as the default tab,
-    // so the extension will always show the Elements tool first.
-    const pattern = /this\._defaultTab\s*=\s*defaultTab;/;
-
-    if (content.match(pattern)) {
-        return content.replace(pattern, "this._defaultTab = 'elements';");
-    } else {
-        return null;
-    }
-}
-
 export function applyRemoveBreakOnContextMenuItem(content: string) {
     const pattern = /const breakpointsMenu=.+hasDOMBreakpoint\(.*\);}/;
     if (content.match(pattern)) {
@@ -260,6 +248,16 @@ export function applyEnableNetworkPatch(): string {
     return `if(approvedTabs.enableNetwork) {
         patchedCondition = patchedCondition && (${networkCondition});
     }`;
+}
+
+export function applyDefaultTabPatch(content: string) {
+    // This patches removes the _defaultTab property
+    const pattern = /this\._defaultTab=[^;]+;/g;
+    if (content.match(pattern)) {
+        return content.replace(pattern,"this._defaultTab=undefined;");
+    } else {
+        return null;
+    }
 }
 
 export function applyDrawerTabLocationPatch(content: string) {
@@ -443,6 +441,17 @@ export function applyMainThemePatch(content: string) {
     const createAppPattern = /;init\(\);/;
     if (content.match(createAppPattern)) {
         return content.replace(createAppPattern, `;const theme = await this.getThemePromise(); init(theme);`);
+    } else {
+        return null;
+    }
+}
+
+export function applyRemovePreferencePatch(content: string) {
+    // This patch returns early whe trying to remove localStorage which we already set as undefined
+    const pattern = /removePreference\(name\){delete window\.localStorage\[name\];}/;
+    const match = content.match(pattern);
+    if (match) {
+        return content.replace(pattern, "removePreference(name){return;}");
     } else {
         return null;
     }


### PR DESCRIPTION
Upgrading to version 85.0.564.40.

Changes:
- Adding `applyRemovePreferencePatch` and `applyDefaultTabPatch`
    - `applyRemovePreferencePatch` patches the `removePreference` function such that it does not try to delete objects from `localStorage` which is set to `undefined` in the extension
    -`applyDefaultTabPatch` removes the need of `TabbedLocation._defaultTab` which was causing issues with our `applyAppendTabPatch`.
- Removing `applyShowElementsTab`
    - removing this patch that sets `_defaultTab` to `elements`
    - This is generally unnecessary as it will default to Elements if Network is disabled and we do not want to pigeonhole users to the Elements panel if Network is enabled.
- Updating extension version to `1.1.2`


