### PR TITLE
[Telemetry]: Add telemetry for file extension types

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -27,6 +27,7 @@ import {
     SETTINGS_VIEW_NAME,
     getActiveDebugSessionId,
     getJsDebugCDPProxyWebsocketUrl,
+    reportFileExtensionTypes,
     reportUrlType,
 } from './utils';
 import { LaunchConfigManager } from './launchConfigManager';
@@ -160,6 +161,7 @@ export function activate(context: vscode.ExtensionContext): void {
             void vscode.env.openExternal(vscode.Uri.parse('https://github.com/microsoft/vscode-edge-devtools/blob/master/README.md'));
         }));
     void vscode.commands.executeCommand('setContext', 'titleCommandsRegistered', true);
+    void reportFileExtensionTypes(telemetryReporter);
 }
 
 export async function attach(

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -631,18 +631,21 @@ export function reportUrlType(url: string, telemetryReporter: Readonly<Telemetry
 
 export async function reportFileExtensionTypes(telemetryReporter: Readonly<TelemetryReporter>): Promise<void> {
     const files = await vscode.workspace.findFiles('**/*.*', '**/node_modules/**');
-    const extensionSet: Set<string> = new Set();
+    const extensionMap: Map<string, number> = new Map<string, number>();
     for (const file of files) {
         const extension: string | undefined = file.path.split('.').pop();
         if (extension) {
-            extensionSet.add(extension);
+            const currentValue = extensionMap.get(extension);
+            if (currentValue) {
+                extensionMap.set(extension, currentValue + 1);
+            } else {
+                extensionMap.set(extension, 1);
+            }
         }
     }
-    let fileTypes = '';
-    for (const extension of extensionSet.keys()) {
-        fileTypes += extension + ';';
-    }
-    telemetryReporter.sendTelemetryEvent('workspace/metadata', {fileTypes});
+    extensionMap.set('total', files.length);
+    const fileTypes = Object.fromEntries(extensionMap);
+    telemetryReporter.sendTelemetryEvent('workspace/metadata', undefined, fileTypes);
 }
 
 (function initialize() {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -644,7 +644,10 @@ export async function reportFileExtensionTypes(telemetryReporter: Readonly<Telem
         }
     }
     extensionMap.set('total', files.length);
-    const fileTypes = Object.fromEntries(extensionMap);
+
+    // Creates Object from map
+    const fileTypes: {[key: string]: number} = {};
+    Object.assign(fileTypes, ...[...extensionMap.entries()].map(([k, v]) => ({[k]: v})));
     telemetryReporter.sendTelemetryEvent('workspace/metadata', undefined, fileTypes);
 }
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -629,6 +629,22 @@ export function reportUrlType(url: string, telemetryReporter: Readonly<Telemetry
     telemetryReporter.sendTelemetryEvent('user/browserNavigation', { 'urlType': urlType });
 }
 
+export async function reportFileExtensionTypes(telemetryReporter: Readonly<TelemetryReporter>): Promise<void> {
+    const files = await vscode.workspace.findFiles('**/*.*', '**/node_modules/**');
+    const extensionSet: Set<string> = new Set();
+    for (const file of files) {
+        const extension: string | undefined = file.path.split('.').pop();
+        if (extension) {
+            extensionSet.add(extension);
+        }
+    }
+    let fileTypes = '';
+    for (const extension of extensionSet.keys()) {
+        fileTypes += extension + ';';
+    }
+    telemetryReporter.sendTelemetryEvent('workspace/metadata', {fileTypes});
+}
+
 (function initialize() {
     // insertion order matters.
     msEdgeBrowserMapping.set('Stable', {

--- a/test/extension.test.ts
+++ b/test/extension.test.ts
@@ -43,6 +43,7 @@ describe("extension", () => {
                 removeTrailingSlash: jest.fn(removeTrailingSlash),
                 getJsDebugCDPProxyWebsocketUrl: jest.fn(),
                 getActiveDebugSessionId: jest.fn(),
+                reportFileExtensionTypes: jest.fn(),
             };
             jest.doMock("../src/utils", () => mockUtils);
             jest.doMock("../src/launchDebugProvider");
@@ -402,6 +403,7 @@ describe("extension", () => {
                 getJsDebugCDPProxyWebsocketUrl: jest.fn(),
                 buttonCode: { launch: '' },
                 reportUrlType: jest.fn(),
+                reportFileExtensionTypes: jest.fn(),
             };
 
             mockPanel = {

--- a/test/helpers/helpers.ts
+++ b/test/helpers/helpers.ts
@@ -62,6 +62,14 @@ export function createFakeVSCode() {
             showTextDocument: jest.fn(),
         },
         workspace: {
+            findFiles: jest.fn(() => {
+                return [
+                    {path: '/c:/test/main.js'},
+                    {path: '/c:/test/styles.css'},
+                    {path: '/c:/test/react/test.jsx'},
+                    {path: '/c:/.vscode/launch.json'}
+                ];
+            }),
             getConfiguration: jest.fn(() => {
                 return { get: (name: string) => {
                     switch(name) {

--- a/test/utils.test.ts
+++ b/test/utils.test.ts
@@ -980,7 +980,7 @@ describe("utils", () => {
         it('correctly lists extension types in the workspace', async () => {
             const reporter = createFakeTelemetryReporter();
             await utils.reportFileExtensionTypes(reporter);
-            expect(reporter.sendTelemetryEvent).toBeCalledWith('workspace/metadata', { 'fileTypes': 'js;css;jsx;json;' });
+            expect(reporter.sendTelemetryEvent).toBeCalledWith('workspace/metadata', undefined, {"css": 1, "js": 1, "json": 1, "jsx": 1, "total": 4});
         });
     });
 });

--- a/test/utils.test.ts
+++ b/test/utils.test.ts
@@ -975,4 +975,12 @@ describe("utils", () => {
             }
         });
     });
+
+    describe('reportFileExtensionTypes', () => {
+        it('correctly lists extension types in the workspace', async () => {
+            const reporter = createFakeTelemetryReporter();
+            await utils.reportFileExtensionTypes(reporter);
+            expect(reporter.sendTelemetryEvent).toBeCalledWith('workspace/metadata', { 'fileTypes': 'js;css;jsx;json;' });
+        });
+    });
 });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,6 @@
 {
     "compilerOptions": {
+        "lib": ["es2019"],
         "module": "commonjs",
         "esModuleInterop": true,
         "target": "es2019",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,7 @@
     "compilerOptions": {
         "module": "commonjs",
         "esModuleInterop": true,
-        "target": "es2017",
+        "target": "es2019",
         "noImplicitAny": true,
         "moduleResolution": "node",
         "sourceMap": true,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,9 +1,8 @@
 {
     "compilerOptions": {
-        "lib": ["es2019"],
         "module": "commonjs",
         "esModuleInterop": true,
-        "target": "es2019",
+        "target": "es2017",
         "noImplicitAny": true,
         "moduleResolution": "node",
         "sourceMap": true,


### PR DESCRIPTION
This PR adds telemetry that sends the used file extension types in the user's currently active workspace.  The telemetry is sent upon the activation of the extension.

- `workspace/metadata`
    - example:
        - `workspace/metadata: undefined, {"css":1,"js":1,"html":1,"json":2,"total":5}`