### PR TITLE
[Screencast]: Use default cursor when interacting with screencast view

### DIFF
--- a/postBuildStep.ts
+++ b/postBuildStep.ts
@@ -31,6 +31,7 @@ import {
     applyRemoveBreakOnContextMenuItem,
     applyContextMenuRevealOption,
     applyRemovePreferencePatch,
+    applyScreencastCursorPatch,
     applySetTabIconPatch,
     applyShowRequestBlockingTab,
     applyStylesRevealerPatch,
@@ -126,6 +127,9 @@ async function patchFilesForWebView(toolsOutDir: string) {
     ]);
     await patchFileForWebViewWrapper("inspector.html", toolsOutDir, [
         applyContentSecurityPolicyPatch,
+    ]);
+    await patchFileForWebViewWrapper("screencast/screencast.js", toolsOutDir, [
+        applyScreencastCursorPatch,
     ]);
     await patchFileForWebViewWrapper("ui/ui.js", toolsOutDir, [
         applyAppendTabOverridePatch,

--- a/src/host/polyfills/simpleView.test.ts
+++ b/src/host/polyfills/simpleView.test.ts
@@ -274,4 +274,12 @@ describe("simpleView", () => {
 
         testPatch(filePath, patch, [], unexpectedStrings);
     });
+
+    it("applyScreencastCursorPatch correctly changes inspector.js text to remove touch cursor", async () => {
+        const filePath = "screencast/screencast.js";
+        const patch = SimpleView.applyScreencastCursorPatch;
+        const expectedStrings = ["this._canvasContainerElement.style.cursor = 'unset';"];
+
+        testPatch(filePath, patch, expectedStrings);
+    });
 });

--- a/src/host/polyfills/simpleView.ts
+++ b/src/host/polyfills/simpleView.ts
@@ -381,3 +381,10 @@ export function applyRemovePreferencePatch(content: string) {
     const replacementText = "removePreference(name){return;}";
     return replaceInSourceCode(content, pattern, replacementText);
 }
+
+export function applyScreencastCursorPatch(content: string) {
+    // This patch removes the touch cursor from the screencast view
+    const pattern = /\('div',\s*'screencast-canvas-container'\);/g
+    const replacementText = "this._canvasContainerElement.style.cursor = 'unset';";
+    return replaceInSourceCode(content, pattern, replacementText, KeepMatchedText.InFront);
+}


### PR DESCRIPTION
Issue:
- Screencast uses a touch cursor, but we aren't targeting mobile devices in the extension

Changes
- Change cursor to default type for screencast view

closes #104 