### PR TITLE
[Bug]: fix *.launch *.refresh not found bug

### DIFF
--- a/package.json
+++ b/package.json
@@ -435,12 +435,12 @@
             "view/title": [
                 {
                     "command": "vscode-edge-devtools-view.launch",
-                    "when": "view == vscode-edge-devtools-view.targets",
+                    "when": "view == vscode-edge-devtools-view.targets && titleCommandsRegistered",
                     "group": "navigation"
                 },
                 {
                     "command": "vscode-edge-devtools-view.refresh",
-                    "when": "view == vscode-edge-devtools-view.targets",
+                    "when": "view == vscode-edge-devtools-view.targets && titleCommandsRegistered",
                     "group": "navigation"
                 }
             ],

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -98,6 +98,7 @@ export function activate(context: vscode.ExtensionContext) {
     context.subscriptions.push(vscode.commands.registerCommand(
         `${SETTINGS_VIEW_NAME}.copyItem`,
         (target: CDPTarget) => vscode.env.clipboard.writeText(target.tooltip)));
+    vscode.commands.executeCommand('setContext', 'titleCommandsRegistered', true);
 }
 
 export async function attach(

--- a/src/test/helpers.ts
+++ b/src/test/helpers.ts
@@ -40,6 +40,7 @@ export function createFakeVSCode() {
         },
         ViewColumn: { One: 1, Two: 2 },
         commands: {
+            executeCommand: jest.fn(),
             registerCommand: jest.fn(),
         },
         debug: {


### PR DESCRIPTION
Issue:
- This message pops up when users press either the `Open a new tab` or `refresh` buttons at the top before the commands can be registered
![image](https://user-images.githubusercontent.com/14304598/109706993-7d03d200-7b4e-11eb-88ac-2a62f079297c.png)

Changes:
- added `titleCommandsRegistered` condition to show the `Open a new tab` or `refresh` buttons
    - the `titleCommandsRegistered` flag is turned to true once registration for those commands are complete.

closes #277 