### PR TITLE
[Bug]: Adding check for http in favicon download to prevent broken state

### DIFF
--- a/src/cdpTargetsProvider.ts
+++ b/src/cdpTargetsProvider.ts
@@ -122,7 +122,7 @@ export default class CDPTargetsProvider implements vscode.TreeDataProvider<CDPTa
     }
 
     public downloadFaviconFromSitePromise(url: string) : Promise<string | null> | null {
-        if (!url || url.startsWith('http:')) {
+        if (!url || !url.startsWith('https')) {
             return null;
         }
         const https = require('https');

--- a/src/cdpTargetsProvider.ts
+++ b/src/cdpTargetsProvider.ts
@@ -122,7 +122,7 @@ export default class CDPTargetsProvider implements vscode.TreeDataProvider<CDPTa
     }
 
     public downloadFaviconFromSitePromise(url: string) : Promise<string | null> | null {
-        if (!url) {
+        if (!url || url.startsWith('http:')) {
             return null;
         }
         const https = require('https');


### PR DESCRIPTION
When passing in an address beginning with `http`, it will throw this failure:
```
TypeError [ERR_INVALID_PROTOCOL]: Protocol "http:" not supported. Expected "https:"
```

This PR adds a check to make sure that we are only downloading from `https` to ensure that we are only downloading the favicon from secure sites.

closes #293 