### PR TITLE
[Accessibility]: Add success alert when selecting 'Toggle property and continue editing selected'

### DIFF
--- a/src/host/polyfills/simpleView.ts
+++ b/src/host/polyfills/simpleView.ts
@@ -109,6 +109,7 @@ export function applyStylesToggleFocusPatch(content: string): string | null {
     const replacementText = `
         const sectionIndex = this._parentPane.focusedSectionIndex();
         contextMenu.defaultSection().appendCheckboxItem(ls \`Toggle property and continue editing\`, async () => {
+            ARIAUtils.alert('Toggle property and continue editing selected', this.nameElement);
     `;
     return replaceInSourceCode(content, pattern, replacementText);
 }

--- a/test/host/polyfills/simpleView.test.ts
+++ b/test/host/polyfills/simpleView.test.ts
@@ -282,8 +282,7 @@ describe("simpleView", () => {
     it("applyStylesToggleFocusPatch correctly changes root.js to set extensionSettings map", async () => {
         const filePath = "elements/elements.js";
         const patch = SimpleView.applyStylesToggleFocusPatch;
-        const expectedStrings = [`const sectionIndex = this._parentPane.focusedSectionIndex();
-        contextMenu.defaultSection()`];
+        const expectedStrings = ["ARIAUtils.alert('Toggle property and continue editing selected', this.nameElement);"];
 
         testPatch(filePath, patch, expectedStrings);
     });


### PR DESCRIPTION
The accessibility issue is that screen reader users do not hear the success message of the "Toggle property and continue editing selected" context menu option for styles properties:

![image](https://user-images.githubusercontent.com/14304598/117894714-d33d7180-b271-11eb-8077-83038ee2329d.png)

This is in part due to the same context menu/webview issue that was causing the accessibility bug here: https://github.com/microsoft/vscode-edge-devtools/pull/332

This PR adds an alert call inside the patch created in the PR above so that it will announce the success message.