### PR TITLE
Side panel auto-refreshes when targets are created or destroyed

### DIFF
--- a/src/extension.test.ts
+++ b/src/extension.test.ts
@@ -363,6 +363,7 @@ describe("extension", () => {
     });
 
     describe("launch", () => {
+        const fakeBrowser = {addListener: () => null};
         let mockReporter: Mocked<Readonly<TelemetryReporter>>;
         let mockUtils: Partial<Mocked<typeof import("./utils")>>;
         let mockPanel: Partial<Mocked<typeof import("./devtoolsPanel")>>;
@@ -381,7 +382,7 @@ describe("extension", () => {
                     useHttps: false,
                 }),
                 getRuntimeConfig: jest.fn().mockReturnValue(fakeRuntimeConfig),
-                launchBrowser: jest.fn(),
+                launchBrowser: jest.fn().mockResolvedValue(fakeBrowser),
                 openNewTab: jest.fn().mockResolvedValue(null),
                 removeTrailingSlash: jest.fn(removeTrailingSlash),
             };

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -236,6 +236,12 @@ export async function launch(context: vscode.ExtensionContext, launchUrl?: strin
             telemetryReporter.sendTelemetryEvent("command/launch/browser", browserProps);
         }
         browserInstance = await launchBrowser(browserPath, port, url, userDataDir);
+        browserInstance.addListener("targetcreated", () => {
+            vscode.commands.executeCommand(`${SETTINGS_VIEW_NAME}.refresh`);
+        });
+        browserInstance.addListener("targetdestroyed", () => {
+            vscode.commands.executeCommand(`${SETTINGS_VIEW_NAME}.refresh`);
+        });
         await attach(context, url, config);
     }
 }


### PR DESCRIPTION
Changes in this PR:
- Add event listeners to the browser instance once it's obtained, so we can refresh the side panel when target creation/destruction events are emitted
- Ensure tests still pass by mocking the browser instance's addListener function