### PR TITLE
Overriding supported localization

### DIFF
--- a/postBuildStep.ts
+++ b/postBuildStep.ts
@@ -44,6 +44,7 @@ import {
     applyThemePatch,
 } from "./src/host/polyfills/simpleView";
 import applySetupTextSelectionPatch from "./src/host/polyfills/textSelection";
+import applyThirdPartyI18nLocalesPatch from "./src/host/polyfills/thirdPartyI18n";
 
 async function copyFile(srcDir: string, outDir: string, name: string) {
     await fse.copy(
@@ -176,6 +177,11 @@ async function patchFilesForWebView(toolsOutDir: string) {
     ])
     await patchFileForWebViewWrapper("sdk/sdk.js", toolsOutDir, [
         applyRerouteConsoleMessagePatch,
+    ]);
+
+    // #341: Devtools should be localized as in the browser.
+    await patchFileForWebViewWrapper("i18n/i18n.js", toolsOutDir, [
+        applyThirdPartyI18nLocalesPatch,
     ]);
 }
 

--- a/postBuildStep.ts
+++ b/postBuildStep.ts
@@ -178,7 +178,6 @@ async function patchFilesForWebView(toolsOutDir: string) {
     await patchFileForWebViewWrapper("sdk/sdk.js", toolsOutDir, [
         applyRerouteConsoleMessagePatch,
     ]);
-
     await patchFileForWebViewWrapper("i18n/i18n.js", toolsOutDir, [
         applyThirdPartyI18nLocalesPatch,
     ]);

--- a/postBuildStep.ts
+++ b/postBuildStep.ts
@@ -179,7 +179,6 @@ async function patchFilesForWebView(toolsOutDir: string) {
         applyRerouteConsoleMessagePatch,
     ]);
 
-    // #341: Devtools should be localized as in the browser.
     await patchFileForWebViewWrapper("i18n/i18n.js", toolsOutDir, [
         applyThirdPartyI18nLocalesPatch,
     ]);

--- a/src/host/polyfills/thirdPartyI18n.test.ts
+++ b/src/host/polyfills/thirdPartyI18n.test.ts
@@ -1,0 +1,12 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+import { testPatch } from "../../test/helpers";
+import applyThirdPartyI18nLocalesPatch from "./thirdPartyI18n";
+
+describe("override i18n locales", () => {
+    it("applySetupTextSelectionPatch correctly changes text", async () => {
+        const filePath = "i18n/i18n.js";
+        const expectedStrings = ["const locales = {'en-US': {'title': 'value'},};"];
+        testPatch(filePath, applyThirdPartyI18nLocalesPatch, expectedStrings);
+    });
+});

--- a/src/host/polyfills/thirdPartyI18n.test.ts
+++ b/src/host/polyfills/thirdPartyI18n.test.ts
@@ -4,7 +4,7 @@ import { testPatch } from "../../test/helpers";
 import applyThirdPartyI18nLocalesPatch from "./thirdPartyI18n";
 
 describe("override i18n locales", () => {
-    it("applySetupTextSelectionPatch correctly changes text", async () => {
+    it("applyThirdPartyI18nLocalesPatch correctly changes text", async () => {
         const filePath = "i18n/i18n.js";
         const expectedStrings = ["const locales = {'en-US': {'title': 'value'},};"];
         testPatch(filePath, applyThirdPartyI18nLocalesPatch, expectedStrings);

--- a/src/host/polyfills/thirdPartyI18n.ts
+++ b/src/host/polyfills/thirdPartyI18n.ts
@@ -1,0 +1,10 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+export default function applyThirdPartyI18nLocalesPatch(content: string) {
+    const pattern = /const\s*locales\s*=\s*\{[^]+?};/g;
+    if (content.match(pattern)) {
+        return content.replace(pattern, "const locales = {'en-US': {'title': 'value'},};");
+    } else {
+        return null;
+    }
+}

--- a/src/host/polyfills/thirdPartyI18n.ts
+++ b/src/host/polyfills/thirdPartyI18n.ts
@@ -1,5 +1,8 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+
+// Needs to change when the following bug is fixed:
+//#341: Devtools should be localized as in the browser.
 export default function applyThirdPartyI18nLocalesPatch(content: string) {
     const pattern = /const\s*locales\s*=\s*\{[^]+?};/g;
     if (content.match(pattern)) {


### PR DESCRIPTION
This PR overrides the list of supported locales on the Devtools as extension currently only support en-US