### PR TITLE
[Telemetry]: Remove unnecessary telemetry

### DIFF
--- a/src/cdpTargetsProvider.ts
+++ b/src/cdpTargetsProvider.ts
@@ -39,11 +39,6 @@ export class CDPTargetsProvider implements vscode.TreeDataProvider<CDPTarget> {
             const responseArray = await getListOfTargets(hostname, port, useHttps);
             if (Array.isArray(responseArray)) {
                 await this.clearFaviconResourceDirectory();
-                this.telemetryReporter.sendTelemetryEvent(
-                    'view/list',
-                    undefined,
-                    { targetCount: responseArray.length },
-                );
                 if (responseArray.length > 0) {
                     const responseIconPromiseArray: Array<Promise<IRemoteTargetJson>> = [];
                     responseArray.forEach((target: IRemoteTargetJson) => {
@@ -90,7 +85,6 @@ export class CDPTargetsProvider implements vscode.TreeDataProvider<CDPTarget> {
     }
 
     refresh(): void {
-        this.telemetryReporter.sendTelemetryEvent('view/refresh');
         this.changeDataEvent.fire(null);
         void this.clearFaviconResourceDirectory();
         LaunchConfigManager.instance.updateLaunchConfig();

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -169,8 +169,6 @@ export async function attach(
     }
 
     const telemetryProps = { viaConfig: `${!!config}`, withTargetUrl: `${!!attachUrl}` };
-    telemetryReporter.sendTelemetryEvent('command/attach', telemetryProps);
-
     const { hostname, port, useHttps, timeout } = getRemoteEndpointSettings(config);
 
     // Get the attach target and keep trying until reaching timeout
@@ -189,12 +187,6 @@ export async function attach(
         }
 
         if (Array.isArray(responseArray)) {
-            telemetryReporter.sendTelemetryEvent(
-                'command/attach/list',
-                telemetryProps,
-                { targetCount: responseArray.length },
-            );
-
             // Try to match the given target with the list of targets we received from the endpoint
             let targetWebsocketUrl = '';
             if (attachUrl) {
@@ -217,7 +209,6 @@ export async function attach(
             if (targetWebsocketUrl) {
                 // Auto connect to found target
                 useRetry = false;
-                telemetryReporter.sendTelemetryEvent('command/attach/devtools', telemetryProps);
                 const runtimeConfig = getRuntimeConfig(config);
                 DevToolsPanel.createOrShow(context, telemetryReporter, targetWebsocketUrl, runtimeConfig);
             } else if (useRetry) {
@@ -241,7 +232,6 @@ export async function attach(
                 // Show the target list and allow the user to select one
                 const selection = await vscode.window.showQuickPick(items);
                 if (selection && selection.detail) {
-                    telemetryReporter.sendTelemetryEvent('command/attach/devtools', telemetryProps);
                     const runtimeConfig = getRuntimeConfig(config);
                     DevToolsPanel.createOrShow(context, telemetryReporter, selection.detail, runtimeConfig);
                 }

--- a/test/cdpTargetsProvider.test.ts
+++ b/test/cdpTargetsProvider.test.ts
@@ -50,7 +50,6 @@ describe("CDPTargetsProvider", () => {
         const provider = new ctp.CDPTargetsProvider(mockContext, mockReporter);
         provider.refresh();
         expect(mockFire).toHaveBeenCalled();
-        expect(mockReporter.sendTelemetryEvent).toHaveBeenCalled();
     });
 
     it("calls getChildren on the element", async () => {


### PR DESCRIPTION
This PR removes these telemetry events

- `view/list`
    - This fires when `getChildren` is called
    - `getChildren` is called in many different ways, so this isn't super useful.
- `view/refresh`
    - This is called when `refresh()` is called which calls `getChildren`.
    - Not entirely useful for the same reason as `view/list` 
- `command/attach`
    - This only triggers when the browser instance is first attached to.  We already have `command/launch` to track every new browser target.
- `command/attach/list`
    - Same as `command/attach`
- `command/attach/devtools`
    - Same as `command/attach`