### PR TITLE
[Telemetry]: Patching in DevTools telemetry events for screencast duration and toggle + change default toggle state based on headless settings

### DIFF
--- a/postBuildStep.ts
+++ b/postBuildStep.ts
@@ -35,8 +35,10 @@ import {
     applyContextMenuRevealOption,
     applyRemovePreferencePatch,
     applyScreencastAppPatch,
-    applyScreencastRepaintPatch,
     applyScreencastCursorPatch,
+    applyScreencastTelemetry,
+    applyScreencastHeadlessPatch,
+    applyScreencastRepaintPatch,
     applySetTabIconPatch,
     applyShowDrawerTabs,
     applyStylesRevealerPatch,
@@ -134,6 +136,8 @@ async function patchFilesForWebView(toolsOutDir: string) {
     ]);
     await patchFileForWebViewWrapper('screencast/screencast.js', toolsOutDir, [
         applyScreencastCursorPatch,
+        applyScreencastTelemetry,
+        applyScreencastHeadlessPatch,
         applyScreencastRepaintPatch,
     ]);
     await patchFileForWebViewWrapper('ui/ui.js', toolsOutDir, [

--- a/src/common/settingsProvider.ts
+++ b/src/common/settingsProvider.ts
@@ -26,6 +26,12 @@ export class SettingsProvider {
     return whatsNewEnabled;
   }
 
+  getHeadlessSettings(): boolean {
+    const settings = vscode.workspace.getConfiguration(SETTINGS_STORE_NAME);
+    const isHeadless: boolean = settings.get('headless') || false;
+    return isHeadless;
+  }
+
   static get instance(): SettingsProvider {
     if (!SettingsProvider.singletonInstance) {
       SettingsProvider.singletonInstance = new SettingsProvider();

--- a/src/devtoolsPanel.ts
+++ b/src/devtoolsPanel.ts
@@ -211,6 +211,7 @@ export class DevToolsPanel {
             enableNetwork: SettingsProvider.instance.isNetworkEnabled(),
             themeString: SettingsProvider.instance.getThemeSettings(),
             whatsNew: SettingsProvider.instance.getWhatsNewSettings(),
+            isHeadless: SettingsProvider.instance.getHeadlessSettings(),
             id });
     }
 

--- a/src/host/toolsHost.ts
+++ b/src/host/toolsHost.ts
@@ -161,6 +161,7 @@ export class ToolsHost {
             enableNetwork: vscodeObject.enableNetwork,
             theme,
             whatsNew: vscodeObject.whatsNew,
+            isHeadless: vscodeObject.isHeadless,
         });
     }
 

--- a/test/devtoolsPanel.test.ts
+++ b/test/devtoolsPanel.test.ts
@@ -484,7 +484,7 @@ describe("devtoolsPanel", () => {
 
             it("calls getVscodeSettings", async () => {
                 const expectedId = { id: 0 };
-                const expectedState = { enableNetwork: true, themeString: "System preference", whatsNew: true};
+                const expectedState = { enableNetwork: true, themeString: "System preference", whatsNew: true, isHeadless: false};
                 (context.workspaceState.get as jest.Mock).mockReturnValue(expectedState);
 
                 const dtp = await import("../src/devtoolsPanel");
@@ -498,6 +498,7 @@ describe("devtoolsPanel", () => {
                         themeString: expectedState.themeString,
                         enableNetwork: expectedState.enableNetwork,
                         whatsNew: expectedState.whatsNew,
+                        isHeadless: expectedState.isHeadless,
                         id: expectedId.id,
                     },
                 );

--- a/test/helpers/helpers.ts
+++ b/test/helpers/helpers.ts
@@ -71,6 +71,8 @@ export function createFakeVSCode() {
                             return "System preference";
                         case "whatsNew":
                             return true;
+                        case "isHeadless":
+                            return false;
                         default:
                             return undefined;
                     }

--- a/test/host/polyfills/simpleView.test.ts
+++ b/test/host/polyfills/simpleView.test.ts
@@ -295,10 +295,26 @@ describe("simpleView", () => {
         testPatch(filePath, patch, expectedStrings);
     });
 
-    it("applyScreencastCursorPatch correctly changes inspector.js text to remove touch cursor", async () => {
+    it("applyScreencastCursorPatch correctly changes screencast.js text to remove touch cursor", async () => {
         const filePath = "screencast/screencast.js";
         const patch = SimpleView.applyScreencastCursorPatch;
         const expectedStrings = ["this._canvasContainerElement.style.cursor = 'unset';"];
+
+        testPatch(filePath, patch, expectedStrings);
+    });
+
+    it("applyScreencastHeadlessPatch correctly replaces screencast.js text to toggle screencast based on headless settings", async () => {
+        const filePath = "screencast/screencast.js";
+        const patch = SimpleView.applyScreencastHeadlessPatch;
+        const expectedStrings = ["const isHeadless = Root.Runtime.vscodeSettings.isHeadless;"];
+
+        testPatch(filePath, patch, expectedStrings);
+    });
+
+    it("applyScreencastTelemetry correctly changes screencast.js text to implement screencast telemetry", async () => {
+        const filePath = "screencast/screencast.js";
+        const patch = SimpleView.applyScreencastTelemetry;
+        const expectedStrings = ["DevTools.ScreencastToggle", "DevTools.ScreencastDuration"];
 
         testPatch(filePath, patch, expectedStrings);
     });


### PR DESCRIPTION
Couple of telemetry / screencast related changes in this PR.

- `applyScreencastHeadlessPatch(...)`
    - This modifies ScreencastApp constructor to show/hide screencast based on whether the extension's headless mode is enabled or disabled.
    - Needed to pipe through the headless extension setting into the `vscodeObject` so we can access it in the DevTools code.
    - This also helps set up a `_startTime` property to properly record session duration for `DevTools.ScreencastDuration`
- `applyScreencastTelemetry(...)`
    - This patch injects two telemetry events that are fired upon toggling the screencast button
        - `DevTools.ScreencastToggle`
            - This fires on each button press and shows whether the view is shown / hidden
                - Show: `devtools/DevTools.ScreencastToggle: {"DevTools.ScreencastToggle.actionCode":"1"}`
                - Hide: `devtools/DevTools.ScreencastToggle: {"DevTools.ScreencastToggle.actionCode":"0"}`
        - `DevTools.ScreencastDuration`
            - This fires when the screencast is toggled off and shows the session time in ms
                - `devtools/DevTools.ScreencastDuration: undefined, {"DevTools.ScreencastDuration.duration":1001.1349999113008}` 