### PR TITLE
[VSCode Revealer]: Fix revealer workflow for style properties sections

### DIFF
--- a/postBuildStep.ts
+++ b/postBuildStep.ts
@@ -24,10 +24,11 @@ import {
     applyMainViewPatch,
     applyPersistRequestBlockingTab,
     applyRemoveBreakOnContextMenuItem,
-    applyRemoveNonSupportedRevealContextMenu,
+    applyContextMenuRevealOption,
     applyRemovePreferencePatch,
     applySetTabIconPatch,
     applyShowRequestBlockingTab,
+    applyStylesRevealerPatch,
     applyThemePatch,
 } from "./src/host/polyfills/simpleView";
 import applySetupTextSelectionPatch from "./src/host/polyfills/textSelection";
@@ -106,10 +107,13 @@ async function patchFilesForWebView(toolsOutDir: string) {
         applyCommonRevealerPatch,
     ]);
     await patchFileForWebViewWrapper("components/components.js", toolsOutDir, [
-        applyRemoveNonSupportedRevealContextMenu,
+        applyContextMenuRevealOption,
     ]);
     await patchFileForWebViewWrapper("elements/elements_module.js", toolsOutDir, [
         applyPaddingInlineCssPatch,
+    ]);
+    await patchFileForWebViewWrapper("elements/elements.js", toolsOutDir, [
+        applyStylesRevealerPatch,
     ]);
     await patchFileForWebViewWrapper("host/host.js", toolsOutDir, [
         applyRemovePreferencePatch,

--- a/src/host/polyfills/simpleView.test.ts
+++ b/src/host/polyfills/simpleView.test.ts
@@ -179,10 +179,10 @@ describe("simpleView", () => {
         await testPatch(filePath, patch, expectedStrings);
     });
 
-    it("applyRemoveNonSupportedRevealContextMenu correctly changes text", async () => {
+    it("applyContextMenuRevealOption correctly changes text", async () => {
         const filePath = "components/components.js";
-        const patch = SimpleView.applyRemoveNonSupportedRevealContextMenu;
-        const expectedStrings = ["if(destination === \"Elements panel\")"];
+        const patch = SimpleView.applyContextMenuRevealOption;
+        const expectedStrings = ['destination = "Visual Studio Code"'];
 
         await testPatch(filePath, patch, expectedStrings);
     });
@@ -233,5 +233,13 @@ describe("simpleView", () => {
         const expectedStrings = ["InspectorFrontendHost.getVscodeSettings(callback);", "this.getVscodeSettings"];
 
         testPatch(filePath, patch, expectedStrings);
+    });
+
+    it("applyStylesRevealerPatch correctly changes root.js to set extensionSettings map", async () => {
+        const filePath = "elements/elements.js";
+        const patch = SimpleView.applyStylesRevealerPatch;
+        const unexpectedStrings = ["this._navigateToSource(selectElement, true);"];
+
+        testPatch(filePath, patch, [], unexpectedStrings);
     });
 });

--- a/src/host/polyfills/simpleView.ts
+++ b/src/host/polyfills/simpleView.ts
@@ -91,11 +91,8 @@ export function applyCommonRevealerPatch(content: string) {
 
 export function applyStylesRevealerPatch(content: string) {
     const pattern = /this\._navigateToSource\(selectElement,\s*true\);/g;
-    if (content.match(pattern)) {
-        return content.replace(pattern, '');
-    } else {
-        return null;
-    }
+    const replacementText = '';
+    return replaceInSourceCode(content, pattern, replacementText);
 }
 
 export function applyQuickOpenPatch(content: string) {
@@ -356,16 +353,12 @@ export function applyInspectorCommonCssTabSliderPatch(content: string) {
 
 export function applyContextMenuRevealOption(content: string) {
     const pattern = /const destination\s*=\s*Revealer\.revealDestination\(revealable\);/;
-    const match = content.match(pattern);
-    if (match) {
-        return content.replace(pattern, `
-            let destination = Revealer.revealDestination(revealable);
-            if (destination==="Sources panel") {
-                destination = "Visual Studio Code";
-            };`);
-    } else {
-        return null;
-    }
+    const replacementText = `
+        let destination = Revealer.revealDestination(revealable);
+        if (destination==="Sources panel") {
+            destination = "Visual Studio Code";
+        };`
+    return replaceInSourceCode(content, pattern, replacementText);
 }
 
 export function applyThemePatch(content: string) {

--- a/src/host/polyfills/simpleView.ts
+++ b/src/host/polyfills/simpleView.ts
@@ -92,6 +92,24 @@ export function applyCommonRevealerPatch(content: string) {
     }
 }
 
+export function applyStylesRevealerPatch(content: string) {
+    const pattern = /this\._navigateToSource\(selectElement,\s*true\);/g;
+    if (content.match(pattern)) {
+        return content.replace(pattern, '');
+    } else {
+        return null;
+    }
+}
+
+export function applyLinkActionsPatch(content: string) {
+    const pattern = /\"Elements panel\"/g;
+    if (content.match(pattern)) {
+        return content.replace(pattern, '"Elements panel" || destination === "Sources panel"');
+    } else {
+        return null;
+    }
+}
+
 export function applyQuickOpenPatch(content: string) {
     // This patch removes the ability to use the quick open menu (CTRL + P)
     const pattern = /handleAction\(context,\s*actionId\)\s*{\s*switch\s*\(actionId\)/;
@@ -423,12 +441,15 @@ export function applyInspectorCommonCssTabSliderPatch(content: string) {
     }
 }
 
-export function applyRemoveNonSupportedRevealContextMenu(content: string) {
-    const pattern = /result\.push\({\s*section:\s*'reveal',\s*title:\s*destination[\s\S]+reveal\(revealable\)\s*}\);/;
+export function applyContextMenuRevealOption(content: string) {
+    const pattern = /const destination\s*=\s*Revealer\.revealDestination\(revealable\);/;
     const match = content.match(pattern);
     if (match) {
-        const matchedString = match[0];
-        return content.replace(pattern, `if(destination === "Elements panel"){${matchedString}}`);
+        return content.replace(pattern, `
+            let destination = Revealer.revealDestination(revealable);
+            if (destination==="Sources panel") {
+                destination = "Visual Studio Code";
+            };`);
     } else {
         return null;
     }

--- a/src/host/polyfills/simpleView.ts
+++ b/src/host/polyfills/simpleView.ts
@@ -101,15 +101,6 @@ export function applyStylesRevealerPatch(content: string) {
     }
 }
 
-export function applyLinkActionsPatch(content: string) {
-    const pattern = /\"Elements panel\"/g;
-    if (content.match(pattern)) {
-        return content.replace(pattern, '"Elements panel" || destination === "Sources panel"');
-    } else {
-        return null;
-    }
-}
-
 export function applyQuickOpenPatch(content: string) {
     // This patch removes the ability to use the quick open menu (CTRL + P)
     const pattern = /handleAction\(context,\s*actionId\)\s*{\s*switch\s*\(actionId\)/;


### PR DESCRIPTION
This PR changes revealing workflow for clicking style properties and style sheet links.

Issues:
- VSCode reveals style sheet whenever a style property is clicked
- Clicking on a style sheet in the styles properties section does not reveal anything

Changes:
- VSCode only reveals the style sheet when the user `CTRL + Click` on the style property
- Clicking on a style sheet link in the styles properties section will reveal the style sheet in VSCode.

GIF:
![extension-fix-revealer](https://user-images.githubusercontent.com/14304598/106231226-0ddd3b80-61a6-11eb-9109-6f956db3e16a.gif)
