### PR TITLE
Patch Styles panel to inform users to resume if debugger paused

### DIFF
--- a/postBuildStep.ts
+++ b/postBuildStep.ts
@@ -42,6 +42,7 @@ import {
     applyStylesRevealerPatch,
     applyStylesToggleFocusPatch,
     applyThemePatch,
+    applyNoMatchingStylesPatch,
 } from './src/host/polyfills/simpleView';
 import { applySetupTextSelectionPatch } from './src/host/polyfills/textSelection';
 import { applyThirdPartyI18nLocalesPatch } from './src/host/polyfills/thirdPartyI18n';
@@ -125,6 +126,7 @@ async function patchFilesForWebView(toolsOutDir: string) {
         applyPaddingInlineCssPatch,
     ]);
     await patchFileForWebViewWrapper('elements/elements.js', toolsOutDir, [
+        applyNoMatchingStylesPatch,
         applySetupTextSelectionPatch,
         applyStylesRevealerPatch,
         applyStylesToggleFocusPatch,

--- a/src/host/polyfills/simpleView.ts
+++ b/src/host/polyfills/simpleView.ts
@@ -114,6 +114,15 @@ export function applyStylesToggleFocusPatch(content: string): string | null {
     return replaceInSourceCode(content, pattern, replacementText);
 }
 
+export function applyNoMatchingStylesPatch(content: string): string | null {
+    // Patch to inform user to refresh/resume target to get CSS information when attaching to a paused target.
+    const pattern = /this\._noMatchesElement\.textContent\s*=\s*(ls\s*`No matching selector or style`);/g;
+    const replacementText = `
+       this._noMatchesElement.innerHTML = ls \`No matching selector or style.<br />Styles may not be available if target was paused when opening Edge DevTools.<br />Please resume or refresh the target.\`;
+    `;
+    return replaceInSourceCode(content, pattern, replacementText);
+}
+
 export function applyQuickOpenPatch(content: string): string | null {
     // This patch removes the ability to use the quick open menu (CTRL + P)
     const pattern = /handleAction\(context,\s*actionId\)\s*{\s*switch\s*\(actionId\)/;

--- a/src/host/polyfills/simpleView.ts
+++ b/src/host/polyfills/simpleView.ts
@@ -118,7 +118,10 @@ export function applyNoMatchingStylesPatch(content: string): string | null {
     // Patch to inform user to refresh/resume target to get CSS information when attaching to a paused target.
     const pattern = /this\._noMatchesElement\.textContent\s*=\s*(ls\s*`No matching selector or style`);/g;
     const replacementText = `
-       this._noMatchesElement.innerHTML = ls \`No matching selector or style.<br />Styles may not be available if target was paused when opening Edge DevTools.<br />Please resume or refresh the target.\`;
+       const noMatchSelector = ls \`No matching selector or style.\`;
+       const pausedExplanation = ls \`Styles may not be available if target was paused when opening Edge DevTools.\`;
+       const resumePrompt = ls \`Please resume or refresh the target.\`;
+       this._noMatchesElement.innerHTML = \`\${noMatchSelector}<br />\${pausedExplanation}<br />\${resumePrompt}\`;
     `;
     return replaceInSourceCode(content, pattern, replacementText);
 }

--- a/test/host/polyfills/simpleView.test.ts
+++ b/test/host/polyfills/simpleView.test.ts
@@ -287,6 +287,14 @@ describe("simpleView", () => {
         testPatch(filePath, patch, expectedStrings);
     });
 
+    it("applyNoMatchingStylesPatch correctly changes elements.js to set No Matching Styles message", async () => {
+        const filePath = "elements/elements.js";
+        const patch = SimpleView.applyNoMatchingStylesPatch;
+        const expectedStrings = ["Styles may not be available if target was paused when opening Edge DevTools."];
+
+        testPatch(filePath, patch, expectedStrings);
+    });
+
     it("applyRerouteConsoleMessagePatch correctly changes root.js to set extensionSettings map", async () => {
         const filePath = "sdk/sdk.js";
         const patch = SimpleView.applyRerouteConsoleMessagePatch;

--- a/test/host/polyfills/simpleView.test.ts
+++ b/test/host/polyfills/simpleView.test.ts
@@ -290,7 +290,12 @@ describe("simpleView", () => {
     it("applyNoMatchingStylesPatch correctly changes elements.js to set No Matching Styles message", async () => {
         const filePath = "elements/elements.js";
         const patch = SimpleView.applyNoMatchingStylesPatch;
-        const expectedStrings = ["Styles may not be available if target was paused when opening Edge DevTools."];
+        const expectedStrings = [
+            `const noMatchSelector = ls \`No matching selector or style.\`;`,
+            `const pausedExplanation = ls \`Styles may not be available if target was paused when opening Edge DevTools.\`;`,
+            `const resumePrompt = ls \`Please resume or refresh the target.\`;`,
+            `this._noMatchesElement.innerHTML = \`\${noMatchSelector}<br />\${pausedExplanation}<br />\${resumePrompt}\`;`,
+        ];
 
         testPatch(filePath, patch, expectedStrings);
     });


### PR DESCRIPTION
This PR patches the styles pane to inform users that they may need to resume or refresh the target to get styles information. The CSS domain cannot be enabled when the debugger is paused, which leads to a blank styles pane. This updates the default message to inform users what to do. This does not occur for standalone/inbox devtools as the css domain is always enabled during initialization, before any breakpoints can be hit. However, this can be hit fairly easily using the "inspect button" when VSCode's JS Debugger is currently attached to a target that is paused.

Before:
![image](https://user-images.githubusercontent.com/42152559/121251764-15030d00-c85c-11eb-8119-4d6f36c42d6e.png)

After:
![image](https://user-images.githubusercontent.com/42152559/121251700-03ba0080-c85c-11eb-94f8-07b82be031ae.png)

Addresses #407