### PR TITLE
Add ability to attach to active debug target using shared CDP connection

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2556,6 +2556,14 @@
             "integrity": "sha1-skV5w77U1tOWru5tmorn9Ugqt7s=",
             "dev": true
         },
+        "bufferutil": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/bufferutil/-/bufferutil-4.0.1.tgz",
+            "integrity": "sha512-xowrxvpxojqkagPcWRQVXZl0YXhRhAtBEIq3VoER1NH5Mw1n1o0ojdspp+GS2J//2gCVyrzQDApQ4unGF+QOoA==",
+            "requires": {
+                "node-gyp-build": "~3.7.0"
+            }
+        },
         "cache-base": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/cache-base/-/cache-base-1.0.1.tgz",
@@ -7789,6 +7797,11 @@
             "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
             "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw=="
         },
+        "node-gyp-build": {
+            "version": "3.7.0",
+            "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-3.7.0.tgz",
+            "integrity": "sha512-L/Eg02Epx6Si2NXmedx+Okg+4UHqmaf3TNcxd50SF9NQGcJaON3AtU++kax69XV7YWz4tUspqZSAsVofhFKG2w=="
+        },
         "node-int64": {
             "version": "0.4.0",
             "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
@@ -10241,6 +10254,14 @@
             "resolved": "https://registry.npmjs.org/use/-/use-3.1.1.tgz",
             "integrity": "sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ==",
             "dev": true
+        },
+        "utf-8-validate": {
+            "version": "5.0.2",
+            "resolved": "https://registry.npmjs.org/utf-8-validate/-/utf-8-validate-5.0.2.tgz",
+            "integrity": "sha512-SwV++i2gTD5qh2XqaPzBnNX88N6HdyhQrNNRykvcS0QKvItV9u3vPEJr+X5Hhfb1JC0r0e1alL0iB09rY8+nmw==",
+            "requires": {
+                "node-gyp-build": "~3.7.0"
+            }
         },
         "util-deprecate": {
             "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -65,6 +65,16 @@
                 }
             },
             {
+                "command": "vscode-edge-devtools-view.attachShare",
+                "category": "Microsoft Edge Tools",
+                "title": "Attach to active debug target",
+                "enablement": "titleCommandsRegistered",
+                "icon": {
+                    "light": "resources/light/launch.svg",
+                    "dark": "resources/dark/launch.svg"
+                }
+            },
+            {
                 "command": "vscode-edge-devtools-view.refresh",
                 "category": "Microsoft Edge Tools",
                 "title": "Refresh Targets",
@@ -457,6 +467,10 @@
                     "when": "view == vscode-edge-devtools-view.targets"
                 },
                 {
+                    "command": "vscode-edge-devtools-view.attachShare",
+                    "when": "view == vscode-edge-devtools-view.targets"
+                },
+                {
                     "command": "vscode-edge-devtools-view.refresh",
                     "when": "view == vscode-edge-devtools-view.targets"
                 },
@@ -476,6 +490,11 @@
             "view/title": [
                 {
                     "command": "vscode-edge-devtools-view.launch",
+                    "when": "view == vscode-edge-devtools-view.targets",
+                    "group": "navigation"
+                },
+                {
+                    "command": "vscode-edge-devtools-view.attachShare",
                     "when": "view == vscode-edge-devtools-view.targets",
                     "group": "navigation"
                 },

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "activationEvents": [
         "onCommand:vscode-edge-devtools.attach",
         "onCommand:vscode-edge-devtools.launch",
+        "onCommand:vscode-edge-devtools.attachToCurrentDebugTarget",
         "onWebviewPanel:vscode-edge-devtools",
         "onView:vscode-edge-devtools-view.targets",
         "onDebug"
@@ -55,19 +56,14 @@
                 "category": "Microsoft Edge Tools"
             },
             {
+                "command": "vscode-edge-devtools.attachToCurrentDebugTarget",
+                "category": "Microsoft Edge Tools",
+                "title": "Attach to active debug target"
+            },
+            {
                 "command": "vscode-edge-devtools-view.launch",
                 "category": "Microsoft Edge Tools",
                 "title": "Open a new tab",
-                "enablement": "titleCommandsRegistered",
-                "icon": {
-                    "light": "resources/light/launch.svg",
-                    "dark": "resources/dark/launch.svg"
-                }
-            },
-            {
-                "command": "vscode-edge-devtools-view.attachToCurrentDebugTarget",
-                "category": "Microsoft Edge Tools",
-                "title": "Attach to active debug target",
                 "enablement": "titleCommandsRegistered",
                 "icon": {
                     "light": "resources/light/launch.svg",
@@ -467,10 +463,6 @@
                     "when": "view == vscode-edge-devtools-view.targets"
                 },
                 {
-                    "command": "vscode-edge-devtools-view.attachToCurrentDebugTarget",
-                    "when": "view == vscode-edge-devtools-view.targets"
-                },
-                {
                     "command": "vscode-edge-devtools-view.refresh",
                     "when": "view == vscode-edge-devtools-view.targets"
                 },
@@ -490,11 +482,6 @@
             "view/title": [
                 {
                     "command": "vscode-edge-devtools-view.launch",
-                    "when": "view == vscode-edge-devtools-view.targets",
-                    "group": "navigation"
-                },
-                {
-                    "command": "vscode-edge-devtools-view.attachToCurrentDebugTarget",
                     "when": "view == vscode-edge-devtools-view.targets",
                     "group": "navigation"
                 },

--- a/package.json
+++ b/package.json
@@ -602,7 +602,9 @@
         "download-edge": "node scripts/downloadAndExtractEdge.js"
     },
     "dependencies": {
+        "bufferutil": "4.0.1",
         "puppeteer-core": "9.1.1",
+        "utf-8-validate": "5.0.2",
         "vscode-chrome-debug-core": "6.8.9",
         "vscode-extension-telemetry": "0.1.7",
         "ws": "7.4.5",

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
                 }
             },
             {
-                "command": "vscode-edge-devtools-view.attachShare",
+                "command": "vscode-edge-devtools-view.attachToCurrentDebugTarget",
                 "category": "Microsoft Edge Tools",
                 "title": "Attach to active debug target",
                 "enablement": "titleCommandsRegistered",
@@ -467,7 +467,7 @@
                     "when": "view == vscode-edge-devtools-view.targets"
                 },
                 {
-                    "command": "vscode-edge-devtools-view.attachShare",
+                    "command": "vscode-edge-devtools-view.attachToCurrentDebugTarget",
                     "when": "view == vscode-edge-devtools-view.targets"
                 },
                 {
@@ -494,7 +494,7 @@
                     "group": "navigation"
                 },
                 {
-                    "command": "vscode-edge-devtools-view.attachShare",
+                    "command": "vscode-edge-devtools-view.attachToCurrentDebugTarget",
                     "when": "view == vscode-edge-devtools-view.targets",
                     "group": "navigation"
                 },

--- a/package.json
+++ b/package.json
@@ -56,11 +56,6 @@
                 "category": "Microsoft Edge Tools"
             },
             {
-                "command": "vscode-edge-devtools.attachToCurrentDebugTarget",
-                "category": "Microsoft Edge Tools",
-                "title": "Attach to active debug target"
-            },
-            {
                 "command": "vscode-edge-devtools-view.launch",
                 "category": "Microsoft Edge Tools",
                 "title": "Open a new tab",

--- a/src/JsDebugProxyPanelSocket.ts
+++ b/src/JsDebugProxyPanelSocket.ts
@@ -1,0 +1,41 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import { WebSocketEvent } from './common/webviewEvents';
+import { PanelSocket } from './panelSocket';
+
+export type IDevToolsPostMessageCallback = (e: WebSocketEvent, message?: string) => void;
+
+export class JsDebugProxyPanelSocket extends PanelSocket {
+    /**
+     * @override
+     */
+    protected onOpen() {
+        if (this.socket) {
+            this.registerForCDPEvents();
+        }
+        super.onOpen();
+    }
+
+    private registerForCDPEvents() {
+        // register for custom events from jsdebug:
+        const registrationMessage = {
+            method: 'JsDebug.subscribe',
+            params: {
+                events: [
+                'Runtime.*',
+                'DOM.*',
+                'CSS.*',
+                'DOMDebugger.*',
+                'Network.*',
+                'Page.*',
+                'Target.*',
+                'Overlay.*',
+                ],
+            },
+        };
+        if (this.socket) {
+            this.socket.send(JSON.stringify(registrationMessage));
+        }
+    }
+}

--- a/src/JsDebugProxyPanelSocket.ts
+++ b/src/JsDebugProxyPanelSocket.ts
@@ -12,13 +12,14 @@ export class JsDebugProxyPanelSocket extends PanelSocket {
      */
     protected onOpen(): void {
         if (this.socket) {
-            this.registerForCDPEvents();
+            this.registerForJsDebugSharedCDPEvents();
         }
         super.onOpen();
     }
 
-    private registerForCDPEvents() {
+    private registerForJsDebugSharedCDPEvents() {
         // register for custom events from jsdebug:
+        // TODO before checkin: add docs here
         const registrationMessage = {
             method: 'JsDebug.subscribe',
             params: {

--- a/src/JsDebugProxyPanelSocket.ts
+++ b/src/JsDebugProxyPanelSocket.ts
@@ -10,7 +10,7 @@ export class JsDebugProxyPanelSocket extends PanelSocket {
     /**
      * @override
      */
-    protected onOpen() {
+    protected onOpen(): void {
         if (this.socket) {
             this.registerForCDPEvents();
         }

--- a/src/JsDebugProxyPanelSocket.ts
+++ b/src/JsDebugProxyPanelSocket.ts
@@ -18,8 +18,8 @@ export class JsDebugProxyPanelSocket extends PanelSocket {
     }
 
     private registerForJsDebugSharedCDPEvents() {
-        // register for custom events from jsdebug:
-        // TODO before checkin: add docs here
+        // Register for CDP events from jsdebug:
+        // https://github.com/microsoft/vscode-js-debug/blob/main/CDP_SHARE.md
         const registrationMessage = {
             method: 'JsDebug.subscribe',
             params: {

--- a/src/devtoolsPanel.ts
+++ b/src/devtoolsPanel.ts
@@ -56,7 +56,7 @@ export class DevToolsPanel {
         this.consoleOutput.appendLine('');
 
         // Hook up the socket events
-        if (this.config.isCDPShared) {
+        if (this.config.isJsDebugProxiedCDPConnection) {
             this.panelSocket = new JsDebugProxyPanelSocket(this.targetUrl, (e, msg) => this.postToDevTools(e, msg));
         } else {
             this.panelSocket = new PanelSocket(this.targetUrl, (e, msg) => this.postToDevTools(e, msg));

--- a/src/devtoolsPanel.ts
+++ b/src/devtoolsPanel.ts
@@ -14,6 +14,7 @@ import {
     TelemetryData,
     WebSocketEvent,
 } from './common/webviewEvents';
+import { JsDebugProxyPanelSocket } from './JsDebugProxyPanelSocket';
 import { PanelSocket } from './panelSocket';
 import {
     applyPathMapping,
@@ -55,7 +56,11 @@ export class DevToolsPanel {
         this.consoleOutput.appendLine('');
 
         // Hook up the socket events
-        this.panelSocket = new PanelSocket(this.targetUrl, (e, msg) => this.postToDevTools(e, msg), this.config.isCDPShared);
+        if (this.config.isCDPShared) {
+            this.panelSocket = new JsDebugProxyPanelSocket(this.targetUrl, (e, msg) => this.postToDevTools(e, msg));
+        } else {
+            this.panelSocket = new PanelSocket(this.targetUrl, (e, msg) => this.postToDevTools(e, msg));
+        }
         this.panelSocket.on('ready', () => this.onSocketReady());
         this.panelSocket.on('websocket', () => this.onSocketMessage());
         this.panelSocket.on('telemetry', msg => this.onSocketTelemetry(msg));

--- a/src/devtoolsPanel.ts
+++ b/src/devtoolsPanel.ts
@@ -55,7 +55,7 @@ export class DevToolsPanel {
         this.consoleOutput.appendLine('');
 
         // Hook up the socket events
-        this.panelSocket = new PanelSocket(this.targetUrl, (e, msg) => this.postToDevTools(e, msg));
+        this.panelSocket = new PanelSocket(this.targetUrl, (e, msg) => this.postToDevTools(e, msg), this.config.isCDPShared);
         this.panelSocket.on('ready', () => this.onSocketReady());
         this.panelSocket.on('websocket', () => this.onSocketMessage());
         this.panelSocket.on('telemetry', msg => this.onSocketTelemetry(msg));

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -289,9 +289,11 @@ export async function attachToCurrentDebugTarget(context: vscode.ExtensionContex
         if (e instanceof Error) {
             telemetryReporter.sendTelemetryErrorEvent('command/attachToCurrentDebugTarget/devtools', {message: e.message});
             void vscode.window.showErrorMessage(e.message);
+        } else {
+            // Throw remaining unhandled exceptions
+            throw e;
         }
-        // Throw remaining unhandled exceptions
-        throw e;
+        return;
     }
 
     if (targetWebsocketUrl) {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -297,7 +297,7 @@ export async function attachToCurrentDebugTarget(context: vscode.ExtensionContex
         // Auto connect to found target
         telemetryReporter.sendTelemetryEvent('command/attachToCurrentDebugTarget/devtools');
         const runtimeConfig = getRuntimeConfig();
-        runtimeConfig.isCDPShared = true;
+        runtimeConfig.isJsDebugProxiedCDPConnection = true;
         DevToolsPanel.createOrShow(context, telemetryReporter, targetWebsocketUrl, runtimeConfig);
     } else {
         const errorMessage = 'Unable to attach DevTools to current debug session.';

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -290,7 +290,8 @@ export async function attachToCurrentDebugTarget(context: vscode.ExtensionContex
             telemetryReporter.sendTelemetryErrorEvent('command/attachToCurrentDebugTarget/devtools', {message: e.message});
             void vscode.window.showErrorMessage(e.message);
         }
-        return;
+        // Throw remaining unhandled exceptions
+        throw e;
     }
 
     if (targetWebsocketUrl) {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -51,7 +51,7 @@ export function activate(context: vscode.ExtensionContext): void {
     }));
 
     context.subscriptions.push(vscode.commands.registerCommand(`${SETTINGS_STORE_NAME}.attachToCurrentDebugTarget`, (): void => {
-        void attach(context);
+        void attachToCurrentDebugTarget(context);
     }));
 
     // Register the launch provider
@@ -74,12 +74,6 @@ export function activate(context: vscode.ExtensionContext): void {
         async () => {
             telemetryReporter.sendTelemetryEvent('user/buttonPress', { 'VSCode.buttonCode': buttonCode.launchBrowserInstance });
             await launch(context);
-            cdpTargetsProvider.refresh();
-        }));
-    context.subscriptions.push(vscode.commands.registerCommand(
-        `${SETTINGS_VIEW_NAME}.attachToCurrentDebugTarget`,
-        async () => {
-            await attachToCurrentDebugTarget(context);
             cdpTargetsProvider.refresh();
         }));
     context.subscriptions.push(vscode.commands.registerCommand(
@@ -199,7 +193,8 @@ export async function attachToCurrentDebugTarget(
     if (targetWebsocketUrl) {
         // Auto connect to found target
         telemetryReporter.sendTelemetryEvent('command/attachToCurrentDebugTarget/devtools');
-        const runtimeConfig = getRuntimeConfig();
+        let runtimeConfig = getRuntimeConfig();
+        runtimeConfig.isCDPShared = true;
         DevToolsPanel.createOrShow(context, telemetryReporter, targetWebsocketUrl, runtimeConfig);
     } else {
         vscode.window.showErrorMessage('Unable to attach DevTools to current debug session.');

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -174,7 +174,9 @@ export async function attachToCurrentDebugTarget(
     // Attempt to attach to active CDP target
     const session = vscode.debug.activeDebugSession;
     if (!session) {
-        vscode.window.showErrorMessage('No active debug session');
+        const errorMessage = 'No active debug session';
+        telemetryReporter.sendTelemetryErrorEvent('command/attachToCurrentDebugTarget/devtools', {message: errorMessage});
+        vscode.window.showErrorMessage(errorMessage);
         return;
     }
 
@@ -197,7 +199,9 @@ export async function attachToCurrentDebugTarget(
         runtimeConfig.isCDPShared = true;
         DevToolsPanel.createOrShow(context, telemetryReporter, targetWebsocketUrl, runtimeConfig);
     } else {
-        vscode.window.showErrorMessage('Unable to attach DevTools to current debug session.');
+        const errorMessage = 'Unable to attach DevTools to current debug session.';
+        telemetryReporter.sendTelemetryErrorEvent('command/attachToCurrentDebugTarget/devtools', {message: errorMessage});
+        vscode.window.showErrorMessage(errorMessage);
     }
 }
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -262,7 +262,7 @@ export async function attachToCurrentDebugTarget(context: vscode.ExtensionContex
     }
 
     telemetryReporter.sendTelemetryEvent('command/attachToCurrentDebugTarget');
-    let sessionId = debugSessionId || getActiveDebugSessionId();
+    const sessionId = debugSessionId || getActiveDebugSessionId();
 
     if (!sessionId) {
         const errorMessage = 'No active debug session';
@@ -271,7 +271,7 @@ export async function attachToCurrentDebugTarget(context: vscode.ExtensionContex
         return;
     }
 
-    let targetWebsocketUrl = await getJsDebugCDPProxyWebsocketUrl(sessionId);
+    const targetWebsocketUrl = await getJsDebugCDPProxyWebsocketUrl(sessionId);
 
     if (targetWebsocketUrl instanceof Error) {
         telemetryReporter.sendTelemetryErrorEvent('command/attachToCurrentDebugTarget/devtools', {message: targetWebsocketUrl.message});

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -50,7 +50,7 @@ export function activate(context: vscode.ExtensionContext): void {
         void launch(context);
     }));
 
-    context.subscriptions.push(vscode.commands.registerCommand(`${SETTINGS_STORE_NAME}.attachShare`, (): void => {
+    context.subscriptions.push(vscode.commands.registerCommand(`${SETTINGS_STORE_NAME}.attachToCurrentDebugTarget`, (): void => {
         void attach(context);
     }));
 
@@ -77,9 +77,9 @@ export function activate(context: vscode.ExtensionContext): void {
             cdpTargetsProvider.refresh();
         }));
     context.subscriptions.push(vscode.commands.registerCommand(
-        `${SETTINGS_VIEW_NAME}.attachShare`,
+        `${SETTINGS_VIEW_NAME}.attachToCurrentDebugTarget`,
         async () => {
-            await attachShare(context);
+            await attachToCurrentDebugTarget(context);
             cdpTargetsProvider.refresh();
         }));
     context.subscriptions.push(vscode.commands.registerCommand(
@@ -169,7 +169,7 @@ export function activate(context: vscode.ExtensionContext): void {
     void vscode.commands.executeCommand('setContext', 'titleCommandsRegistered', true);
 }
 
-export async function attachShare(
+export async function attachToCurrentDebugTarget(
     context: vscode.ExtensionContext, attachUrl?: string, config?: Partial<IUserConfig>, useRetry?: boolean): Promise<void> {
     if (!telemetryReporter) {
         telemetryReporter = createTelemetryReporter(context);
@@ -196,8 +196,7 @@ export async function attachShare(
             'extension.js-debug.requestCDPProxy',
             session.id,
             );
-            const formed = `ws://${addr.host}:${addr.port}`;
-            vscode.window.showInformationMessage(`Address copied to your clipboard (${formed})`);
+            const formed = `ws://${addr.host}:${addr.port}${addr.path || ''}`;
             targetWebsocketUrl = formed;
         } catch (e) {
             vscode.window.showErrorMessage(e.message);

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -50,6 +50,10 @@ export function activate(context: vscode.ExtensionContext): void {
         void launch(context);
     }));
 
+    context.subscriptions.push(vscode.commands.registerCommand(`${SETTINGS_STORE_NAME}.attachShare`, (): void => {
+        void attach(context);
+    }));
+
     // Register the launch provider
     vscode.debug.registerDebugConfigurationProvider(`${SETTINGS_STORE_NAME}.debug`,
         new LaunchDebugProvider(context, telemetryReporter, attach, launch));
@@ -70,6 +74,12 @@ export function activate(context: vscode.ExtensionContext): void {
         async () => {
             telemetryReporter.sendTelemetryEvent('user/buttonPress', { 'VSCode.buttonCode': buttonCode.launchBrowserInstance });
             await launch(context);
+            cdpTargetsProvider.refresh();
+        }));
+    context.subscriptions.push(vscode.commands.registerCommand(
+        `${SETTINGS_VIEW_NAME}.attachShare`,
+        async () => {
+            await attachShare(context);
             cdpTargetsProvider.refresh();
         }));
     context.subscriptions.push(vscode.commands.registerCommand(
@@ -157,6 +167,59 @@ export function activate(context: vscode.ExtensionContext): void {
             void vscode.env.openExternal(vscode.Uri.parse('https://github.com/microsoft/vscode-edge-devtools/blob/master/README.md'));
         }));
     void vscode.commands.executeCommand('setContext', 'titleCommandsRegistered', true);
+}
+
+export async function attachShare(
+    context: vscode.ExtensionContext, attachUrl?: string, config?: Partial<IUserConfig>, useRetry?: boolean): Promise<void> {
+    if (!telemetryReporter) {
+        telemetryReporter = createTelemetryReporter(context);
+    }
+
+    const telemetryProps = { viaConfig: `${!!config}`, withTargetUrl: `${!!attachUrl}` };
+    telemetryReporter.sendTelemetryEvent('command/attach', telemetryProps);
+
+    const { timeout } = getRemoteEndpointSettings(config);
+
+    // Get the attach target and keep trying until reaching timeout
+    const startTime = Date.now();
+    do {
+        // Attempt to attach to active CDP target
+        const session = vscode.debug.activeDebugSession;
+        if (!session) {
+            vscode.window.showErrorMessage('No active debug session');
+            continue;
+        }
+
+        let targetWebsocketUrl;
+        try {
+            const addr: any = await vscode.commands.executeCommand(
+            'extension.js-debug.requestCDPProxy',
+            session.id,
+            );
+            const formed = `ws://${addr.host}:${addr.port}`;
+            vscode.window.showInformationMessage(`Address copied to your clipboard (${formed})`);
+            targetWebsocketUrl = formed;
+        } catch (e) {
+            vscode.window.showErrorMessage(e.message);
+        }
+
+        if (targetWebsocketUrl) {
+            // Auto connect to found target
+            useRetry = false;
+            telemetryReporter.sendTelemetryEvent('command/attach/devtools', telemetryProps);
+            const runtimeConfig = getRuntimeConfig(config);
+            DevToolsPanel.createOrShow(context, telemetryReporter, targetWebsocketUrl, runtimeConfig);
+        } else if (useRetry) {
+            // Wait for a little bit until we retry
+            await new Promise<void>(resolve => {
+                setTimeout(() => {
+                    resolve();
+                }, SETTINGS_DEFAULT_ATTACH_INTERVAL);
+            });
+        } else {
+            console.error("could not connect to shared url")
+        }
+    } while (useRetry && Date.now() - startTime < timeout);
 }
 
 export async function attach(

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -176,7 +176,7 @@ export async function attachToCurrentDebugTarget(
     }
 
     const telemetryProps = { viaConfig: `${!!config}`, withTargetUrl: `${!!attachUrl}` };
-    telemetryReporter.sendTelemetryEvent('command/attach', telemetryProps);
+    telemetryReporter.sendTelemetryEvent('command/attachToCurrentDebugTarget', telemetryProps);
 
     const { timeout } = getRemoteEndpointSettings(config);
 
@@ -205,7 +205,7 @@ export async function attachToCurrentDebugTarget(
         if (targetWebsocketUrl) {
             // Auto connect to found target
             useRetry = false;
-            telemetryReporter.sendTelemetryEvent('command/attach/devtools', telemetryProps);
+            telemetryReporter.sendTelemetryEvent('command/attachToCurrentDebugTarget/devtools', telemetryProps);
             const runtimeConfig = getRuntimeConfig(config);
             DevToolsPanel.createOrShow(context, telemetryReporter, targetWebsocketUrl, runtimeConfig);
         } else if (useRetry) {
@@ -216,7 +216,7 @@ export async function attachToCurrentDebugTarget(
                 }, SETTINGS_DEFAULT_ATTACH_INTERVAL);
             });
         } else {
-            console.error("could not connect to shared url")
+            console.error("could not connect to shared current debug target")
         }
     } while (useRetry && Date.now() - startTime < timeout);
 }

--- a/src/panelSocket.ts
+++ b/src/panelSocket.ts
@@ -13,7 +13,7 @@ export class PanelSocket extends EventEmitter {
     private socket: WebSocket | undefined;
     private isConnected = false;
     private messages: string[] = [];
-    private isCDPShared = false
+    private isCDPShared = false;
 
     constructor(targetUrl: string, postMessageToDevTools: IDevToolsPostMessageCallback, isCDPShared: boolean = false) {
         super();
@@ -76,7 +76,6 @@ export class PanelSocket extends EventEmitter {
         this.socket.onmessage = ev => this.onMessage(ev);
         this.socket.onerror = () => this.onError();
         this.socket.onclose = () => this.onClose();
-
     }
 
     private onOpen() {
@@ -122,20 +121,22 @@ export class PanelSocket extends EventEmitter {
     private registerForCDPEvents() {
         // register for custom events from jsdebug:
         const registrationMessage = {
-            method: "JsDebug.subscribe",
+            method: 'JsDebug.subscribe',
             params: {
                 events: [
-                "Runtime.*",
-                "DOM.*",
-                "CSS.*",
-                "DOMDebugger.*",
-                "Network.*",
-                "Page.*",
-                "Target.*",
-                "Overlay.*"
+                'Runtime.*',
+                'DOM.*',
+                'CSS.*',
+                'DOMDebugger.*',
+                'Network.*',
+                'Page.*',
+                'Target.*',
+                'Overlay.*',
                 ]
             }
         }
-        this.socket?.send(JSON.stringify(registrationMessage));
+        if (this.socket) {
+            this.socket.send(JSON.stringify(registrationMessage));
+        }
     }
 }

--- a/src/panelSocket.ts
+++ b/src/panelSocket.ts
@@ -78,7 +78,9 @@ export class PanelSocket extends EventEmitter {
 
     protected onOpen(): void {
         this.isConnected = true;
+
         this.postMessageToDevTools('open');
+
         if (this.socket) {
             // Forward any cached messages onto the real websocket
             for (const message of this.messages) {

--- a/src/panelSocket.ts
+++ b/src/panelSocket.ts
@@ -15,7 +15,7 @@ export class PanelSocket extends EventEmitter {
     private messages: string[] = [];
     private isCDPShared = false;
 
-    constructor(targetUrl: string, postMessageToDevTools: IDevToolsPostMessageCallback, isCDPShared: boolean = false) {
+    constructor(targetUrl: string, postMessageToDevTools: IDevToolsPostMessageCallback, isCDPShared = false) {
         super();
         this.targetUrl = targetUrl;
         this.postMessageToDevTools = postMessageToDevTools;
@@ -132,9 +132,9 @@ export class PanelSocket extends EventEmitter {
                 'Page.*',
                 'Target.*',
                 'Overlay.*',
-                ]
-            }
-        }
+                ],
+            },
+        };
         if (this.socket) {
             this.socket.send(JSON.stringify(registrationMessage));
         }

--- a/src/panelSocket.ts
+++ b/src/panelSocket.ts
@@ -10,7 +10,7 @@ export type IDevToolsPostMessageCallback = (e: WebSocketEvent, message?: string)
 export class PanelSocket extends EventEmitter {
     private readonly targetUrl: string;
     private readonly postMessageToDevTools: IDevToolsPostMessageCallback;
-    private socket: WebSocket | undefined;
+    protected socket: WebSocket | undefined;
     private isConnected = false;
     private messages: string[] = [];
 

--- a/src/panelSocket.ts
+++ b/src/panelSocket.ts
@@ -57,6 +57,7 @@ export class PanelSocket extends EventEmitter {
                     this.messages.push(message);
                 } else {
                     // Websocket ready so send the message directly
+                    console.log(message)
                     if (this.socket) {
                         this.socket.send(message);
                     }
@@ -74,9 +75,28 @@ export class PanelSocket extends EventEmitter {
         this.socket.onmessage = ev => this.onMessage(ev);
         this.socket.onerror = () => this.onError();
         this.socket.onclose = () => this.onClose();
+
     }
 
     private onOpen() {
+        // register for custom events from jsdebug:
+        const registrationMessage = {
+            method: "JsDebug.subscribe",
+            params: {
+                events: [
+                "Runtime.*",
+                "DOM.*",
+                "CSS.*",
+                "DOMDebugger.*",
+                "Network.*",
+                "Page.*",
+                "Target.*",
+                "Overlay.*"
+                ]
+            }
+        }
+        this.socket?.send(JSON.stringify(registrationMessage));
+        console.log("registered for events")
         this.isConnected = true;
 
         this.postMessageToDevTools('open');

--- a/src/panelSocket.ts
+++ b/src/panelSocket.ts
@@ -76,7 +76,7 @@ export class PanelSocket extends EventEmitter {
         this.socket.onclose = () => this.onClose();
     }
 
-    protected onOpen() {
+    protected onOpen(): void {
         this.isConnected = true;
         this.postMessageToDevTools('open');
         if (this.socket) {

--- a/src/panelSocket.ts
+++ b/src/panelSocket.ts
@@ -57,7 +57,6 @@ export class PanelSocket extends EventEmitter {
                     this.messages.push(message);
                 } else {
                     // Websocket ready so send the message directly
-                    console.log(message)
                     if (this.socket) {
                         this.socket.send(message);
                     }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -295,10 +295,9 @@ export async function getJsDebugCDPProxyWebsocketUrl(debugSessionId: string): Pr
     } catch (e) {
         if (e instanceof Error) {
             return e;
-        } else {
-            // Throw remaining unhandled exceptions
-            throw e;
         }
+        // Throw remaining unhandled exceptions
+        throw e;
     }
 }
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -55,7 +55,7 @@ export interface IRuntimeConfig {
     sourceMapPathOverrides: IStringDictionary<string>;
     sourceMaps: boolean;
     webRoot: string;
-    isCDPShared: boolean;
+    isJsDebugProxiedCDPConnection: boolean;
 }
 export interface IStringDictionary<T> {
     [name: string]: T;
@@ -473,7 +473,7 @@ export function getRuntimeConfig(config: Partial<IUserConfig> = {}): IRuntimeCon
         sourceMapPathOverrides: resolvedOverrides,
         sourceMaps,
         webRoot: resolvedWebRoot,
-        isCDPShared: false,
+        isJsDebugProxiedCDPConnection: false,
     };
 }
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -55,6 +55,7 @@ export interface IRuntimeConfig {
     sourceMapPathOverrides: IStringDictionary<string>;
     sourceMaps: boolean;
     webRoot: string;
+    isCDPShared: boolean;
 }
 export interface IStringDictionary<T> {
     [name: string]: T;
@@ -472,6 +473,7 @@ export function getRuntimeConfig(config: Partial<IUserConfig> = {}): IRuntimeCon
         sourceMapPathOverrides: resolvedOverrides,
         sourceMaps,
         webRoot: resolvedWebRoot,
+        isCDPShared: false,
     };
 }
 

--- a/test/devtoolsPanel.test.ts
+++ b/test/devtoolsPanel.test.ts
@@ -39,7 +39,7 @@ describe("devtoolsPanel", () => {
             sourceMapPathOverrides: {},
             sourceMaps: true,
             webRoot: "",
-            isCDPShared: false,
+            isJsDebugProxiedCDPConnection: false,
         };
 
         mockPanel = {

--- a/test/devtoolsPanel.test.ts
+++ b/test/devtoolsPanel.test.ts
@@ -39,6 +39,7 @@ describe("devtoolsPanel", () => {
             sourceMapPathOverrides: {},
             sourceMaps: true,
             webRoot: "",
+            isCDPShared: false,
         };
 
         mockPanel = {

--- a/test/extension.test.ts
+++ b/test/extension.test.ts
@@ -42,7 +42,7 @@ describe("extension", () => {
                 getRuntimeConfig: jest.fn(),
                 removeTrailingSlash: jest.fn(removeTrailingSlash),
                 getLaunchJson: jest.fn(),
-                getJsDebugCDPProxyWebsocketUrl: jest.fn().mockResolvedValue('ws://127.0.0.1:9222/uniquePath'),
+                getJsDebugCDPProxyWebsocketUrl: jest.fn(),
                 getActiveDebugSessionId: jest.fn(),
             };
             jest.doMock("../src/utils", () => mockUtils);
@@ -401,6 +401,7 @@ describe("extension", () => {
                 openNewTab: jest.fn().mockResolvedValue(null),
                 removeTrailingSlash: jest.fn(removeTrailingSlash),
                 getLaunchJson: jest.fn(),
+                getJsDebugCDPProxyWebsocketUrl: jest.fn(),
                 buttonCode: { launch: '' },
             };
 

--- a/test/extension.test.ts
+++ b/test/extension.test.ts
@@ -77,32 +77,34 @@ describe("extension", () => {
             // Activation should add the commands as subscriptions on the context
             newExtension.activate(context);
 
-            expect(context.subscriptions.length).toBe(13);
-            expect(commandMock).toHaveBeenCalledTimes(12);
+            expect(context.subscriptions.length).toBe(14);
+            expect(commandMock).toHaveBeenCalledTimes(13);
             expect(commandMock)
                 .toHaveBeenNthCalledWith(1, `${SETTINGS_STORE_NAME}.attach`, expect.any(Function));
             expect(commandMock)
                 .toHaveBeenNthCalledWith(2, `${SETTINGS_STORE_NAME}.launch`, expect.any(Function));
             expect(commandMock)
-                .toHaveBeenNthCalledWith(3, `${SETTINGS_VIEW_NAME}.launch`, expect.any(Function));
+                .toHaveBeenNthCalledWith(3, `${SETTINGS_STORE_NAME}.attachToCurrentDebugTarget`, expect.any(Function));
             expect(commandMock)
-                .toHaveBeenNthCalledWith(4, `${SETTINGS_VIEW_NAME}.refresh`, expect.any(Function));
+                .toHaveBeenNthCalledWith(4, `${SETTINGS_VIEW_NAME}.launch`, expect.any(Function));
             expect(commandMock)
-                .toHaveBeenNthCalledWith(5, `${SETTINGS_VIEW_NAME}.attach`, expect.any(Function));
+                .toHaveBeenNthCalledWith(5, `${SETTINGS_VIEW_NAME}.refresh`, expect.any(Function));
             expect(commandMock)
-                .toHaveBeenNthCalledWith(6, `${SETTINGS_VIEW_NAME}.openSettings`, expect.any(Function));
+                .toHaveBeenNthCalledWith(6, `${SETTINGS_VIEW_NAME}.attach`, expect.any(Function));
             expect(commandMock)
-                .toHaveBeenNthCalledWith(7, `${SETTINGS_VIEW_NAME}.viewChangelog`, expect.any(Function));
+                .toHaveBeenNthCalledWith(7, `${SETTINGS_VIEW_NAME}.openSettings`, expect.any(Function));
             expect(commandMock)
-                .toHaveBeenNthCalledWith(8, `${SETTINGS_VIEW_NAME}.close-instance`, expect.any(Function));
+                .toHaveBeenNthCalledWith(8, `${SETTINGS_VIEW_NAME}.viewChangelog`, expect.any(Function));
             expect(commandMock)
-                .toHaveBeenNthCalledWith(9, `${SETTINGS_VIEW_NAME}.copyItem`, expect.any(Function));
+                .toHaveBeenNthCalledWith(9, `${SETTINGS_VIEW_NAME}.close-instance`, expect.any(Function));
             expect(commandMock)
-                .toHaveBeenNthCalledWith(10, `${SETTINGS_VIEW_NAME}.configureLaunchJson`, expect.any(Function));
+                .toHaveBeenNthCalledWith(10, `${SETTINGS_VIEW_NAME}.copyItem`, expect.any(Function));
             expect(commandMock)
-                .toHaveBeenNthCalledWith(11, `${SETTINGS_VIEW_NAME}.launchProject`, expect.any(Function));
+                .toHaveBeenNthCalledWith(11, `${SETTINGS_VIEW_NAME}.configureLaunchJson`, expect.any(Function));
             expect(commandMock)
-                .toHaveBeenNthCalledWith(12, `${SETTINGS_VIEW_NAME}.viewDocumentation`, expect.any(Function)); 
+                .toHaveBeenNthCalledWith(12, `${SETTINGS_VIEW_NAME}.launchProject`, expect.any(Function));
+            expect(commandMock)
+                .toHaveBeenNthCalledWith(13, `${SETTINGS_VIEW_NAME}.viewDocumentation`, expect.any(Function));
             expect(mockRegisterTree)
                 .toHaveBeenNthCalledWith(1, `${SETTINGS_VIEW_NAME}.targets`, expect.any(Object));
         });
@@ -151,15 +153,15 @@ describe("extension", () => {
                 return { callback: commandMock.mock.calls[index][1], thisObj: commandMock.mock.instances[index] };
             }
 
-            const refresh = getCommandCallback(3);
+            const refresh = getCommandCallback(4);
             refresh.callback.call(refresh.thisObj);
             expect(mockProviderRefresh).toHaveBeenCalled();
 
-            const attach = getCommandCallback(4);
+            const attach = getCommandCallback(5);
             attach.callback.call(attach.thisObj, { websocketUrl: "" });
             expect(mockPanelShow).toHaveBeenCalled();
 
-            const copy = getCommandCallback(8);
+            const copy = getCommandCallback(9);
             copy.callback.call(copy.thisObj, { tooltip: "something" });
             expect(mockClipboard).toHaveBeenCalledWith("something");
         });

--- a/test/helpers/helpers.ts
+++ b/test/helpers/helpers.ts
@@ -45,6 +45,9 @@ export function createFakeVSCode() {
         },
         debug: {
             registerDebugConfigurationProvider: jest.fn(),
+            activeDebugSession: {
+                id: 'vscode-session-debug-id'
+            }
         },
         env: {
             clipboard: { writeText: jest.fn() },

--- a/test/utils.test.ts
+++ b/test/utils.test.ts
@@ -986,4 +986,40 @@ describe("utils", () => {
             })).toEqual(pathResolve("/project/src/app.js"));
         });
     });
+
+    describe("getActiveDebugSessionId", () => {
+        it("retrieves the debug session id from vscode properly", () => {
+            expect(utils.getActiveDebugSessionId()).toBe('vscode-session-debug-id');
+        });
+
+        it("returns undefined when there is not an active vscode session", async () => {
+            const vscodeMock = await jest.requireMock("vscode");
+            vscodeMock.debug.activeDebugSession = undefined;
+            expect(utils.getActiveDebugSessionId()).toBe(undefined);
+        });
+    });
+
+    describe("getJsDebugCDPProxyWebsocketUrl", () => {
+        it("creates a proper websocket url from a debug session id", async () => {
+            const expectedAddr = {
+                host: '127.0.0.1',
+                port: '9222',
+                path: '/uniquePath'
+            };
+            const vscodeMock = await jest.requireMock("vscode");
+            vscodeMock.commands.executeCommand.mockImplementationOnce((name: string, sessionId: string) => {return expectedAddr;});
+
+            const result = await utils.getJsDebugCDPProxyWebsocketUrl('debugSessionId');
+            expect(result).toBe('ws://127.0.0.1:9222/uniquePath');
+        });
+
+        it("returns an error if the VSCode execute command throws an error", async () => {
+            const vscodeMock = await jest.requireMock("vscode");
+            vscodeMock.commands.executeCommand.mockImplementationOnce((name: string, sessionId: string) => {throw new Error("error message")});
+
+            const result = await utils.getJsDebugCDPProxyWebsocketUrl('debugSessionId') as Error;
+            expect(result).toBeInstanceOf(Error);
+            expect(result.message).toBe('error message');
+        });
+    });
 });


### PR DESCRIPTION
This Pull request registers a new command for the extension that allows VSCode's JavaScript Debugger to attach the devtools to the currently active debug target.

It also leverages the new CDPProxy that allows our extension to connect to the client using the same websocket as the JsDebugger, giving us the benefits of:
- Appearing as a single debugger to the debug client page
- Allowing us to attach to debugging instances of Edge that are connected via annonymous pipes from VSCode debugger, instead of only remote-debugging-port launched Edge instances

![image](https://user-images.githubusercontent.com/42152559/118722572-26b73e80-b7e1-11eb-9827-c69a3e1fb909.png)

![image](https://user-images.githubusercontent.com/42152559/118722623-3767b480-b7e1-11eb-859d-1bde0d528d38.png)

![image](https://user-images.githubusercontent.com/42152559/118722662-42224980-b7e1-11eb-9d99-3563ba282f63.png)


Testing instructions:
To test the new features, Follow the instructions to install the Nightly flight of the JavaScript Debugger into VSCode Insiders from: https://github.com/microsoft/vscode-js-debug#nightly-extension
Then, debug a build from this branch.
In the resulting Extension host environment:
1. Attach the JsDebugger to a target page using an Edge launch.json:
        {
            "name": "Launch Edge",
            "request": "launch",
            "type": "pwa-msedge",
            "url": "http://localhost:8080",
            "webRoot": "${workspaceFolder}"
        },

2. Click the new "inspect icon" in the Vscode debugger bar
2a. An alternative is to use the 'Debug: Open Browser Devtools' command prompt