### PR TITLE
[Telemetry]: Creating an opt-in system to attach session ID to telemetry

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
             "license": "SEE LICENSE IN LICENSE",
             "dependencies": {
                 "puppeteer-core": "7.1.0",
+                "uuid": "^8.3.2",
                 "vscode-chrome-debug-core": "6.8.9",
                 "vscode-extension-telemetry": "0.1.7",
                 "ws": "7.4.3",
@@ -21,6 +22,7 @@
                 "@types/jest": "26.0.13",
                 "@types/node": "14.6.3",
                 "@types/puppeteer-core": "2.0.0",
+                "@types/uuid": "^8.3.0",
                 "@types/vscode": "1.48.0",
                 "@types/ws": "7.2.6",
                 "@typescript-eslint/eslint-plugin": "4.19.0",
@@ -1954,6 +1956,12 @@
             "dependencies": {
                 "source-map": "^0.6.1"
             }
+        },
+        "node_modules/@types/uuid": {
+            "version": "8.3.0",
+            "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-8.3.0.tgz",
+            "integrity": "sha512-eQ9qFW/fhfGJF8WKHGEHZEyVWfZxrT+6CLIJGBcZPfxUh/+BnEj+UCGYMlr9qZuX/2AltsvwrGqp0LhEW8D0zQ==",
+            "dev": true
         },
         "node_modules/@types/vscode": {
             "version": "1.48.0",
@@ -12546,8 +12554,6 @@
             "version": "8.3.2",
             "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
             "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-            "dev": true,
-            "optional": true,
             "bin": {
                 "uuid": "dist/bin/uuid"
             }
@@ -14881,6 +14887,12 @@
             "requires": {
                 "source-map": "^0.6.1"
             }
+        },
+        "@types/uuid": {
+            "version": "8.3.0",
+            "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-8.3.0.tgz",
+            "integrity": "sha512-eQ9qFW/fhfGJF8WKHGEHZEyVWfZxrT+6CLIJGBcZPfxUh/+BnEj+UCGYMlr9qZuX/2AltsvwrGqp0LhEW8D0zQ==",
+            "dev": true
         },
         "@types/vscode": {
             "version": "1.48.0",
@@ -23563,9 +23575,7 @@
         "uuid": {
             "version": "8.3.2",
             "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-            "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-            "dev": true,
-            "optional": true
+            "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
         },
         "v8-compile-cache": {
             "version": "2.3.0",

--- a/package.json
+++ b/package.json
@@ -202,6 +202,16 @@
                     "description": "Show service and shared workers in the target list.",
                     "default": false
                 },
+                "vscode-edge-devtools.enableSessionId": {
+                    "type": "string",
+                    "default": "Undecided",
+                    "enum": [
+                        "Undecided",
+                        "Opted in",
+                        "Opted out"
+                    ],
+                    "description": "Allow Edge DevTools for VS Code to send a session ID with telemetry to help improve user experience."
+                },
                 "vscode-edge-devtools.whatsNew": {
                     "type": "boolean",
                     "description": "Enable What's New panel in the drawer (requires relaunching extension)",
@@ -597,6 +607,7 @@
     },
     "dependencies": {
         "puppeteer-core": "7.1.0",
+        "uuid": "^8.3.2",
         "vscode-chrome-debug-core": "6.8.9",
         "vscode-extension-telemetry": "0.1.7",
         "ws": "7.4.3",
@@ -609,6 +620,7 @@
         "@types/jest": "26.0.13",
         "@types/node": "14.6.3",
         "@types/puppeteer-core": "2.0.0",
+        "@types/uuid": "^8.3.0",
         "@types/vscode": "1.48.0",
         "@types/ws": "7.2.6",
         "@typescript-eslint/eslint-plugin": "4.19.0",

--- a/src/EdgeTelemetryReporter.ts
+++ b/src/EdgeTelemetryReporter.ts
@@ -1,15 +1,14 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { DebugTelemetryReporter } from './debugTelemetryReporter';
 import * as vscode from 'vscode';
 import { SETTINGS_STORE_NAME } from './utils';
+import TelemetryReporter from 'vscode-extension-telemetry';
+import { v4 } from 'uuid';
 
-export class EdgeTelemetryReporter extends DebugTelemetryReporter {
+export class EdgeTelemetryReporter extends TelemetryReporter {
     private uuid: string;
     constructor(extensionId: string, extensionVersion: string, key: string, firstParty?: boolean) {
-        // super(extensionId, extensionVersion, key, firstParty);
-        super();
-        const { v4 } = require('uuid');
+        super(extensionId, extensionVersion, key, firstParty);
         this.uuid = v4();
     }
 

--- a/src/EdgeTelemetryReporter.ts
+++ b/src/EdgeTelemetryReporter.ts
@@ -1,0 +1,30 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+import { DebugTelemetryReporter } from './debugTelemetryReporter';
+import * as vscode from 'vscode';
+import { SETTINGS_STORE_NAME } from './utils';
+
+export class EdgeTelemetryReporter extends DebugTelemetryReporter {
+    private uuid: string;
+    constructor(extensionId: string, extensionVersion: string, key: string, firstParty?: boolean) {
+        // super(extensionId, extensionVersion, key, firstParty);
+        super();
+        const { v4 } = require('uuid');
+        this.uuid = v4();
+    }
+
+    sendTelemetryEvent(eventName: string, properties?: {
+        [key: string]: string;
+    }, measurements?: {
+        [key: string]: number;
+    }): void {
+        const settings = vscode.workspace.getConfiguration(SETTINGS_STORE_NAME);
+        if (settings.get('enableSessionId') === 'Opted in') {
+            const updatedProperties = properties ? properties : {};
+            updatedProperties.uuid = this.uuid;
+            super.sendTelemetryEvent(eventName, updatedProperties, measurements);
+        } else {
+            super.sendTelemetryEvent(eventName, properties, measurements);
+        }
+    }
+}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -159,7 +159,7 @@ export function activate(context: vscode.ExtensionContext): void {
     void vscode.commands.executeCommand('setContext', 'titleCommandsRegistered', true);
     const settings = vscode.workspace.getConfiguration(SETTINGS_STORE_NAME);
     if (settings.get('enableSessionId') === 'Undecided') {
-        sessionTelemetryInformationToast();
+        void sessionTelemetryInformationToast();
     }
 }
 
@@ -308,14 +308,14 @@ export function setLaunchConfig(): void {
 }
 
 async function sessionTelemetryInformationToast() {
-    const response = await vscode.window.showInformationMessage(`Opt into sending session information?`, 'Yes', 'No');
+    const response = await vscode.window.showInformationMessage(`Help Edge DevTools for VS Code improve the user experience by enabling session IDs to be sent with telemetry`, 'Yes', 'No');
     const settings = vscode.workspace.getConfiguration(SETTINGS_STORE_NAME);
     if (response === 'Yes') {
         // Updating for both user and workspace settings
-        settings.update('enableSessionId', 'Opted in', true);
-        settings.update('enableSessionId', 'Opted in');
+        void settings.update('enableSessionId', 'Opted in', true);
+        void settings.update('enableSessionId', 'Opted in');
     } else if (response === 'No') {
-        settings.update('enableSessionId', 'Opted out', true);
-        settings.update('enableSessionId', 'Opted out');
+        void settings.update('enableSessionId', 'Opted out', true);
+        void settings.update('enableSessionId', 'Opted out');
     }
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -157,6 +157,10 @@ export function activate(context: vscode.ExtensionContext): void {
             void vscode.env.openExternal(vscode.Uri.parse('https://github.com/microsoft/vscode-edge-devtools/blob/master/README.md'));
         }));
     void vscode.commands.executeCommand('setContext', 'titleCommandsRegistered', true);
+    const settings = vscode.workspace.getConfiguration(SETTINGS_STORE_NAME);
+    if (settings.get('enableSessionId') === 'Undecided') {
+        sessionTelemetryInformationToast();
+    }
 }
 
 export async function attach(
@@ -301,4 +305,17 @@ export async function launch(context: vscode.ExtensionContext, launchUrl?: strin
 
 export function setLaunchConfig(): void {
     launchConfig = getLaunchJson();
+}
+
+async function sessionTelemetryInformationToast() {
+    const response = await vscode.window.showInformationMessage(`Opt into sending session information?`, 'Yes', 'No');
+    const settings = vscode.workspace.getConfiguration(SETTINGS_STORE_NAME);
+    if (response === 'Yes') {
+        // Updating for both user and workspace settings
+        settings.update('enableSessionId', 'Opted in', true);
+        settings.update('enableSessionId', 'Opted in');
+    } else if (response === 'No') {
+        settings.update('enableSessionId', 'Opted out', true);
+        settings.update('enableSessionId', 'Opted out');
+    }
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -12,7 +12,7 @@ import * as debugCore from 'vscode-chrome-debug-core';
 import TelemetryReporter from 'vscode-extension-telemetry';
 import packageJson from '../package.json';
 import { DebugTelemetryReporter } from './debugTelemetryReporter';
-import { EdgeTelemetryReporter } from './EdgeTelemetryReporter';
+import { EdgeTelemetryReporter } from './edgeTelemetryReporter';
 
 import puppeteer from 'puppeteer-core';
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -12,6 +12,7 @@ import * as debugCore from 'vscode-chrome-debug-core';
 import TelemetryReporter from 'vscode-extension-telemetry';
 import packageJson from '../package.json';
 import { DebugTelemetryReporter } from './debugTelemetryReporter';
+import { EdgeTelemetryReporter } from './EdgeTelemetryReporter';
 
 import puppeteer from 'puppeteer-core';
 
@@ -268,7 +269,7 @@ export function getRemoteEndpointSettings(config: Partial<IUserConfig> = {}): ID
 export function createTelemetryReporter(_context: vscode.ExtensionContext): Readonly<TelemetryReporter> {
     if (packageJson && vscode.env.machineId !== 'someValue.machineId') {
         // Use the real telemetry reporter
-        return new TelemetryReporter(packageJson.name, packageJson.version, packageJson.aiKey);
+        return new EdgeTelemetryReporter(packageJson.name, packageJson.version, packageJson.aiKey);
     }
         // Fallback to a fake telemetry reporter
         return new DebugTelemetryReporter();


### PR DESCRIPTION
This PR creates the `EdgeTelemetryReporter` class which extends and replaces the original `TelemetryReporter`.  The `EdgeTelemetryReporter` contains a unique user id when first created and will send it with all telemetry based on an opt-in system from the user.

The three states for the `enableSessionId` setting are `"Undecided"`, `"Opted in"`, and `"Opted out"`. The default setting is `"Undecided"`.  If the setting is set to `"Undecided"`, a toast notification will pop up prompting the user to opt in or out.  After the decision, the `enableSessionId` setting will be updated.

![image](https://user-images.githubusercontent.com/14304598/117351090-2a060e00-ae62-11eb-80f7-b973556425a3.png)
*text is not finalized and meant as a placeholder
