### PR TITLE
Updating version 1.1.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 1.1.7
+* **[Bug Fix]**: Retain focus on property after toggling with context menu
+ [PR #332](https://github.com/microsoft/vscode-edge-devtools/pull/332)
+* **[Bug Fix]**: Extension does not work and panel is blank - [PR #342](https://github.com/microsoft/vscode-edge-devtools/pull/342)
+
 ## 1.1.6
 * **[Feature]**: Update Edge version to 88.0.705.9 - [PR #302](https://github.com/microsoft/vscode-edge-devtools/pull/302)
 * **[Bug Fix]**: Support for ARM devices [PR #293](https://github.com/microsoft/vscode-edge-devtools/pull/318)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "vscode-edge-devtools",
-    "version": "1.1.6",
+    "version": "1.1.7",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "vscode-edge-devtools",
     "displayName": "Microsoft Edge Tools for VS Code",
     "description": "Use the Microsoft Edge Tools from within VS Code to see your site's runtime HTML structure, alter its layout, fix styling issues as well as see your site's network requests.",
-    "version": "1.1.6",
+    "version": "1.1.7",
     "license": "SEE LICENSE IN LICENSE",
     "publisher": "ms-edgedevtools",
     "preview": false,


### PR DESCRIPTION
Updating to version 1.1.7 to release some bug fixes:

## 1.1.7
* **[Bug Fix]**: Retain focus on property after toggling with context menu
 [PR #332](https://github.com/microsoft/vscode-edge-devtools/pull/332)
* **[Bug Fix]**: Extension does not work and panel is blank - [PR #342](https://github.com/microsoft/vscode-edge-devtools/pull/342)
