### PR TITLE
[Shortcuts]: Add Focus next/previous editor group

### DIFF
--- a/src/common/webviewEvents.ts
+++ b/src/common/webviewEvents.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 export type WebviewEvent = "getState" | "getUrl" | "openInEditor" | "ready" | "setState" | "telemetry" | "websocket"
-| "getApprovedTabs" | "getThemes" | "copyText" | "focusNextEditor" | "focusPreviousEditor";
+| "getApprovedTabs" | "getThemes" | "copyText" | "focusEditor" | "focusEditorGroup";
 export const webviewEventNames: WebviewEvent[] = [
     "getState",
     "getUrl",
@@ -14,8 +14,8 @@ export const webviewEventNames: WebviewEvent[] = [
     "getApprovedTabs",
     "getThemes",
     "copyText",
-    "focusNextEditor",
-    "focusPreviousEditor",
+    "focusEditor",
+    "focusEditorGroup",
 ];
 
 export type WebSocketEvent = "open" | "close" | "error" | "message";

--- a/src/devtoolsPanel.ts
+++ b/src/devtoolsPanel.ts
@@ -62,8 +62,8 @@ export class DevToolsPanel {
         this.panelSocket.on("openInEditor", (msg) => this.onSocketOpenInEditor(msg));
         this.panelSocket.on("close", () => this.onSocketClose());
         this.panelSocket.on("copyText", (msg) => this.onSocketCopyText(msg));
-        this.panelSocket.on("focusNextEditor", () => this.onSocketFocusNextEditor());
-        this.panelSocket.on("focusPreviousEditor", () => this.onSocketFocusPreviousEditor());
+        this.panelSocket.on("focusEditor", (msg) => this.onSocketFocusEditor(msg));
+        this.panelSocket.on("focusEditorGroup", (msg) => this.onSocketFocusEditorGroup(msg));
 
         // Handle closing
         this.panel.onDidDispose(() => {
@@ -129,12 +129,22 @@ export class DevToolsPanel {
         vscode.env.clipboard.writeText(clipboardData);
     }
 
-    private onSocketFocusNextEditor() {
-        vscode.commands.executeCommand("workbench.action.nextEditor");
+    private onSocketFocusEditor(message: string) {
+        const { next } = JSON.parse(message) as { next: boolean };
+        if (next) {
+            vscode.commands.executeCommand("workbench.action.nextEditor");
+        } else {
+            vscode.commands.executeCommand("workbench.action.previousEditor");
+        }
     }
 
-    private onSocketFocusPreviousEditor() {
-        vscode.commands.executeCommand("workbench.action.previousEditor");
+    private onSocketFocusEditorGroup(message: string) {
+        const { next } = JSON.parse(message) as { next: boolean };
+        if (next) {
+            vscode.commands.executeCommand("workbench.action.focusNextGroup");
+        } else {
+            vscode.commands.executeCommand("workbench.action.focusPreviousGroup");
+        }
     }
 
     private onSocketTelemetry(message: string) {

--- a/src/host/host.ts
+++ b/src/host/host.ts
@@ -6,6 +6,8 @@ import ToolsHost from "./toolsHost";
 import ToolsResourceLoader, { IRuntimeResourceLoader } from "./toolsResourceLoader";
 import ToolsWebSocket from "./toolsWebSocket";
 
+let listenForSecondKeyChord = false;
+
 export interface IDevToolsWindow extends Window {
     InspectorFrontendHost: ToolsHost;
     WebSocket: typeof ToolsWebSocket;
@@ -81,11 +83,29 @@ export function initialize(dtWindow: IDevToolsWindow) {
                 dtWindow.document.execCommand("redo");
             }
         }
-        if (e.ctrlKey && e.code === "PageDown") {
-            dtWindow.InspectorFrontendHost.focusNextEditor();
+        const isCtrlOrCmdKey = (e.ctrlKey || e.metaKey);
+        if (!isCtrlOrCmdKey && listenForSecondKeyChord) {
+            listenForSecondKeyChord = false;
         }
-        if (e.ctrlKey && e.code === "PageUp") {
-            dtWindow.InspectorFrontendHost.focusPreviousEditor();
+
+        if (isCtrlOrCmdKey && e.code === "PageDown") {
+            dtWindow.InspectorFrontendHost.focusEditor(/** next= */ true);
+        }
+        if (isCtrlOrCmdKey && e.code === "PageUp") {
+            dtWindow.InspectorFrontendHost.focusEditor(/** next= */ false);
+        }
+        if (isCtrlOrCmdKey && e.code === "KeyK") {
+            listenForSecondKeyChord = true;
+        }
+        if (listenForSecondKeyChord) {
+            if (isCtrlOrCmdKey  && e.code === "ArrowRight"){
+                dtWindow.InspectorFrontendHost.focusEditorGroup(/** next= */ true);
+                listenForSecondKeyChord = false;
+            }
+            if (isCtrlOrCmdKey && e.code === "ArrowLeft") {
+                dtWindow.InspectorFrontendHost.focusEditorGroup(/** next= */ false);
+                listenForSecondKeyChord = false;
+            }
         }
     });
 }

--- a/src/host/toolsHost.ts
+++ b/src/host/toolsHost.ts
@@ -97,12 +97,12 @@ export default class ToolsHost {
         encodeMessageForChannel((msg) => window.parent.postMessage(msg, "*"), "copyText", {clipboardData});
     }
 
-    public focusNextEditor() {
-        encodeMessageForChannel((msg) => window.parent.postMessage(msg, "*"), "focusNextEditor", {});
+    public focusEditor(next: boolean) {
+        encodeMessageForChannel((msg) => window.parent.postMessage(msg, "*"), "focusEditor", {next});
     }
 
-    public focusPreviousEditor() {
-        encodeMessageForChannel((msg) => window.parent.postMessage(msg, "*"), "focusPreviousEditor", {});
+    public focusEditorGroup(next: boolean) {
+        encodeMessageForChannel((msg) => window.parent.postMessage(msg, "*"), "focusEditorGroup", {next});
     }
 
     public onMessageFromChannel(e: WebviewEvent, args: string): boolean {


### PR DESCRIPTION
This PR adds shortcuts for `workbench.action.focusPreviousGroup` and `workbench.action.focusNextGroup`.  These commands by default in vscode require listening for a second key chord (e.g. `Ctrl + K -> Ctrl + ArrowRight` for `focusNextGroup`).  This structure is now replicated in `host.ts` with the `listenForSecondKeyChord` boolean.

Other changes include improvements to the `focusNextEditor`/`focusPreviousEditor` commands by merging them into one `focusEditor` command with an argument determining direction.

closes #208 