### PR TITLE
[Telemetry]: Adding telemetry to button presses in title and target view

### DIFF
--- a/src/cdpTargetsProvider.ts
+++ b/src/cdpTargetsProvider.ts
@@ -86,6 +86,7 @@ export class CDPTargetsProvider implements vscode.TreeDataProvider<CDPTarget> {
             // Just expand the element to show its properties
             targets = element.getChildren();
         }
+
         return targets;
     }
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -297,6 +297,6 @@ export async function launch(context: vscode.ExtensionContext, launchUrl?: strin
     }
 }
 
-export function setLaunchConfig() {
+export function setLaunchConfig(): void {
     launchConfig = getLaunchJson();
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -81,8 +81,10 @@ export function activate(context: vscode.ExtensionContext): void {
     context.subscriptions.push(vscode.commands.registerCommand(
         `${SETTINGS_VIEW_NAME}.attach`,
         (target?: CDPTarget) => {
-            if (!target)
-                {return;}
+            if (!target){
+                telemetryReporter.sendTelemetryEvent('command/attach/noTarget');
+                return;
+            }
             telemetryReporter.sendTelemetryEvent('user/buttonPress', { 'VSCode.buttonCode': buttonCode.attachToTarget });
             telemetryReporter.sendTelemetryEvent('view/devtools');
             const runtimeConfig = getRuntimeConfig();

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -77,7 +77,6 @@ export function activate(context: vscode.ExtensionContext): void {
         () => {
             telemetryReporter.sendTelemetryEvent('user/buttonPress', { 'VSCode.buttonCode': buttonCode.refreshTargetList });
             cdpTargetsProvider.refresh();
-            setLaunchConfig();
         }));
     context.subscriptions.push(vscode.commands.registerCommand(
         `${SETTINGS_VIEW_NAME}.attach`,

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -32,6 +32,7 @@ import {
 let telemetryReporter: Readonly<TelemetryReporter>;
 let browserInstance: Browser;
 let launchConfig: LaunchConfig;
+let cdpTargetsProvider: CDPTargetsProvider;
 
 export function activate(context: vscode.ExtensionContext): void {
     if (!telemetryReporter) {
@@ -39,7 +40,7 @@ export function activate(context: vscode.ExtensionContext): void {
     }
 
     // Check if launch.json exists and has supported config to populate side pane welcome message
-    launchConfig = getLaunchJson();
+    setLaunchConfig();
 
     context.subscriptions.push(vscode.commands.registerCommand(`${SETTINGS_STORE_NAME}.attach`, (): void => {
         void attach(context);
@@ -60,7 +61,7 @@ export function activate(context: vscode.ExtensionContext): void {
         new LaunchDebugProvider(context, telemetryReporter, attach, launch));
 
     // Register the side-panel view and its commands
-    const cdpTargetsProvider = new CDPTargetsProvider(context, telemetryReporter);
+    cdpTargetsProvider = new CDPTargetsProvider(context, telemetryReporter);
     context.subscriptions.push(vscode.window.registerTreeDataProvider(
         `${SETTINGS_VIEW_NAME}.targets`,
         cdpTargetsProvider));
@@ -74,30 +75,36 @@ export function activate(context: vscode.ExtensionContext): void {
     context.subscriptions.push(vscode.commands.registerCommand(
         `${SETTINGS_VIEW_NAME}.refresh`,
         () => {
+            telemetryReporter.sendTelemetryEvent('user/buttonPress', { 'VSCode.buttonCode': buttonCode.refreshTargetList });
             cdpTargetsProvider.refresh();
-            launchConfig = getLaunchJson();
+            setLaunchConfig();
         }));
     context.subscriptions.push(vscode.commands.registerCommand(
         `${SETTINGS_VIEW_NAME}.attach`,
         (target?: CDPTarget) => {
             if (!target)
                 {return;}
+            telemetryReporter.sendTelemetryEvent('user/buttonPress', { 'VSCode.buttonCode': buttonCode.attachToTarget });
             telemetryReporter.sendTelemetryEvent('view/devtools');
             const runtimeConfig = getRuntimeConfig();
             DevToolsPanel.createOrShow(context, telemetryReporter, target.websocketUrl, runtimeConfig);
         }));
     context.subscriptions.push(vscode.commands.registerCommand(`${SETTINGS_VIEW_NAME}.openSettings`, () => {
+        telemetryReporter.sendTelemetryEvent('user/buttonPress', { 'VSCode.buttonCode': buttonCode.openSettings });
         void vscode.commands.executeCommand('workbench.action.openSettings', `${SETTINGS_STORE_NAME}`);
     }));
     context.subscriptions.push(vscode.commands.registerCommand(`${SETTINGS_VIEW_NAME}.viewChangelog`, () => {
+        telemetryReporter.sendTelemetryEvent('user/buttonPress', { 'VSCode.buttonCode': buttonCode.viewChangelog });
         void vscode.env.openExternal(vscode.Uri.parse('https://github.com/microsoft/vscode-edge-devtools/blob/master/CHANGELOG.md'));
     }));
     context.subscriptions.push(vscode.commands.registerCommand(
         `${SETTINGS_VIEW_NAME}.close-instance`,
         async (target?: CDPTarget) => {
-            if (!target)
-                {return;}
-
+            if (!target) {
+                telemetryReporter.sendTelemetryEvent('command/close/noTarget');
+                return;
+            }
+            telemetryReporter.sendTelemetryEvent('user/buttonPress', { 'VSCode.buttonCode': buttonCode.closeTarget });
             // disable buttons for this target
             target.contextValue = 'cdpTargetClosing';
             cdpTargetsProvider.changeDataEvent.fire(target);
@@ -131,13 +138,13 @@ export function activate(context: vscode.ExtensionContext): void {
                 'VSCode.buttonCode': launchConfig === 'None' ? buttonCode.generateLaunchJson : buttonCode.configureLaunchJson,
             });
             void configureLaunchJson();
-            launchConfig = getLaunchJson();
+            setLaunchConfig();
         }));
     context.subscriptions.push(vscode.commands.registerCommand(
         `${SETTINGS_VIEW_NAME}.launchProject`,
         () => {
             telemetryReporter.sendTelemetryEvent('user/buttonPress', { 'VSCode.buttonCode': buttonCode.launchProject });
-            launchConfig = getLaunchJson();
+            setLaunchConfig();
             const isValidLaunchConfig = typeof launchConfig === 'object';
             if (vscode.workspace.workspaceFolders && isValidLaunchConfig) {
                 void vscode.debug.startDebugging(vscode.workspace.workspaceFolders[0], launchConfig);
@@ -282,11 +289,15 @@ export async function launch(context: vscode.ExtensionContext, launchUrl?: strin
 
         browserInstance = await launchBrowser(browserPath, port, url, userDataDir);
         browserInstance.addListener('targetcreated', () => {
-            void vscode.commands.executeCommand(`${SETTINGS_VIEW_NAME}.refresh`);
+            cdpTargetsProvider.refresh();
         });
         browserInstance.addListener('targetdestroyed', () => {
-            void vscode.commands.executeCommand(`${SETTINGS_VIEW_NAME}.refresh`);
+            cdpTargetsProvider.refresh();
         });
         await attach(context, url, config);
     }
+}
+
+export function setLaunchConfig() {
+    launchConfig = getLaunchJson();
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -118,6 +118,11 @@ export const buttonCode: Record<string, string> = {
     viewDocumentation: '2',
     configureLaunchJson: '3',
     generateLaunchJson: '4',
+    refreshTargetList: '5',
+    attachToTarget: '6',
+    openSettings: '7',
+    viewChangelog: '8',
+    closeTarget: '9',
 };
 
 export type LaunchConfig = 'None' | 'Unsupported' | vscode.DebugConfiguration;

--- a/test/extension.test.ts
+++ b/test/extension.test.ts
@@ -5,6 +5,7 @@ import { ExtensionContext } from "vscode";
 import TelemetryReporter from "vscode-extension-telemetry";
 import { createFakeExtensionContext, createFakeTelemetryReporter, createFakeVSCode, Mocked } from "./helpers/helpers";
 import {
+    buttonCode,
     IRemoteTargetJson,
     IRuntimeConfig,
     removeTrailingSlash,
@@ -32,6 +33,7 @@ describe("extension", () => {
 
             // Mock out the imported utils
             mockUtils = {
+                buttonCode,
                 SETTINGS_STORE_NAME,
                 SETTINGS_VIEW_NAME,
                 createTelemetryReporter: jest.fn((_: ExtensionContext) => createFakeTelemetryReporter()),


### PR DESCRIPTION
Adding more button press telemetry:

- Refresh
- View Settings from triple dot menu
- View Changelog from triple dot menu
- Attach to target
- Close target

Other changes:
- Removed calls to `vscode.commands.executeCommand(${SETTINGS_VIEW_NAME}.refresh)` to ensure that all telemetry fires are from the button only.
    - Changed those calls to call `cdpTargetsProvider.refresh()` directly - no functional difference.
    - Created and exported `setLaunchConfig()` so that `cdpTargetsProvider` can update `launchConfig` when calling `cdpTargetsProvider.refresh()`
        - This also used to rely on `vscode.commands.executeCommand(${SETTINGS_VIEW_NAME}.refresh)`
- Fixed some spacing issues in `cdpTargetsProvider.ts` that were bugging me