### PR TITLE
Remove console output in favor of JSDebug complete CDP Console

### DIFF
--- a/postBuildStep.ts
+++ b/postBuildStep.ts
@@ -31,7 +31,6 @@ import {
     applyPersistDrawerTabs,
     applyQueryParamsObjectPatch,
     applyRemoveBreakOnContextMenuItem,
-    applyRerouteConsoleMessagePatch,
     applyContextMenuRevealOption,
     applyRemovePreferencePatch,
     applyScreencastAppPatch,
@@ -178,9 +177,6 @@ async function patchFilesForWebView(toolsOutDir: string) {
         applyAnnouncementNamePatch,
         applyGithubLinksPatch,
         applyReleaseNotePatch,
-    ]);
-    await patchFileForWebViewWrapper('sdk/sdk.js', toolsOutDir, [
-        applyRerouteConsoleMessagePatch,
     ]);
     await patchFileForWebViewWrapper('i18n/i18n.js', toolsOutDir, [
         applyThirdPartyI18nLocalesPatch,

--- a/src/common/webviewEvents.ts
+++ b/src/common/webviewEvents.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 export type WebviewEvent = 'getState' | 'getUrl' | 'openInEditor' | 'ready' | 'setState' | 'telemetry' | 'websocket'
-| 'getVscodeSettings' | 'copyText' | 'focusEditor' | 'focusEditorGroup' | 'openUrl' | 'consoleOutput';
+| 'getVscodeSettings' | 'copyText' | 'focusEditor' | 'focusEditorGroup' | 'openUrl';
 export const webviewEventNames: WebviewEvent[] = [
     'getState',
     'getUrl',
@@ -16,7 +16,6 @@ export const webviewEventNames: WebviewEvent[] = [
     'focusEditor',
     'focusEditorGroup',
     'openUrl',
-    'consoleOutput',
 ];
 
 export type WebSocketEvent = 'open' | 'close' | 'error' | 'message';

--- a/src/devtoolsPanel.ts
+++ b/src/devtoolsPanel.ts
@@ -54,9 +54,9 @@ export class DevToolsPanel {
         this.config = config;
         this.timeStart = null;
         this.consoleOutput = vscode.window.createOutputChannel('DevTools Console');
-        this.consoleOutput.appendLine('// This Output window displays the DevTools extension\'s console output in text format.');
-        this.consoleOutput.appendLine('// Note that this feature is only unidirectional and cannot communicate back to the DevTools.');
-        this.consoleOutput.appendLine('');
+        this.consoleOutput.appendLine('// Microsoft Edge Devtools Console output is Deprecated and will be removed soon.');
+        this.consoleOutput.appendLine('// For console output from your webpage, please use VSCode\'s Built in JavaScript Debugger and the "Debug Console".');
+
 
         // Hook up the socket events
         if (this.config.isJsDebugProxiedCDPConnection) {
@@ -77,7 +77,6 @@ export class DevToolsPanel {
         this.panelSocket.on('copyText', msg => this.onSocketCopyText(msg));
         this.panelSocket.on('focusEditor', msg => this.onSocketFocusEditor(msg));
         this.panelSocket.on('focusEditorGroup', msg => this.onSocketFocusEditorGroup(msg));
-        this.panelSocket.on('consoleOutput', msg => this.onSocketConsoleOutput(msg));
 
         // Handle closing
         this.panel.onDidDispose(() => {
@@ -165,11 +164,6 @@ export class DevToolsPanel {
         } else {
             void vscode.commands.executeCommand('workbench.action.focusPreviousGroup');
         }
-    }
-
-    private onSocketConsoleOutput(message: string) {
-        const { consoleMessage } = JSON.parse(message) as { consoleMessage: string };
-        this.consoleOutput.appendLine(consoleMessage);
     }
 
     private onSocketTelemetry(message: string) {

--- a/src/host/polyfills/simpleView.ts
+++ b/src/host/polyfills/simpleView.ts
@@ -443,12 +443,6 @@ export function applyRemovePreferencePatch(content: string): string | null {
     return replaceInSourceCode(content, pattern, replacementText);
 }
 
-export function applyRerouteConsoleMessagePatch(content: string): string | null {
-    const pattern = /this\.dispatchEventToListeners\(Events\$h\.MessageAdded,\s*msg\);/g;
-    const replacementText = `sendToVscodeOutput(msg.level + ': ' + msg.messageText); ${sendToVscodeOutput.toString()}`;
-    return replaceInSourceCode(content, pattern, replacementText, KeepMatchedText.InFront);
-}
-
 export function applyScreencastCursorPatch(content: string): string | null {
     // This patch removes the touch cursor from the screencast view
     const pattern = /\('div',\s*'screencast-canvas-container'\)\);/g;

--- a/src/host/toolsHost.ts
+++ b/src/host/toolsHost.ts
@@ -92,10 +92,6 @@ export class ToolsHost {
         encodeMessageForChannel(msg => vscode.postMessage(msg, '*'), 'getVscodeSettings', {id});
     }
 
-    sendToVscodeOutput(consoleMessage: string): void {
-        encodeMessageForChannel(msg => vscode.postMessage(msg, '*'), 'consoleOutput', {consoleMessage});
-    }
-
     copyText(clipboardData: string): void {
         encodeMessageForChannel(msg => vscode.postMessage(msg, '*'), 'copyText', {clipboardData});
     }

--- a/test/host/polyfills/simpleView.test.ts
+++ b/test/host/polyfills/simpleView.test.ts
@@ -300,14 +300,6 @@ describe("simpleView", () => {
         testPatch(filePath, patch, expectedStrings);
     });
 
-    it("applyRerouteConsoleMessagePatch correctly changes root.js to set extensionSettings map", async () => {
-        const filePath = "sdk/sdk.js";
-        const patch = SimpleView.applyRerouteConsoleMessagePatch;
-        const expectedStrings = ["sendToVscodeOutput"];
-
-        testPatch(filePath, patch, expectedStrings);
-    });
-
     it("applyScreencastCursorPatch correctly changes screencast.js text to remove touch cursor", async () => {
         const filePath = "screencast/screencast.js";
         const patch = SimpleView.applyScreencastCursorPatch;


### PR DESCRIPTION
This PR removes our console polyfills and replaces our current Devtools Console output with a single message that informs users to use JSDebug instead. Since JSDebug is a complete console experience already built into VSCode, it does not make sense for us to offer a duplicated and subpar one-way console output

Before:
![image](https://user-images.githubusercontent.com/42152559/121384363-0caede80-c8fd-11eb-90c2-f09299f0fa2f.png)


After:
![image](https://user-images.githubusercontent.com/42152559/121383543-6367e880-c8fc-11eb-9ccd-85602c7631b0.png)


JSDebug Console:
![image](https://user-images.githubusercontent.com/42152559/121383641-737fc800-c8fc-11eb-86ce-79f4aa098e9b.png)

Addresses #403 