### PR TITLE
[Feature]: Added ability to switch targets with DevTools open

### DIFF
--- a/src/devtoolsPanel.ts
+++ b/src/devtoolsPanel.ts
@@ -363,9 +363,12 @@ export class DevToolsPanel {
         config: IRuntimeConfig): void {
         const column = vscode.ViewColumn.Beside;
 
-        if (DevToolsPanel.instance) {
-            DevToolsPanel.instance.panel.reveal(column);
+        if (DevToolsPanel.instance && DevToolsPanel.instance.targetUrl === targetUrl) {
+                DevToolsPanel.instance.panel.reveal(column);
         } else {
+            if (DevToolsPanel.instance) {
+                DevToolsPanel.instance.dispose();
+            }
             const panel = vscode.window.createWebviewPanel(SETTINGS_STORE_NAME, SETTINGS_WEBVIEW_NAME, column, {
                 enableCommandUris: true,
                 enableScripts: true,

--- a/test/devtoolsPanel.test.ts
+++ b/test/devtoolsPanel.test.ts
@@ -103,8 +103,8 @@ describe("devtoolsPanel", () => {
             const dtp = await import("../src/devtoolsPanel");
             const mockVsCode = jest.requireMock("vscode");
             
-            dtp.DevToolsPanel.createOrShow(context, mockTelemetry, "www.google.com", mockRuntimeConfig);
-            dtp.DevToolsPanel.createOrShow(context, mockTelemetry, "www.microsoft.com", mockRuntimeConfig);
+            dtp.DevToolsPanel.createOrShow(context, mockTelemetry, "https://www.bing.com/", mockRuntimeConfig);
+            dtp.DevToolsPanel.createOrShow(context, mockTelemetry, "https://www.microsoft.com/", mockRuntimeConfig);
             expect(mockPanel.onDidDispose).toHaveBeenCalledTimes(2);
             expect(mockVsCode.window.createWebviewPanel).toHaveBeenCalledTimes(2);
         });

--- a/test/devtoolsPanel.test.ts
+++ b/test/devtoolsPanel.test.ts
@@ -99,6 +99,16 @@ describe("devtoolsPanel", () => {
             expect(mockPanel.onDidDispose).toHaveBeenCalled();
         });
 
+        it("switches targets with active session", async () => {
+            const dtp = await import("../src/devtoolsPanel");
+            const mockVsCode = jest.requireMock("vscode");
+            
+            dtp.DevToolsPanel.createOrShow(context, mockTelemetry, "www.google.com", mockRuntimeConfig);
+            dtp.DevToolsPanel.createOrShow(context, mockTelemetry, "www.microsoft.com", mockRuntimeConfig);
+            expect(mockPanel.onDidDispose).toHaveBeenCalledTimes(2);
+            expect(mockVsCode.window.createWebviewPanel).toHaveBeenCalledTimes(2);
+        });
+
         it("calls reveal on existing instance", async () => {
             const dtp = await import("../src/devtoolsPanel");
             dtp.DevToolsPanel.createOrShow(context, mockTelemetry, "", mockRuntimeConfig);


### PR DESCRIPTION
This PR adds the feature to switch to another instance of the DevTools if one is currently open.

GIF:
![devtools-switching](https://user-images.githubusercontent.com/14304598/121754304-1dac4b00-cac9-11eb-8970-c5f2510a58b9.gif)
