### PR TITLE
[Bug Fix]: Close DevTools output channel upon closing DevTools

### DIFF
--- a/src/devtoolsPanel.ts
+++ b/src/devtoolsPanel.ts
@@ -94,6 +94,7 @@ export class DevToolsPanel {
 
         this.panel.dispose();
         this.panelSocket.dispose();
+        this.consoleOutput.dispose();
 
         this.telemetryReporter.sendTelemetryEvent("websocket/dispose");
 

--- a/src/test/helpers.ts
+++ b/src/test/helpers.ts
@@ -50,7 +50,7 @@ export function createFakeVSCode() {
             machineId: "someValue.machineId",
         },
         window: {
-            createOutputChannel: jest.fn().mockReturnValue({ appendLine: jest.fn() }),
+            createOutputChannel: jest.fn().mockReturnValue({ appendLine: jest.fn(), dispose: jest.fn() }),
             createWebviewPanel: jest.fn(),
             registerTreeDataProvider: jest.fn(),
             showErrorMessage: jest.fn(),


### PR DESCRIPTION
This PR closes the VSCode Output channel where the DevTools redirects console output to upon close of the DevTools.  This change prevents the issue where multiple instances of the DevTools will create more and more output channels.

![image](https://user-images.githubusercontent.com/14304598/110170539-352fb580-7daf-11eb-97b7-783b66853b51.png)
****

closes #291 