### PR TITLE
[Telemetry]: Implement extra launch parameters and websocket session length

### DIFF
--- a/package.json
+++ b/package.json
@@ -538,7 +538,7 @@
         "viewsWelcome": [
             {
                 "view": "vscode-edge-devtools-view.targets",
-                "contents": "Launch an instance of Microsoft Edge to begin inspecting and modifying webpages.\n[Launch Instance](command:vscode-edge-devtools-view.launch)",
+                "contents": "Launch an instance of Microsoft Edge to begin inspecting and modifying webpages.\n[Launch Instance](command:vscode-edge-devtools-view.launch?[true])",
                 "when": "launchJsonStatus != Supported"
             },
             {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -290,7 +290,11 @@ export async function launch(context: vscode.ExtensionContext, launchUrl?: strin
         telemetryReporter = createTelemetryReporter(context);
     }
 
-    const telemetryProps = { viaConfig: `${!!config}` };
+    const settings = vscode.workspace.getConfiguration(SETTINGS_STORE_NAME);
+    const browserType: string = settings.get('browserFlavor') || 'Default';
+    const isHeadless: string = settings.get('headless') || 'false';
+
+    const telemetryProps = { viaConfig: `${!!config}`, browserType, isHeadless};
     telemetryReporter.sendTelemetryEvent('command/launch', telemetryProps);
 
     const { hostname, port, defaultUrl, userDataDir } = getRemoteEndpointSettings(config);

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -72,8 +72,12 @@ export function activate(context: vscode.ExtensionContext): void {
         cdpTargetsProvider));
     context.subscriptions.push(vscode.commands.registerCommand(
         `${SETTINGS_VIEW_NAME}.launch`,
-        async () => {
-            telemetryReporter.sendTelemetryEvent('user/buttonPress', { 'VSCode.buttonCode': buttonCode.launchBrowserInstance });
+        async (fromEmptyTargetView?: boolean) => {
+            if (fromEmptyTargetView) {
+                telemetryReporter.sendTelemetryEvent('user/buttonPress', { 'VSCode.buttonCode': buttonCode.emptyTargetListLaunchBrowserInstance });
+            } else {
+                telemetryReporter.sendTelemetryEvent('user/buttonPress', { 'VSCode.buttonCode': buttonCode.launchBrowserInstance });
+            }
             await launch(context);
             cdpTargetsProvider.refresh();
         }));

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -124,6 +124,7 @@ export const buttonCode: Record<string, string> = {
     openSettings: '7',
     viewChangelog: '8',
     closeTarget: '9',
+    emptyTargetListLaunchBrowserInstance: '10',
 };
 
 /**


### PR DESCRIPTION
This PR adds extra parameters to existing telemetry events.  Here are the changes:

- `command/launch`
    - added extra parameters `browserType` and `isHeadless`
    - `browserType` can be `Default`, `Stable`, `Beta`, `Dev` or `Canary`
    - `isHeadless` can be `true` or `false`
    - Example: 
        - `command/launch: {"viaConfig":"false","browserType":"Default","isHeadless":"false"}`
- `websocket/dispose`
    - added extra parameter `sessionTime` which tracks length the DevTools extension was connected to that target
    - Example:
        - `websocket/dispose: undefined, {"sessionTime":489728.6491000056}`
- `user/buttonPress`
    - We now differentiate whether the `.launch` command is triggered through the plus button or the launch instance blue button. 



