### PR TITLE
[Tests]: Use test helper function for all tests in polyfill directory

### DIFF
--- a/src/host/polyfills/cssPaddingInline.test.ts
+++ b/src/host/polyfills/cssPaddingInline.test.ts
@@ -1,39 +1,27 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { getTextFromFile } from "../../test/helpers";
+import { testPatch } from "../../test/helpers";
+import applyPaddingInlineCssPatch from "./cssPaddingInline";
 
 describe("cssPaddingInline", () => {
     it("applyPaddingInlineCssPatch correctly changes elements-disclosure text", async () => {
         const filePath = "elements/elements_module.js";
-        const fileContents = getTextFromFile(filePath);
-        if (!fileContents) {
-            throw new Error(`Could not find file: ${filePath}`);
-        }
+        const expectedStrings =
+        [".elements-disclosure .gutter-container {\\n        display: none !important;\\n    }"];
 
-        const apply = await import("./cssPaddingInline");
-        const result = apply.default(fileContents);
-        const expectedResult =
-        ".elements-disclosure .gutter-container {\\n        display: none !important;\\n    }";
-        expect(result).toEqual(
-            expect.stringContaining(expectedResult));
+        testPatch(filePath, applyPaddingInlineCssPatch, expectedStrings);
     });
 
     it("applyPaddingInlineCssPatch correctly changes padding-inline-start text", async () => {
         const filePath = "elements/elements_module.js";
-        const fileContents = getTextFromFile(filePath);
-        if (!fileContents) {
-            throw new Error(`Could not find file: ${filePath}`);
-        }
+        const expectedStrings = ["webkit-padding-start"];
 
-        const apply = await import("./cssPaddingInline");
-        const result = apply.default(fileContents);
-        expect(result).toEqual(expect.stringContaining("webkit-padding-start"));
+        testPatch(filePath, applyPaddingInlineCssPatch, expectedStrings);
     });
 
     it("applyPaddingInlineCssPatch ignores other text", async () => {
-        const apply = await import("./cssPaddingInline");
-        const expectedText = "body { scroll-padding-inline-start: 10px; }";
-        const result = apply.default(expectedText);
+        const sampleText = "body { scroll-padding-inline-start: 10px; }";
+        const result = applyPaddingInlineCssPatch(sampleText);
         expect(result).toEqual(null);
     });
 });

--- a/src/host/polyfills/inspectorContentPolicy.test.ts
+++ b/src/host/polyfills/inspectorContentPolicy.test.ts
@@ -1,22 +1,12 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { getTextFromFile } from "../../test/helpers";
+import { testPatch } from "../../test/helpers";
+import { applyContentSecurityPolicyPatch } from "./inspectorContentPolicy"
 
 describe("inspectorContentPolicy", () => {
     it("applyContentSecurityPolicyPatch correctly changes text", async () => {
         const filePath = "inspector.html";
-        const fileContents = getTextFromFile(filePath);
-        if (!fileContents) {
-            throw new Error(`Could not find file: ${filePath}`);
-        }
-
-        const apply = await import("./inspectorContentPolicy");
-        const result = apply.applyContentSecurityPolicyPatch(fileContents);
-        expect(result).toEqual(
-            expect.stringContaining(
-                `script-src vscode-webview-resource: 'self'`));
-        expect(result).toEqual(
-            expect.stringContaining(
-                `<script src="../../host/host.bundle.js"></script>`));
+        const expectedStrings = [`script-src vscode-webview-resource: 'self'`, `<script src="../../host/host.bundle.js"></script>`];
+        testPatch(filePath, applyContentSecurityPolicyPatch, expectedStrings);
     });
 });

--- a/src/host/polyfills/runtime.test.ts
+++ b/src/host/polyfills/runtime.test.ts
@@ -1,28 +1,19 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { getTextFromFile } from "../../test/helpers";
+import { testPatch } from "../../test/helpers";
+import applyRuntimeImportScriptPathPrefixPatch from "./runtime";
 
 describe("importScriptPathPrefix replacement", () => {
     it("verifies that importScriptPathPrefix is exposed as a module variable", async () => {
         const filePath = "root/root.js";
-        const fileContents = getTextFromFile(filePath);
-        if (!fileContents) {
-            throw new Error(`Could not find file: ${filePath}`);
-        }
+        const expectedStrings = ["self.importScriptPathPrefix=baseUrl.substring(0,baseUrl.lastIndexOf('/')+1);})();"];
+        const unexpectedStrings = ["let importScriptPathPrefix"]
 
-        const apply = await import("./runtime");
-        const result = apply.default(fileContents);
-        const importScriptReplacementPattern =
-            "self.importScriptPathPrefix=baseUrl.substring(0,baseUrl.lastIndexOf('/')+1);})();";
-        const variableDeclarationPattern = "let importScriptPathPrefix";
-
-        expect(result).toEqual(expect.stringContaining(importScriptReplacementPattern));
-        expect(result).not.toEqual(expect.stringContaining(variableDeclarationPattern));
+        testPatch(filePath, applyRuntimeImportScriptPathPrefixPatch, expectedStrings, unexpectedStrings);
     });
 
     it("verifies that importScriptPathPrefix correctly reports a wrong replacement", async () => {
-        const apply = await import("./runtime");
-        const result = apply.default("");
+        const result = applyRuntimeImportScriptPathPrefixPatch("");
         expect(result).toEqual(null);
     });
 });

--- a/src/host/polyfills/simpleView.test.ts
+++ b/src/host/polyfills/simpleView.test.ts
@@ -1,35 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { getTextFromFile } from "../../test/helpers";
+import { testPatch } from "../../test/helpers";
 import * as SimpleView from "./simpleView"
-
-/**
- * This helper test function grabs the source code, applies the given patch, checks to see if the patch is applied, and checks for expected and unexpected strings.
- * @param filename
- * @param patchFunction
- * @param expectedStrings
- * @param unexpectedStrings
- * @return
- */
-async function testPatch(filename: string, patch: (content:string)=>string|null, expectedStrings?: string[], unexpectedStrings?: string[]) {
-    const fileContents = getTextFromFile(filename);
-    if (!fileContents) {
-        throw new Error(`Could not find file: ${filename}`);
-    }
-
-    const result = patch(fileContents);
-    expect(result).not.toEqual(null);
-    if (expectedStrings) {
-        for (const expectedString of expectedStrings) {
-            expect(result).toEqual(expect.stringContaining(expectedString));
-        }
-    }
-    if (unexpectedStrings) {
-        for (const unexpectedString of unexpectedStrings) {
-            expect(result).not.toEqual(expect.stringContaining(unexpectedString));
-        }
-    }
-}
 
 describe("simpleView", () => {
     it("revealInVSCode calls openInEditor", async () => {
@@ -158,7 +130,7 @@ describe("simpleView", () => {
     it("applyInspectorCommonCssPatch correctly changes text", async () => {
         const filePath = "shell.js";
         const patch = SimpleView.applyInspectorCommonCssPatch;
-        const expectedStrings = [".toolbar-button[aria-label='Toggle screencast'] {\\n            visibility: visible !important;"];
+        const expectedStrings = [".toolbar-button[aria-label='Toggle screencast']", ".toolbar-button[aria-label='More Tools']"];
 
         await testPatch(filePath, patch, expectedStrings);
     });
@@ -166,7 +138,7 @@ describe("simpleView", () => {
     it("applyInspectorCommonNetworkPatch correctly changes text", async () => {
         const filePath = "shell.js";
         const patch = SimpleView.applyInspectorCommonNetworkPatch;
-        const expectedStrings = [".toolbar-button[aria-label='Export HAR...'] {\\n            display: none !important;"];
+        const expectedStrings = [".toolbar-button[aria-label='Export HAR...']", ".toolbar-button[aria-label='Pretty print']", ".toolbar-button[aria-label='Close']"];
 
         await testPatch(filePath, patch, expectedStrings);
     });
@@ -174,7 +146,7 @@ describe("simpleView", () => {
     it("applyInspectorCommonContextMenuPatch correctly changes text", async () => {
         const filePath = "shell.js";
         const patch = SimpleView.applyInspectorCommonContextMenuPatch;
-        const expectedStrings = [".soft-context-menu-item[aria-label='Save as...'] {\\n            display: none !important;"];
+        const expectedStrings = [".soft-context-menu-item[aria-label='Save as...']", ".soft-context-menu-item[aria-label='Open in Sources panel']", ".soft-context-menu-item[aria-label='Clear browser cookies']"];
 
         await testPatch(filePath, patch, expectedStrings);
     });

--- a/src/host/polyfills/textSelection.test.ts
+++ b/src/host/polyfills/textSelection.test.ts
@@ -1,25 +1,18 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { getTextFromFile } from "../../test/helpers";
+import { testPatch } from "../../test/helpers";
+import applySetupTextSelectionPatch from "./textSelection";
 
 describe("textSelection", () => {
     it("applySetupTextSelectionPatch correctly changes text", async () => {
         const filePath = "elements/elements.js";
-        const fileContents = getTextFromFile(filePath);
-        if (!fileContents) {
-            throw new Error(`Could not find file: ${filePath}`);
-        }
-
-        const apply = await import("./textSelection");
-        const result = apply.default(fileContents);
-        expect(result).not.toEqual(null);
-        expect(result).toEqual(expect.stringContaining("_setupTextSelectionHack() { return;"));
+        const expectedStrings = ["_setupTextSelectionHack() { return;"];
+        testPatch(filePath, applySetupTextSelectionPatch, expectedStrings);
     });
 
     it("applySetupTextSelectionPatch ignores other text", async () => {
-        const apply = await import("./textSelection");
         const expectedText = "hello world";
-        const result = apply.default(expectedText);
+        const result = applySetupTextSelectionPatch(expectedText);
         expect(result).toEqual(null);
     });
 });

--- a/src/test/helpers.ts
+++ b/src/test/helpers.ts
@@ -166,6 +166,34 @@ export function getTextFromFile(uri: string) {
 }
 
 /**
+ * This helper test function grabs the source code, applies the given patch, checks to see if the patch is applied, and checks for expected and unexpected strings.
+ * @param filename
+ * @param patchFunction
+ * @param expectedStrings
+ * @param unexpectedStrings
+ * @return
+ */
+export async function testPatch(filename: string, patch: (content:string)=>string|null, expectedStrings?: string[], unexpectedStrings?: string[]) {
+    const fileContents = getTextFromFile(filename);
+    if (!fileContents) {
+        throw new Error(`Could not find file: ${filename}`);
+    }
+
+    const result = patch(fileContents);
+    expect(result).not.toEqual(null);
+    if (expectedStrings) {
+        for (const expectedString of expectedStrings) {
+            expect(result).toEqual(expect.stringContaining(expectedString));
+        }
+    }
+    if (unexpectedStrings) {
+        for (const unexpectedString of unexpectedStrings) {
+            expect(result).not.toEqual(expect.stringContaining(unexpectedString));
+        }
+    }
+}
+
+/**
  * @param filepath
  */
 function removeLastTwoDirectories(filepath: string) {

--- a/src/test/helpers.ts
+++ b/src/test/helpers.ts
@@ -170,16 +170,15 @@ export function getTextFromFile(uri: string) {
 
 /**
  * This helper test function grabs the source code, applies the given patch, checks to see if the patch is applied, and checks for expected and unexpected strings.
- * @param filename
- * @param patchFunction
- * @param expectedStrings
- * @param unexpectedStrings
- * @return
+ * @param filePath Path to the source file (e.g. elements/elements.js)
+ * @param patchFunction The patch function that replaces source code
+ * @param expectedStrings An array of expected strings after running the patchFunction
+ * @param unexpectedStrings An array of non-expected strings after running the patchFunction
  */
-export async function testPatch(filename: string, patch: (content:string)=>string|null, expectedStrings?: string[], unexpectedStrings?: string[]) {
-    const fileContents = getTextFromFile(filename);
+export async function testPatch(filePath: string, patch: (content:string)=>string|null, expectedStrings?: string[], unexpectedStrings?: string[]) {
+    const fileContents = getTextFromFile(filePath);
     if (!fileContents) {
-        throw new Error(`Could not find file: ${filename}`);
+        throw new Error(`Could not find file: ${filePath}`);
     }
 
     const result = patch(fileContents);


### PR DESCRIPTION
This PR moves the `testPatch` function to `helpers.ts` so that other tests inside the `polyfill` directory can use the function.  This helps simplify and standardize testing.

#282 