### PR TITLE
[Bug Fix]: Fix command menu copy functions

### DIFF
--- a/src/common/webviewEvents.ts
+++ b/src/common/webviewEvents.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 export type WebviewEvent = "getState" | "getUrl" | "openInEditor" | "ready" | "setState" | "telemetry" | "websocket"
-| "getApprovedTabs" | "getThemes";
+| "getApprovedTabs" | "getThemes" | "copyText";
 export const webviewEventNames: WebviewEvent[] = [
     "getState",
     "getUrl",
@@ -13,6 +13,7 @@ export const webviewEventNames: WebviewEvent[] = [
     "websocket",
     "getApprovedTabs",
     "getThemes",
+    "copyText",
 ];
 
 export type WebSocketEvent = "open" | "close" | "error" | "message";

--- a/src/devtoolsPanel.ts
+++ b/src/devtoolsPanel.ts
@@ -122,8 +122,9 @@ export class DevToolsPanel {
         this.dispose();
     }
 
-    private onSocketCopyText(msg: string) {
-        vscode.env.clipboard.writeText(msg)
+    private onSocketCopyText(message: string) {
+        const { clipboardData } = JSON.parse(message) as { clipboardData: string };
+        vscode.env.clipboard.writeText(clipboardData);
     }
 
     private onSocketTelemetry(message: string) {

--- a/src/devtoolsPanel.ts
+++ b/src/devtoolsPanel.ts
@@ -61,6 +61,7 @@ export class DevToolsPanel {
         this.panelSocket.on("getUrl", (msg) => this.onSocketGetUrl(msg));
         this.panelSocket.on("openInEditor", (msg) => this.onSocketOpenInEditor(msg));
         this.panelSocket.on("close", () => this.onSocketClose());
+        this.panelSocket.on("copyText", (msg) => this.onSocketCopyText(msg));
 
         // Handle closing
         this.panel.onDidDispose(() => {
@@ -119,6 +120,10 @@ export class DevToolsPanel {
 
     private onSocketClose() {
         this.dispose();
+    }
+
+    private onSocketCopyText(msg: string) {
+        vscode.env.clipboard.writeText(msg)
     }
 
     private onSocketTelemetry(message: string) {

--- a/src/host/toolsHost.ts
+++ b/src/host/toolsHost.ts
@@ -93,6 +93,11 @@ export default class ToolsHost {
         encodeMessageForChannel((msg) => window.parent.postMessage(msg, "*"), "getThemes", {id});
     }
 
+    public copyText(clipboardData: string) {
+        const postMessage = "copyText:" + clipboardData;
+        window.parent.postMessage(postMessage, "*");
+    }
+
     public onMessageFromChannel(e: WebviewEvent, args: string): boolean {
         switch (e) {
             case "getState": {

--- a/src/host/toolsHost.ts
+++ b/src/host/toolsHost.ts
@@ -94,8 +94,7 @@ export default class ToolsHost {
     }
 
     public copyText(clipboardData: string) {
-        const postMessage = "copyText:" + clipboardData;
-        window.parent.postMessage(postMessage, "*");
+        encodeMessageForChannel((msg) => window.parent.postMessage(msg, "*"), "copyText", {clipboardData});
     }
 
     public onMessageFromChannel(e: WebviewEvent, args: string): boolean {


### PR DESCRIPTION
This PR closes #231 by implementing a `copyText` function within `toolsHost.ts` which overwrites the original `copyText` function implemented in `InspectorFrontendHost`.

Command menu copy functions:
![image](https://user-images.githubusercontent.com/14304598/99847501-09a0fc00-2b2d-11eb-9081-24a3d4a48230.png)
