### PR TITLE
[Settings]: Create setting to show service and shared workers in the target list (will now hide by default)

### DIFF
--- a/package.json
+++ b/package.json
@@ -169,6 +169,11 @@
                     "description": "Enable network panel (requires relaunching extension)",
                     "default": true
                 },
+                "vscode-edge-devtools.showWorkers": {
+                    "type": "boolean",
+                    "description": "Show service and shared workers in the target list.",
+                    "default": false
+                },
                 "vscode-edge-devtools.whatsNew": {
                     "type": "boolean",
                     "description": "Enable What's New panel in the drawer (requires relaunching extension)",


### PR DESCRIPTION
This PR hides service and shared workers behind a settings flag to declutter the target list.

GIF:
![settings-show-workers](https://user-images.githubusercontent.com/14304598/110714701-c2f90f80-81b8-11eb-99ab-2bbb5010e4eb.gif)


closes #276 