### PR TITLE
[Feature]: Show target website favicon in extension sidebar

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,5 +63,8 @@ typings/
 # project specific
 out/
 coverage/
-resources/favicons/
 *.vsix
+
+# favicons - we want to ignore any downloaded .ico files but keep the directory that stores them.
+resources/favicons/*
+!resources/favicons/.gitkeep

--- a/.gitignore
+++ b/.gitignore
@@ -63,4 +63,5 @@ typings/
 # project specific
 out/
 coverage/
+resources/favicons/
 *.vsix

--- a/src/cdpTarget.ts
+++ b/src/cdpTarget.ts
@@ -14,7 +14,7 @@ export default class CDPTarget extends vscode.TreeItem {
     private readonly extensionPath: string | undefined;
     private children: CDPTarget[] = [];
 
-    constructor(targetJson: IRemoteTargetJson, propertyName: string, extensionPath?: string) {
+    constructor(targetJson: IRemoteTargetJson, propertyName: string, extensionPath?: string, iconPath?: string) {
         super(propertyName || targetJson.title || "Target",
               (propertyName ? vscode.TreeItemCollapsibleState.None : vscode.TreeItemCollapsibleState.Collapsed));
         this.targetJson = targetJson;
@@ -24,11 +24,18 @@ export default class CDPTarget extends vscode.TreeItem {
 
         // Get the icon for this type of target
         if (this.extensionPath) {
-            const icon = `${this.targetJson.type}.svg`;
-            this.iconPath = {
-                dark: path.join(this.extensionPath, "resources", "dark", icon),
-                light: path.join(this.extensionPath, "resources", "light", icon),
-            };
+            if (iconPath) {
+                this.iconPath = {
+                    dark: iconPath,
+                    light: iconPath,
+                };
+            } else {
+                const icon = `${this.targetJson.type}.svg`;
+                this.iconPath = {
+                    dark: path.join(this.extensionPath, "resources", "dark", icon),
+                    light: path.join(this.extensionPath, "resources", "light", icon),
+                };
+            }
         }
     }
 

--- a/src/cdpTargetsProvider.test.ts
+++ b/src/cdpTargetsProvider.test.ts
@@ -103,4 +103,32 @@ describe("CDPTargetsProvider", () => {
         expect(result2.length).toEqual(0);
         expect(mockReporter.sendTelemetryEvent).toHaveBeenCalled();
     });
+
+    it("check if favicons are downloaded and cleared correctly", async () => {
+        const { default: cdpTargetsProvider } = await import("./cdpTargetsProvider");
+        const fs = require('fs');
+        const dir = './resources/favicons/';
+
+        const provider = new cdpTargetsProvider(mockContext, mockReporter);
+        const microsoftIcon = await provider.downloadFaviconFromSitePromise("https://docs.microsoft.com/en-us/microsoft-edge/");
+        const bingIcon = await provider.downloadFaviconFromSitePromise("https://www.bing.com/");
+        expect(microsoftIcon).toEqual("resources\\favicons\\microsoftFavicon.ico");
+        expect(bingIcon).toEqual("resources\\favicons\\bingFavicon.ico");
+        const checkFileLengthPromise = new Promise<number>((resolve) => {
+            fs.readdir(dir, (err: Error, files: File[]) => {
+                resolve(files.length);
+            });
+        });
+        const numFiles = await checkFileLengthPromise;
+        expect(numFiles).toEqual(3); // Two favicon files plus the .gitkeep file.
+
+        await provider.clearFaviconResourceDirectory();
+        const checkFileLengthAfterDeletionPromise = new Promise<number>((resolve) => {
+            fs.readdir(dir, (err: Error, files: File[]) => {
+                resolve(files.length);
+            });
+        });
+        const numFilesAfterDeletion = await checkFileLengthAfterDeletionPromise;
+        expect(numFilesAfterDeletion).toEqual(1); // the .gitkeep file.
+    });
 });

--- a/src/cdpTargetsProvider.test.ts
+++ b/src/cdpTargetsProvider.test.ts
@@ -112,8 +112,8 @@ describe("CDPTargetsProvider", () => {
         const provider = new cdpTargetsProvider(mockContext, mockReporter);
         const microsoftIcon = await provider.downloadFaviconFromSitePromise("https://docs.microsoft.com/en-us/microsoft-edge/");
         const bingIcon = await provider.downloadFaviconFromSitePromise("https://www.bing.com/");
-        expect(microsoftIcon).toEqual("resources\\favicons\\microsoftFavicon.ico");
-        expect(bingIcon).toEqual("resources\\favicons\\bingFavicon.ico");
+        expect(microsoftIcon).not.toEqual(null);
+        expect(bingIcon).not.toEqual(null);
         const checkFileLengthPromise = new Promise<number>((resolve) => {
             fs.readdir(dir, (err: Error, files: File[]) => {
                 resolve(files.length);

--- a/src/cdpTargetsProvider.ts
+++ b/src/cdpTargetsProvider.ts
@@ -88,7 +88,10 @@ export default class CDPTargetsProvider implements vscode.TreeDataProvider<CDPTa
         this.changeDataEvent.fire(null);
     }
 
-    private downloadFaviconFromSitePromise(url: string, targets: any, actualTarget: any) : Promise<string | null> | null {
+    private downloadFaviconFromSitePromise(url: string) : Promise<string | null> | null {
+        if (!this.extensionPath || !url) {
+            return null;
+        }
         const https = require('https');
         const fs = require('fs');
         const faviconRegex = /((?:\/\/|\.)([^\.]*)\.[^\.^\/]+\/).*/;
@@ -107,10 +110,6 @@ export default class CDPTargetsProvider implements vscode.TreeDataProvider<CDPTa
 
         // Replacing ".microsoft.com/en-us/microsoft-edge/" with ".microsoft.com/favicon.ico"
         const faviconUrl = url.replace(faviconRegex, "$1favicon.ico");
-
-        if (!this.extensionPath) {
-            return null;
-        }
 
         const filePath = path.join(this.extensionPath, "resources", "favicons", filename);
 

--- a/src/cdpTargetsProvider.ts
+++ b/src/cdpTargetsProvider.ts
@@ -45,7 +45,7 @@ export default class CDPTargetsProvider implements vscode.TreeDataProvider<CDPTa
                             if (actualTarget.type !== 'page') {
                                 targets.push(new CDPTarget(actualTarget, "", this.extensionPath));
                             } else {
-                                const iconPath = await this.downloadFaviconFromSitePromise(actualTarget.url, targets, actualTarget);
+                                const iconPath = await this.downloadFaviconFromSitePromise(actualTarget.url);
                                 if (iconPath) {
                                     targets.push(new CDPTarget(actualTarget, "", this.extensionPath, iconPath));
                                 } else {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -160,7 +160,7 @@ export async function attach(
                 DevToolsPanel.createOrShow(context, telemetryReporter, targetWebsocketUrl, runtimeConfig);
             } else if (useRetry) {
                 // Wait for a little bit until we retry
-                await new Promise((resolve, reject) => {
+                await new Promise<void>((resolve) => {
                     setTimeout(() => {
                         resolve();
                     }, SETTINGS_DEFAULT_ATTACH_INTERVAL);


### PR DESCRIPTION
This PR introduces the functionality of pulling down the target website's favicon when populating the target tree item in the extension side bar.

GIF:
![extension-favicon](https://user-images.githubusercontent.com/14304598/107307747-1eaa6e80-6a3c-11eb-9602-1797d5301fa3.gif)

closes #250 