### PR TITLE
[Bug Fix]: Disables and hides drawer when Network tool is disabled

### DIFF
--- a/postBuildStep.ts
+++ b/postBuildStep.ts
@@ -21,6 +21,8 @@ import {
     applyInspectorCommonCssRightToolbarPatch,
     applyInspectorCommonCssTabSliderPatch,
     applyInspectorCommonNetworkPatch,
+    applyInspectorViewCloseDrawerPatch,
+    applyInspectorViewShowDrawerPatch,
     applyMainViewPatch,
     applyPersistRequestBlockingTab,
     applyRemoveBreakOnContextMenuItem,
@@ -97,6 +99,7 @@ async function patchFilesForWebView(toolsOutDir: string) {
         applyInspectorCommonCssTabSliderPatch,
     ]);
     await patchFileForWebViewWrapper("main/main.js", toolsOutDir, [
+        applyInspectorViewCloseDrawerPatch,
         applyMainViewPatch,
     ]);
     await patchFileForWebViewWrapper("elements/elements.js", toolsOutDir, [
@@ -121,6 +124,7 @@ async function patchFilesForWebView(toolsOutDir: string) {
         applyAppendTabPatch,
         applyDefaultTabPatch,
         applyDrawerTabLocationPatch,
+        applyInspectorViewShowDrawerPatch,
         applyPersistRequestBlockingTab,
         applySetTabIconPatch,
         applyShowRequestBlockingTab,

--- a/src/host/polyfills/simpleView.test.ts
+++ b/src/host/polyfills/simpleView.test.ts
@@ -75,10 +75,18 @@ describe("simpleView", () => {
         await testPatch(filePath, patch, expectedStrings);
     });
 
-    it("applyInspectorViewPatch correctly changes _showDrawer text", async () => {
+    it("applyInspectorViewShowDrawerPatch correctly changes _showDrawer text", async () => {
         const filePath = "ui/ui.js";
         const patch = SimpleView.applyInspectorViewShowDrawerPatch;
-        const expectedStrings = ["_showDrawer(focus) { return false;"];
+        const expectedStrings = ["if (!Root.Runtime.vscodeSettings.enableNetwork) {return false;}"];
+
+        await testPatch(filePath, patch, expectedStrings);
+    });
+
+    it("applyInspectorViewCloseDrawerPatch correctly changes _showAppUI text", async () => {
+        const filePath = "main/main.js";
+        const patch = SimpleView.applyInspectorViewCloseDrawerPatch;
+        const expectedStrings = ["self.UI.InspectorView.instance()._closeDrawer();"];
 
         await testPatch(filePath, patch, expectedStrings);
     });


### PR DESCRIPTION
Issue:
- If the Network tool is disabled, the drawer is a blank piece of UI that can be toggled on and off
    - The drawer is used to show the Request Blocking tool when the Network tool is enabled

GIF:
![empty-drawer-broken](https://user-images.githubusercontent.com/14304598/106673769-fd8edd00-6566-11eb-9040-4052e31cfcf9.gif)

Changes:
- Disables drawer toggle when Network tool is disabled
- Will automatically close drawer upon initialization if the Network tool is disabled.

closes #234 