### PR TITLE
[Keyboard Shortcuts]: Adding focus next/previous editor listeners inside dtwindow to quickly switch between panes

### DIFF
--- a/src/common/webviewEvents.ts
+++ b/src/common/webviewEvents.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 export type WebviewEvent = "getState" | "getUrl" | "openInEditor" | "ready" | "setState" | "telemetry" | "websocket"
-| "getApprovedTabs" | "getThemes" | "copyText";
+| "getApprovedTabs" | "getThemes" | "copyText" | "focusNextEditor" | "focusPreviousEditor";
 export const webviewEventNames: WebviewEvent[] = [
     "getState",
     "getUrl",
@@ -14,6 +14,8 @@ export const webviewEventNames: WebviewEvent[] = [
     "getApprovedTabs",
     "getThemes",
     "copyText",
+    "focusNextEditor",
+    "focusPreviousEditor",
 ];
 
 export type WebSocketEvent = "open" | "close" | "error" | "message";

--- a/src/devtoolsPanel.ts
+++ b/src/devtoolsPanel.ts
@@ -62,6 +62,8 @@ export class DevToolsPanel {
         this.panelSocket.on("openInEditor", (msg) => this.onSocketOpenInEditor(msg));
         this.panelSocket.on("close", () => this.onSocketClose());
         this.panelSocket.on("copyText", (msg) => this.onSocketCopyText(msg));
+        this.panelSocket.on("focusNextEditor", () => this.onSocketFocusNextEditor());
+        this.panelSocket.on("focusPreviousEditor", () => this.onSocketFocusPreviousEditor());
 
         // Handle closing
         this.panel.onDidDispose(() => {
@@ -125,6 +127,14 @@ export class DevToolsPanel {
     private onSocketCopyText(message: string) {
         const { clipboardData } = JSON.parse(message) as { clipboardData: string };
         vscode.env.clipboard.writeText(clipboardData);
+    }
+
+    private onSocketFocusNextEditor() {
+        vscode.commands.executeCommand("workbench.action.nextEditor");
+    }
+
+    private onSocketFocusPreviousEditor() {
+        vscode.commands.executeCommand("workbench.action.previousEditor");
     }
 
     private onSocketTelemetry(message: string) {

--- a/src/host/host.ts
+++ b/src/host/host.ts
@@ -81,5 +81,11 @@ export function initialize(dtWindow: IDevToolsWindow) {
                 dtWindow.document.execCommand("redo");
             }
         }
+        if (e.ctrlKey && e.code === "PageDown") {
+            dtWindow.InspectorFrontendHost.focusNextEditor();
+        }
+        if (e.ctrlKey && e.code === "PageUp") {
+            dtWindow.InspectorFrontendHost.focusPreviousEditor();
+        }
     });
 }

--- a/src/host/toolsHost.ts
+++ b/src/host/toolsHost.ts
@@ -97,6 +97,14 @@ export default class ToolsHost {
         encodeMessageForChannel((msg) => window.parent.postMessage(msg, "*"), "copyText", {clipboardData});
     }
 
+    public focusNextEditor() {
+        encodeMessageForChannel((msg) => window.parent.postMessage(msg, "*"), "focusNextEditor", {});
+    }
+
+    public focusPreviousEditor() {
+        encodeMessageForChannel((msg) => window.parent.postMessage(msg, "*"), "focusPreviousEditor", {});
+    }
+
     public onMessageFromChannel(e: WebviewEvent, args: string): boolean {
         switch (e) {
             case "getState": {


### PR DESCRIPTION
The DevTools window traps keyboard shortcuts inside the iframe, so users who are focused inside the DevTools cannot navigate in/out using `CTRL + PageDown` or `CTRL + PageUp`.  This change implements the next/previous editor shortcut keys within the DevTools window to allow users to easily switch between windows with the next/previous shortcuts.

closes #208 