### PR TITLE
[Telemetry]: Adding extension settings related telemetry

### DIFF
--- a/package.json
+++ b/package.json
@@ -176,6 +176,8 @@
                     "type": "object",
                     "description": "A set of mappings to override the locations of source map files.",
                     "default": {
+                        "webpack://./*": "${webRoot}/*",
+                        "webpack://*": "${webRoot}/*",
                         "webpack:///./*": "${webRoot}/*",
                         "webpack:///src/*": "${webRoot}/*",
                         "webpack:///*": "*",

--- a/src/devtoolsPanel.ts
+++ b/src/devtoolsPanel.ts
@@ -342,7 +342,7 @@ export class DevToolsPanel {
                     style-src 'self' 'unsafe-inline' ${this.panel.webview.cspSource};
                     script-src 'self' 'unsafe-eval' ${this.panel.webview.cspSource};
                     frame-src 'self' ${this.panel.webview.cspSource};
-                    connect-src 'self' ${this.panel.webview.cspSource};
+                    connect-src 'self' data: ${this.panel.webview.cspSource};
                 ">
                 <meta name="referrer" content="no-referrer">
                 <link href="${stylesUri}" rel="stylesheet"/>

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -28,6 +28,8 @@ import {
     getActiveDebugSessionId,
     getJsDebugCDPProxyWebsocketUrl,
     reportFileExtensionTypes,
+    reportChangedExtensionSetting,
+    reportExtensionSettings,
     reportUrlType,
 } from './utils';
 import { LaunchConfigManager } from './launchConfigManager';
@@ -166,6 +168,8 @@ export function activate(context: vscode.ExtensionContext): void {
         }));
     void vscode.commands.executeCommand('setContext', 'titleCommandsRegistered', true);
     void reportFileExtensionTypes(telemetryReporter);
+    reportExtensionSettings(telemetryReporter);
+    vscode.workspace.onDidChangeConfiguration(event => reportChangedExtensionSetting(event, telemetryReporter));
 }
 
 export async function attach(

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -653,8 +653,6 @@ export function reportChangedExtensionSetting(event: vscode.ConfigurationChangeE
         const settingValue: boolean | string | {[key: string]: string} | undefined = currentSetting[1];
         if (event.affectsConfiguration(`${SETTINGS_STORE_NAME}.${settingName}`)) {
             const settings = vscode.workspace.getConfiguration(SETTINGS_STORE_NAME);
-            const test = Object.entries(settings);
-            test;
             if (settingName !== undefined) {
                 if (settingValue !== undefined) {
                     const telemetryObject: {[key: string]: string}  = {};

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -652,7 +652,6 @@ export function reportChangedExtensionSetting(event: vscode.ConfigurationChangeE
         const settingName: string = currentSetting[0];
         const settingValue: boolean | string | {[key: string]: string} | undefined = currentSetting[1];
         if (event.affectsConfiguration(`${SETTINGS_STORE_NAME}.${settingName}`)) {
-            const settings = vscode.workspace.getConfiguration(SETTINGS_STORE_NAME);
             if (settingName !== undefined) {
                 if (settingValue !== undefined) {
                     const telemetryObject: {[key: string]: string}  = {};

--- a/test/extension.test.ts
+++ b/test/extension.test.ts
@@ -44,6 +44,8 @@ describe("extension", () => {
                 getJsDebugCDPProxyWebsocketUrl: jest.fn(),
                 getActiveDebugSessionId: jest.fn(),
                 reportFileExtensionTypes: jest.fn(),
+                reportChangedExtensionSetting: jest.fn(),
+                reportExtensionSettings: jest.fn(),
             };
             jest.doMock("../src/utils", () => mockUtils);
             jest.doMock("../src/launchDebugProvider");
@@ -402,6 +404,8 @@ describe("extension", () => {
                 removeTrailingSlash: jest.fn(removeTrailingSlash),
                 getJsDebugCDPProxyWebsocketUrl: jest.fn(),
                 buttonCode: { launch: '' },
+                reportChangedExtensionSetting: jest.fn(),
+                reportExtensionSettings: jest.fn(),
                 reportUrlType: jest.fn(),
                 reportFileExtensionTypes: jest.fn(),
             };

--- a/test/helpers/helpers.ts
+++ b/test/helpers/helpers.ts
@@ -71,20 +71,36 @@ export function createFakeVSCode() {
                 ];
             }),
             getConfiguration: jest.fn(() => {
-                return { get: (name: string) => {
-                    switch(name) {
-                        case "enableNetwork":
-                            return true;
-                        case "themeString":
-                            return "System preference";
-                        case "whatsNew":
-                            return true;
-                        case "isHeadless":
-                            return false;
-                        default:
-                            return undefined;
+                return {
+                    get: (name: string) => {
+                        switch(name) {
+                            case "enableNetwork":
+                                return true;
+                            case "themes":
+                                return "System preference";
+                            case "whatsNew":
+                                return true;
+                            case "isHeadless":
+                                return false;
+                            default:
+                                return undefined;
+                        }
+                    },
+                    inspect: (name: string) => {
+                        switch(name) {
+                            case "enableNetwork":
+                                return {defaultValue: true};
+                            case "themes":
+                                return {defaultValue: "Light"};
+                            case "whatsNew":
+                                return {defaultValue: false};
+                            case "isHeadless":
+                                return {defaultValue: false};
+                            default:
+                                return {defaultValue: undefined};
+                        }
                     }
-                } };
+                };
             }),
             onDidChangeConfiguration: jest.fn(),
             openTextDocument: jest.fn().mockResolvedValue(null),
@@ -149,6 +165,13 @@ export function createFakeGet(getResponse: () => string, getStatusCode: () => nu
     };
 
     return { get: fakeGet, on: getOnMock };
+}
+
+/**
+ * Creates a fake vscode.ConfigurationChangeEvent
+ */
+export function createFakeConfigurationChangeEvent() {
+
 }
 
 /**

--- a/test/helpers/helpers.ts
+++ b/test/helpers/helpers.ts
@@ -168,13 +168,6 @@ export function createFakeGet(getResponse: () => string, getStatusCode: () => nu
 }
 
 /**
- * Creates a fake vscode.ConfigurationChangeEvent
- */
-export function createFakeConfigurationChangeEvent() {
-
-}
-
-/**
  * Get a callable function from the first invocation of a mock function
  * @param mock The mock function that got passed the callback as an argument
  * @param callbackArgIndex The index of the argument that contains the callback

--- a/test/utils.test.ts
+++ b/test/utils.test.ts
@@ -1016,8 +1016,8 @@ describe("utils", () => {
                                 return {defaultValue: undefined};
                         }
                     },
-                    filler: 'hello',
-                    filler1: 'hello',
+                    fillerPropertyOne: 'Need to add filler values since the extension related telemetry functions removes the first 4 entries to create an array of extension settings',
+                    fillerPropertyTwo: 'The first 4 entries for a workspaceConfiguration object are class related functions, the rest are all extension related settings.',
                     themes: 'System preference',
                     whatsNew: 'true',
                     enableNetwork: 'false',

--- a/test/utils.test.ts
+++ b/test/utils.test.ts
@@ -990,32 +990,10 @@ describe("utils", () => {
 
         beforeEach(() => {
             const vscodeMock = jest.requireMock("vscode");
+            const originalWorkspaceMockConfig = vscodeMock.workspace.getConfiguration();
             vscodeMock.workspace.getConfiguration.mockImplementation(() => {
                 return {
-                    get: (name: string) => {
-                        switch(name) {
-                            case "enableNetwork":
-                                return true;
-                            case "themes":
-                                return "System preference";
-                            case "whatsNew":
-                                return true;
-                            default:
-                                return undefined;
-                        }
-                    },
-                    inspect: (name: string) => {
-                        switch(name) {
-                            case "enableNetwork":
-                                return {defaultValue: true};
-                            case "themes":
-                                return {defaultValue: "Light"};
-                            case "whatsNew":
-                                return {defaultValue: false};
-                            default:
-                                return {defaultValue: undefined};
-                        }
-                    },
+                    ...originalWorkspaceMockConfig,
                     fillerPropertyOne: 'Need to add filler values since the extension related telemetry functions removes the first 4 entries to create an array of extension settings',
                     fillerPropertyTwo: 'The first 4 entries for a workspaceConfiguration object are class related functions, the rest are all extension related settings.',
                     themes: 'System preference',


### PR DESCRIPTION
This PR implements two telemetry events related to the extension settings:

- `user/settingsChangedAtLaunch`
    - This event fires upon extension activation and displays all extension settings that differ from the default value
    - Example: `user/settingsChangedAtLaunch: {"enableNetwork":"false","themes":"Light"}, undefined`
- `user/settingsChanged`
    - This event fires whenever a user changes a setting related to our extension
    - Example: `user/settingsChanged: {"enableNetwork":"false"}, undefined`

Going to try something new and do code explanation via comments. Marking them all as resolved so they are collapsible, but feel free to reply to and/or activate them if you have a question regarding that section.