### PR TITLE
[Feature]: Add dropdown menu in title view containing link to settings and changelog

### DIFF
--- a/package.json
+++ b/package.json
@@ -97,6 +97,16 @@
                 "command": "vscode-edge-devtools-view.copyItem",
                 "category": "Microsoft Edge Tools",
                 "title": "Copy Value"
+            },
+            {
+                "command": "vscode-edge-devtools-view.openSettings",
+                "category": "Microsoft Edge Tools",
+                "title": "Open Settings"
+            },
+            {
+                "command": "vscode-edge-devtools-view.viewChangelog",
+                "category": "Microsoft Edge Tools",
+                "title": "View Changelog"
             }
         ],
         "configuration": {
@@ -430,6 +440,14 @@
                 {
                     "command": "vscode-edge-devtools-view.copyItem",
                     "when": "view == vscode-edge-devtools-view.targets && viewItem == cdpTargetProperty"
+                },
+                {
+                    "command": "vscode-edge-devtools-view.openSettings",
+                    "when": "view == vscode-edge-devtools-view.targets"
+                },
+                {
+                    "command": "vscode-edge-devtools-view.viewChangelog",
+                    "when": "view == vscode-edge-devtools-view.targets"
                 }
             ],
             "view/title": [
@@ -442,6 +460,16 @@
                     "command": "vscode-edge-devtools-view.refresh",
                     "when": "view == vscode-edge-devtools-view.targets",
                     "group": "navigation"
+                },
+                {
+                    "command": "vscode-edge-devtools-view.openSettings",
+                    "when": "view == vscode-edge-devtools-view.targets",
+                    "group": "2_vscode-edge-devtools"
+                },
+                {
+                    "command": "vscode-edge-devtools-view.viewChangelog",
+                    "when": "view == vscode-edge-devtools-view.targets",
+                    "group": "2_vscode-edge-devtools"
                 }
             ],
             "view/item/context": [

--- a/src/extension.test.ts
+++ b/src/extension.test.ts
@@ -72,8 +72,8 @@ describe("extension", () => {
             // Activation should add the commands as subscriptions on the context
             newExtension.activate(context);
 
-            expect(context.subscriptions.length).toBe(8);
-            expect(commandMock).toHaveBeenCalledTimes(7);
+            expect(context.subscriptions.length).toBe(10);
+            expect(commandMock).toHaveBeenCalledTimes(9);
             expect(commandMock)
                 .toHaveBeenNthCalledWith(1, `${SETTINGS_STORE_NAME}.attach`, expect.any(Function));
             expect(commandMock)
@@ -85,9 +85,13 @@ describe("extension", () => {
             expect(commandMock)
                 .toHaveBeenNthCalledWith(5, `${SETTINGS_VIEW_NAME}.attach`, expect.any(Function));
             expect(commandMock)
-                .toHaveBeenNthCalledWith(6, `${SETTINGS_VIEW_NAME}.close-instance`, expect.any(Function));
+                .toHaveBeenNthCalledWith(6, `${SETTINGS_VIEW_NAME}.openSettings`, expect.any(Function));
             expect(commandMock)
-                .toHaveBeenNthCalledWith(7, `${SETTINGS_VIEW_NAME}.copyItem`, expect.any(Function));
+                .toHaveBeenNthCalledWith(7, `${SETTINGS_VIEW_NAME}.viewChangelog`, expect.any(Function));
+            expect(commandMock)
+                .toHaveBeenNthCalledWith(8, `${SETTINGS_VIEW_NAME}.close-instance`, expect.any(Function));
+            expect(commandMock)
+                .toHaveBeenNthCalledWith(9, `${SETTINGS_VIEW_NAME}.copyItem`, expect.any(Function));
             expect(mockRegisterTree)
                 .toHaveBeenNthCalledWith(1, `${SETTINGS_VIEW_NAME}.targets`, expect.any(Object));
         });
@@ -144,7 +148,7 @@ describe("extension", () => {
             attach.callback.call(attach.thisObj, { websocketUrl: "" });
             expect(mockPanelShow).toHaveBeenCalled();
 
-            const copy = getCommandCallback(6);
+            const copy = getCommandCallback(8);
             copy.callback.call(copy.thisObj, { tooltip: "something" });
             expect(mockClipboard).toHaveBeenCalledWith("something");
         });

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -72,6 +72,12 @@ export function activate(context: vscode.ExtensionContext) {
             const runtimeConfig = getRuntimeConfig();
             DevToolsPanel.createOrShow(context, telemetryReporter, target.websocketUrl, runtimeConfig);
         }));
+    context.subscriptions.push(vscode.commands.registerCommand(`${SETTINGS_VIEW_NAME}.openSettings`, async () => {
+        vscode.commands.executeCommand("workbench.action.openSettings", `${SETTINGS_STORE_NAME}`);
+    }));
+    context.subscriptions.push(vscode.commands.registerCommand(`${SETTINGS_VIEW_NAME}.viewChangelog`, async () => {
+        vscode.env.openExternal(vscode.Uri.parse("https://github.com/microsoft/vscode-edge-devtools/blob/master/CHANGELOG.md"));
+    }));
     context.subscriptions.push(vscode.commands.registerCommand(
         `${SETTINGS_VIEW_NAME}.close-instance`,
         async (target: CDPTarget) => {


### PR DESCRIPTION
This PR adds a dropdown menu in the extension's title view that contains links to the extension's settings and changelog.

GIF:
![extension-more-actions](https://user-images.githubusercontent.com/14304598/110720214-0bb5c600-81c3-11eb-82ea-d097e042cef1.gif)

closes #255 