### PR TITLE
Interactive documentation for side panel (2)

### DIFF
--- a/package.json
+++ b/package.json
@@ -108,6 +108,18 @@
                 "command": "vscode-edge-devtools-view.viewChangelog",
                 "category": "Microsoft Edge Tools",
                 "title": "View Changelog"
+            },
+            {
+                "command": "vscode-edge-devtools-view.configureLaunchJson",
+                "category": "Microsoft Edge Tools",
+                "enablement": "titleCommandsRegistered",
+                "title": "Configure launch.json file"
+            },
+            {
+                "command": "vscode-edge-devtools-view.launchProject",
+                "category": "Microsoft Edge Tools",
+                "enablement": "titleCommandsRegistered",
+                "title": "Launch project"
             }
         ],
         "configuration": {
@@ -516,7 +528,38 @@
                     "name": "Targets"
                 }
             ]
-        }
+        },
+        "viewsWelcome": [
+            {
+                "view": "vscode-edge-devtools-view.targets",
+                "contents": "Launch an instance of Microsoft Edge to begin inspecting and modifying webpages.\n[Launch Instance](command:vscode-edge-devtools-view.launch)",
+                "when": "launchJsonStatus != Supported"
+            },
+            {
+                "view": "vscode-edge-devtools-view.targets",
+                "contents": "To customize your launch experience, [open a folder](command:vscode.openFolder) and create a launch.json file.",
+                "when": "workbenchState == empty"
+            },
+            {
+                "view": "vscode-edge-devtools-view.targets",
+                "contents": "Customize your launch experience by adding a launch.json file to your project.\n[Generate launch.json](command:vscode-edge-devtools-view.configureLaunchJson)",
+                "when": "workbenchState != empty && launchJsonStatus == None"
+            },
+            {
+                "view": "vscode-edge-devtools-view.targets",
+                "contents": "Customize your launch experience by adding a debug configuration to your launch.json file.\n[Configure launch.json](command:vscode-edge-devtools-view.configureLaunchJson)",
+                "when": "launchJsonStatus == Unsupported"
+            },
+            {
+                "view": "vscode-edge-devtools-view.targets",
+                "contents": "Launch an instance of Microsoft Edge to begin inspecting and modifying your site.\n[Launch Project](command:vscode-edge-devtools-view.launchProject)",
+                "when": "launchJsonStatus == Supported"
+            },
+            {
+                "view": "vscode-edge-devtools-view.targets",
+                "contents": "If you have any questions or want to learn more, check the [docs on GitHub](https://github.com/microsoft/vscode-edge-devtools/blob/master/README.md)."
+            }
+        ]
     },
     "jest": {
         "transform": {

--- a/src/extension.test.ts
+++ b/src/extension.test.ts
@@ -39,6 +39,7 @@ describe("extension", () => {
                 getRemoteEndpointSettings: jest.fn(),
                 getRuntimeConfig: jest.fn(),
                 removeTrailingSlash: jest.fn(removeTrailingSlash),
+                getLaunchJson: jest.fn(),
             };
             jest.doMock("./utils", () => mockUtils);
             jest.doMock("./launchDebugProvider");
@@ -74,8 +75,8 @@ describe("extension", () => {
             // Activation should add the commands as subscriptions on the context
             newExtension.activate(context);
 
-            expect(context.subscriptions.length).toBe(10);
-            expect(commandMock).toHaveBeenCalledTimes(9);
+            expect(context.subscriptions.length).toBe(12);
+            expect(commandMock).toHaveBeenCalledTimes(11);
             expect(commandMock)
                 .toHaveBeenNthCalledWith(1, `${SETTINGS_STORE_NAME}.attach`, expect.any(Function));
             expect(commandMock)
@@ -94,6 +95,10 @@ describe("extension", () => {
                 .toHaveBeenNthCalledWith(8, `${SETTINGS_VIEW_NAME}.close-instance`, expect.any(Function));
             expect(commandMock)
                 .toHaveBeenNthCalledWith(9, `${SETTINGS_VIEW_NAME}.copyItem`, expect.any(Function));
+            expect(commandMock)
+                .toHaveBeenNthCalledWith(10, `${SETTINGS_VIEW_NAME}.configureLaunchJson`, expect.any(Function));
+            expect(commandMock)
+                .toHaveBeenNthCalledWith(11, `${SETTINGS_VIEW_NAME}.launchProject`, expect.any(Function));
             expect(mockRegisterTree)
                 .toHaveBeenNthCalledWith(1, `${SETTINGS_VIEW_NAME}.targets`, expect.any(Object));
         });
@@ -387,6 +392,7 @@ describe("extension", () => {
                 launchBrowser: jest.fn().mockResolvedValue(fakeBrowser),
                 openNewTab: jest.fn().mockResolvedValue(null),
                 removeTrailingSlash: jest.fn(removeTrailingSlash),
+                getLaunchJson: jest.fn(),
             };
 
             mockPanel = {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -130,6 +130,7 @@ export function activate(context: vscode.ExtensionContext): void {
             launchConfig = getLaunchJson();
             if (vscode.workspace.workspaceFolders && launchConfig) {
                 void vscode.debug.startDebugging(vscode.workspace.workspaceFolders[0], launchConfig);
+                cdpTargetsProvider.refresh()
             }
         }));
     void vscode.commands.executeCommand('setContext', 'titleCommandsRegistered', true);

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -70,7 +70,10 @@ export function activate(context: vscode.ExtensionContext): void {
         }));
     context.subscriptions.push(vscode.commands.registerCommand(
         `${SETTINGS_VIEW_NAME}.refresh`,
-        () => cdpTargetsProvider.refresh()));
+        () => {
+            cdpTargetsProvider.refresh();
+            launchConfig = getLaunchJson();
+        }));
     context.subscriptions.push(vscode.commands.registerCommand(
         `${SETTINGS_VIEW_NAME}.attach`,
         (target?: CDPTarget) => {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -130,7 +130,7 @@ export function activate(context: vscode.ExtensionContext): void {
             launchConfig = getLaunchJson();
             if (vscode.workspace.workspaceFolders && launchConfig) {
                 void vscode.debug.startDebugging(vscode.workspace.workspaceFolders[0], launchConfig);
-                cdpTargetsProvider.refresh()
+                cdpTargetsProvider.refresh();
             }
         }));
     void vscode.commands.executeCommand('setContext', 'titleCommandsRegistered', true);

--- a/src/launchDebugProvider.ts
+++ b/src/launchDebugProvider.ts
@@ -5,6 +5,7 @@ import * as vscode from 'vscode';
 import TelemetryReporter from 'vscode-extension-telemetry';
 import {
     IUserConfig,
+    providedDebugConfig,
     SETTINGS_DEFAULT_ATTACH_INTERVAL,
     SETTINGS_DEFAULT_EDGE_DEBUGGER_PORT,
     SETTINGS_STORE_NAME,
@@ -40,12 +41,7 @@ export class LaunchDebugProvider implements vscode.DebugConfigurationProvider {
     provideDebugConfigurations(
         _folder: vscode.WorkspaceFolder | undefined,
         _token?: vscode.CancellationToken): vscode.ProviderResult<vscode.DebugConfiguration[]> {
-        return Promise.resolve([{
-            name: 'Launch Microsoft Edge and open the Edge DevTools',
-            request: 'launch',
-            type: `${SETTINGS_STORE_NAME}.debug`,
-            url: 'http://localhost:8080',
-        }]);
+        return Promise.resolve([providedDebugConfig]);
     }
 
     resolveDebugConfiguration(

--- a/src/utils.test.ts
+++ b/src/utils.test.ts
@@ -547,6 +547,98 @@ describe("utils", () => {
         });
     });
 
+    describe('getLaunchJson', () => {
+        let fse: Mocked<typeof import("fs-extra")>;
+
+        beforeEach(async () => {
+            jest.doMock("fs-extra");
+            jest.resetModules();
+            utils = await import("./utils");
+            fse = jest.requireMock("fs-extra");
+        });
+
+        it('updates launchJsonStatus with "None" when there is no folder open', async () => {
+            const vscodeMock = await jest.requireMock("vscode");
+            vscodeMock.workspace.workspaceFolders = null;
+            utils.getLaunchJson();
+            expect(utils.getLaunchJson()).toEqual(null);
+            expect(vscodeMock.commands.executeCommand).toBeCalledWith('setContext', 'launchJsonStatus', 'None');
+        });
+
+        it('updates launchJsonStatus with "None" when launch.json does not exist', async () => {
+            const vscodeMock = await jest.requireMock("vscode");
+            fse.pathExistsSync.mockImplementation(() => false);
+            utils.getLaunchJson();
+            expect(utils.getLaunchJson()).toEqual(null);
+            expect(vscodeMock.commands.executeCommand).toBeCalledWith('setContext', 'launchJsonStatus', 'None');
+        });
+
+        it('updates launchJsonStatus with "Unsupported" when there is no supported debug config', async () => {
+            const vscodeMock = await jest.requireMock("vscode");
+            fse.pathExistsSync.mockImplementation(() => true);
+            vscodeMock.workspace.getConfiguration.mockImplementation(() => {
+                return { 
+                    get: (name: string) => [{type: ''}]
+                }
+            });
+            expect(utils.getLaunchJson()).toEqual(null);
+            expect(vscodeMock.commands.executeCommand).toBeCalledWith('setContext', 'launchJsonStatus', 'Unsupported');
+        });
+
+        it('returns a supported debug config when one exists', async () => {
+            const vscodeMock = await jest.requireMock("vscode");
+            fse.pathExistsSync.mockImplementation(() => true);
+            vscodeMock.workspace.getConfiguration.mockImplementation(() => {
+                return { 
+                    get: (name: string) => [{type: 'vscode-edge-devtools.debug'}]
+                }
+            });
+            expect(utils.getLaunchJson()).toEqual({type: 'vscode-edge-devtools.debug'});
+            expect(vscodeMock.commands.executeCommand).toBeCalledWith('setContext', 'launchJsonStatus', 'Supported');
+        });
+    });
+
+    describe('configureLaunchJson', () => {
+        let fse: Mocked<typeof import("fs-extra")>;
+
+        beforeEach(async () => {
+            jest.doMock("fs-extra");
+            jest.resetModules();
+            utils = await import("./utils");
+
+            fse = jest.requireMock("fs-extra");
+            fse.readFileSync.mockImplementation((() => ''));
+
+            const vscodeMock = await jest.requireMock("vscode");
+            vscodeMock.Uri.joinPath = jest.fn();
+            vscodeMock.WorkspaceConfiguration = {
+                update: jest.fn((name: string, value: any) => {}),
+            };
+            vscodeMock.workspace.getConfiguration.mockImplementation(() => {
+                return { 
+                        get: jest.fn((name: string) => []),
+                        update: vscodeMock.WorkspaceConfiguration.update,
+                    
+                }
+            });
+        });
+
+        it('adds a debug config to launch.json', async () => {
+            const vscodeMock = await jest.requireMock("vscode");
+            
+            utils.configureLaunchJson();
+            expect(vscodeMock.WorkspaceConfiguration.update).toBeCalledWith('configurations', expect.arrayContaining([expect.any(Object)]));
+        });
+
+        it('inserts a comment after the url property', async () => {
+            const expectedText = '\"url\":\"' + utils.providedDebugConfig.url + '\" // Provide your project\'s url to finish configuring';
+            fse.readFileSync.mockImplementation(() => JSON.stringify(utils.providedDebugConfig));
+
+            await utils.configureLaunchJson();
+            expect(fse.writeFileSync).toHaveBeenCalledWith(expect.any(String), expect.stringContaining(expectedText));
+        });
+    });
+
     describe("launchBrowser", () => {
         beforeEach(async () => {
             jest.mock("puppeteer-core", () => {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -317,9 +317,8 @@ export async function getBrowserPath(config: Partial<IUserConfig> = {}): Promise
         void vscode.commands.executeCommand('setContext', 'launchJsonStatus', 'Unsupported');
         return null;
     }
-        void vscode.commands.executeCommand('setContext', 'launchJsonStatus', 'None');
-        return null;
-
+    void vscode.commands.executeCommand('setContext', 'launchJsonStatus', 'None');
+    return null;
 }
 
 /**
@@ -327,8 +326,10 @@ export async function getBrowserPath(config: Partial<IUserConfig> = {}): Promise
  * @returns {void}
  */
 export async function configureLaunchJson(): Promise<void> {
-    if (!vscode.workspace.workspaceFolders)
-        {return;}
+    if (!vscode.workspace.workspaceFolders) {
+        void vscode.window.showErrorMessage('Cannot configure launch.json for an empty workspace. Please open a folder in the editor.');
+        return;
+    }
 
     // Create ./.vscode/launch.json if it doesn't already exist
     const workspaceUri = vscode.workspace.workspaceFolders[0].uri;
@@ -346,7 +347,7 @@ export async function configureLaunchJson(): Promise<void> {
     const re = new RegExp(`{(.|\\n|\\s)*(${providedDebugConfig.type})(.|\\n|\\s)*(${providedDebugConfig.url}")`, 'm');
     const match = re.exec(launchText);
     const instructions = ' // Provide your project\'s url to finish configuring';
-    launchText = launchText.replace(re,  `${match ? match[0] : ''}${instructions}`);
+    launchText = launchText.replace(re, `${match ? match[0] : ''}${instructions}`);
     fse.writeFileSync(workspaceUri.fsPath + relativePath, launchText);
 
     // Open launch.json in editor


### PR DESCRIPTION
This PR adds explanatory welcome content to the side pane when there are no targets to display. Users are prompted to launch an instance of Edge and configure their launch.json file to streamline the workflow.

Here's how the "getting started" workflow looks with a project that originally has no launch.json:
![sidepane-cta](https://user-images.githubusercontent.com/80795982/115080107-0e3cc700-9eb7-11eb-9b53-941cd11346ba.gif)

Summary of the changes:
- Added welcome messages and buttons
- Added 2 new commands to edit and make use of launch.json
- Updated existing tests and added tests for new functions

A second attempt of #351
Closes #337