### PR TITLE
Transitioning What's New to Welcome tab

### DIFF
--- a/package.json
+++ b/package.json
@@ -205,9 +205,9 @@
                     "description": "Show service and shared workers in the target list.",
                     "default": false
                 },
-                "vscode-edge-devtools.whatsNew": {
+                "vscode-edge-devtools.welcome": {
                     "type": "boolean",
-                    "description": "Enable What's New panel in the drawer (requires relaunching extension)",
+                    "description": "Enable Welcome panel (requires relaunching extension)",
                     "default": true
                 },
                 "vscode-edge-devtools.headless": {

--- a/postBuildStep.ts
+++ b/postBuildStep.ts
@@ -4,7 +4,7 @@ import * as fse from 'fs-extra';
 import path from 'path';
 
 import { applyRuntimeImportScriptPathPrefixPatch } from './src/host/polyfills/runtime';
-import {applyAnnouncementNamePatch, applyGithubLinksPatch, applyReleaseNotePatch} from './src/host/polyfills/releaseNote';
+import {applyAnnouncementNamePatch, applyReleaseNotePatch, applySettingsCheckboxPatch, applyShowMorePatch} from './src/host/polyfills/releaseNote';
 import {
     applyAppendTabOverridePatch,
     applyAppendTabConditionsPatch,
@@ -179,9 +179,9 @@ async function patchFilesForWebView(toolsOutDir: string) {
     await patchFileForWebViewWrapper('themes/ThemesImpl.js', toolsOutDir, [
         applyThemePatch,
     ]);
-    await patchFileForWebViewWrapper('panels/help/ReleaseNoteView.js', toolsOutDir, [
+    await patchFileForWebViewWrapper('welcome/WelcomePanel.js', toolsOutDir, [
         applyAnnouncementNamePatch,
-        applyGithubLinksPatch,
+        applySettingsCheckboxPatch,
     ]);
     await patchFileForWebViewWrapper('panels/help/ReleaseNoteText.js', toolsOutDir, [
         applyReleaseNotePatch,
@@ -192,6 +192,9 @@ async function patchFilesForWebView(toolsOutDir: string) {
     ]);
     await patchFileForWebViewWrapper('third_party/i18n/i18n-bundle.js', toolsOutDir, [
         applyThirdPartyI18nLocalesPatch,
+    ]);
+    await patchFileForWebViewWrapper('welcome/WhatsNewList.js', toolsOutDir, [
+        applyShowMorePatch,
     ]);
 }
 

--- a/src/common/settingsProvider.ts
+++ b/src/common/settingsProvider.ts
@@ -20,10 +20,10 @@ export class SettingsProvider {
     return themeString;
   }
 
-  getWhatsNewSettings(): boolean {
+  getWelcomeSettings(): boolean {
     const settings = vscode.workspace.getConfiguration(SETTINGS_STORE_NAME);
-    const whatsNewEnabled: boolean = settings.get('whatsNew') || false;
-    return whatsNewEnabled;
+    const welcomeEnabled: boolean = settings.get('welcome') || false;
+    return welcomeEnabled;
   }
 
   getHeadlessSettings(): boolean {

--- a/src/devtoolsPanel.ts
+++ b/src/devtoolsPanel.ts
@@ -218,7 +218,7 @@ export class DevToolsPanel {
         encodeMessageForChannel(msg => this.panel.webview.postMessage(msg) as unknown as void, 'getVscodeSettings', {
             enableNetwork: SettingsProvider.instance.isNetworkEnabled(),
             themeString: SettingsProvider.instance.getThemeSettings(),
-            whatsNew: SettingsProvider.instance.getWhatsNewSettings(),
+            welcome: SettingsProvider.instance.getWelcomeSettings(),
             isHeadless: SettingsProvider.instance.getHeadlessSettings(),
             id });
     }

--- a/src/host/polyfills/releaseNote.ts
+++ b/src/host/polyfills/releaseNote.ts
@@ -4,20 +4,30 @@
 import {devtoolsHighlights, extensionHighlights} from './releaseNoteContent';
 
 export function applyReleaseNotePatch(content: string): string | null {
+    // This patch changes the content for the Welcome tab.
     const releaseNoteTextPattern = /const releaseNoteText\s*=\s*\[[\s\S]+export\s*{\s*releaseNoteText\s*};/;
     const replacementNotes = `
         export const releaseNoteText = [
             {
             version: 1,
-            header: ls\`Highlights from the latest version of Microsoft Edge Developer Tools for Visual Studio Code\`,
+            header: i18nLazyString('Highlights from the latest version of Microsoft Edge Developer Tools for Visual Studio Code'),
             highlightsEdge: ${extensionHighlights}
             highlights: ${devtoolsHighlights}
-            githubLink: 'https://github.com/microsoft/vscode-edge-devtools',
-            issuesLink: 'https://github.com/microsoft/vscode-edge-devtools/issues',
+            help: [
+                {
+                    title: i18nLazyString("Microsoft Edge DevTools for VS Code Documentation"),
+                    link: 'https://microsoft.github.io/vscode-edge-devtools/',
+                },
+                {
+                    title: i18nLazyString(UIStrings.devToolsForBeginners),
+                    link: 'https://docs.microsoft.com/microsoft-edge/devtools-guide-chromium/beginners/html',
+                },
+                { title: i18nLazyString("Visit our GitHub Page"), link: 'https://www.twitter.com/EdgeDevTools' },
+                { title: i18nLazyString(UIStrings.submitFeedback), link: 'https://github.com/microsoft/vscode-edge-devtools/issues' },
+                { title: i18nLazyString(UIStrings.followOnTwitter), link: 'https://www.twitter.com/EdgeDevTools' },
+            ],
             },
         ];
-
-        export { releaseNoteText };
     `;
 
     if (releaseNoteTextPattern.exec(content)) {
@@ -27,29 +37,29 @@ export function applyReleaseNotePatch(content: string): string | null {
 
 }
 
-export function applyGithubLinksPatch(content: string): string | null {
-    const linkPattern = /const learnMore\s*=[\s\S]+learnMore\);/g;
-    const linkReplacementText = `
-        const githubLink = XLink.XLink.create(releaseNote.githubLink, ls \`Visit our Github Page\`, 'release-note-link-learn-more');
-        actionContainer.appendChild(githubLink);
-        const issuesContainer = buttonContainer.createChild('div', 'release-note-action-container');
-        const issuesLink = XLink.XLink.create(releaseNote.issuesLink, ls \`Send us feedback\`, 'release-note-link-learn-more');
-        issuesContainer.appendChild(issuesLink);
-    `;
-    if (linkPattern.exec(content)) {
-        return content.replace(linkPattern, linkReplacementText);
+export function applyAnnouncementNamePatch(content: string): string | null {
+    // This patch changes the section headers for the Welcome tab.
+    const chromiumAnnouncement = /UIStrings\.chromiumHighlightsTitle/;
+    if (chromiumAnnouncement.exec(content)) {
+        return content.replace(chromiumAnnouncement, '\'New in Developer Tools\'');
     }
-        return null;
-
+    return null;
 }
 
-export function applyAnnouncementNamePatch(content: string): string | null {
-    const microsoftAnnouncement = /Announcements from the Microsoft Edge DevTools team/;
-    const chromiumAnnouncement = /Announcements from the Chromium project/;
-    if (microsoftAnnouncement.exec(content) && chromiumAnnouncement.exec(content)) {
-        content = content.replace(microsoftAnnouncement, 'New extension features');
-        return content.replace(chromiumAnnouncement, 'New in Developer Tools');
+export function applyShowMorePatch(content: string): string | null {
+    // This patch removes the empty href in the 'Show more' button so that VS Code doesn't try to open a blank web page.
+    const hrefText = /href=""/;
+    if (hrefText.exec(content)) {
+        return content.replace(hrefText, '');
     }
-        return null;
+    return null;
+}
 
+export function applySettingsCheckboxPatch(content: string): string | null {
+    // This patch removes the checkbox on the page to enable/disable the Welcome tool. We already handle that in the extension settings.
+    const hrefText = /titleContainer\.appendChild\(this\.startupCheckBox\);/;
+    if (hrefText.exec(content)) {
+        return content.replace(hrefText, '');
+    }
+    return null;
 }

--- a/src/host/polyfills/releaseNoteContent.ts
+++ b/src/host/polyfills/releaseNoteContent.ts
@@ -3,58 +3,50 @@
 
 export const extensionHighlights = `[
     {
-        title: ls\`New integration with VSCode's JavaScript Debugger\`,
+        title: i18nLazyString("Introducing the new 'Welcome' tab!"),
         subtitle:
-            ls\`JavaScript Debugger can now ask Microsoft Edge Devtools to attach to the active debug target.\`,
-        link: 'https://github.com/microsoft/vscode-edge-devtools/pull/391',
+            i18nLazyString("The 'Welcome' tab has replaced the What's New tab as part of the Edge DevTools version update."),
+        link: 'https://docs.microsoft.com/en-us/microsoft-edge/devtools-guide-chromium/whats-new/2021/01/devtools#whats-new-is-now-welcome',
     },
     {
-        title: ls\`Bug Fix for accessibility in the styles property pane\`,
+        title: i18nLazyString("Major Edge DevTools Version update"),
         subtitle:
-            ls\`Screen readers now announces a success message for when using the "Toggle Property and continue editing" option in the style property context menu.\`,
-        link: 'https://github.com/microsoft/vscode-edge-devtools/pull/390',
+            i18nLazyString("We have updated the DevTools version from 88 to 91.  Check out all the major new features in the section below!"),
+        link: 'https://github.com/microsoft/vscode-edge-devtools/pull/414',
     },
     {
-        title: ls\`New default start page when launching Edge DevTools\`,
+        title: i18nLazyString("New home for Microsoft Edge DevTools for VS Code documentation"),
         subtitle:
-            ls\`Launch page contains useful links and instructions to help get you started.\`,
-        link: 'https://github.com/microsoft/vscode-edge-devtools/pull/350',
-    },
-    {
-        title: ls\`New landing view for the sidebar when no targets are available\`,
-        subtitle:
-            ls\`The view contains instructions and buttons to help launch a target or configure your project's launch.json file.\`,
-        link: 'https://github.com/microsoft/vscode-edge-devtools/pull/357',
-    },
-    {
-        title: ls\`New triple dot dropdown menu on extension sidebar\`,
-        subtitle:
-            ls\`Dropdown menu contains links to extension settings and changelog.\`,
-        link: 'https://github.com/microsoft/vscode-edge-devtools/pull/288',
-    },
-    {
-        title: ls\`Hide and show service and shared workers\`,
-        subtitle:
-            ls\`Created new settings checkbox that will hide or show service and shared workers in the target list (default to hide).\`,
-        link: 'https://github.com/microsoft/vscode-edge-devtools/pull/284',
+            i18nLazyString("Find our new location for all up-to-date documentation regarding this extension!"),
+        link: 'https://microsoft.github.io/vscode-edge-devtools/',
     },
 ],`;
 
 export const devtoolsHighlights = `[
     {
-        title: ls\`Use improved CSS Grid tools\`,
+        title: i18nLazyString("New Flexbox (flex) icon helps identify and display flex containers"),
         subtitle:
-            ls\`Now you can debug and inspect CSS Grids with persistent overlays, with support for multiple grids, and the new Layout tool.\`,
-        link: 'https://go.microsoft.com/fwlink/?linkid=2146827',
+            i18nLazyString("In the Elements tool, the new Flexbox (flex) icon helps you identify Flexbox containers in your code."),
+        link: 'https://docs.microsoft.com/en-us/microsoft-edge/devtools-guide-chromium/whats-new/2021/01/devtools#new-flexbox-flex-icon-helps-identify-and-display-flex-containers',
     },
     {
-        title: ls\`Learn about updates to the Elements tool\`,
-        subtitle: ls\`View the Computed pane in the Styles pane, and more.\`,
-        link: 'https://go.microsoft.com/fwlink/?linkid=2146829',
+        title: i18nLazyString("Display alignment icons and visual guides when Flexbox layouts change using CSS properties"),
+        subtitle: i18nLazyString("When you edit CSS for your Flexbox layout, CSS autocompletes in the Styles pane now displays helpful icons next to relevant Flexbox properties."),
+        link: 'https://docs.microsoft.com/en-us/microsoft-edge/devtools-guide-chromium/whats-new/2021/01/devtools#display-alignment-icons-and-visual-guides-when-flexbox-layouts-change-using-css-properties',
     },
     {
-        title: ls\`Apply new filters in the Network tool\`,
-        subtitle: ls\`Filter network requests with the new 'resource-type' and 'url' keywords in the Network tool.\`,
-        link: 'https://go.microsoft.com/fwlink/?linkid=2147022',
+        title: i18nLazyString("Improved CSS flexbox editing with visual flexbox editor and multiple overlays"),
+        subtitle: i18nLazyString("DevTools now has dedicated CSS flexbox debugging tools. If the display: flex or display: inline-flex CSS style is applied to an HTML element, a flex icon displays next to that element in the Elements tool."),
+        link: 'https://docs.microsoft.com/en-us/microsoft-edge/devtools-guide-chromium/whats-new/2021/02/devtools#improved-css-flexbox-editing-with-visual-flexbox-editor-and-multiple-overlays',
+    },
+    {
+        title: i18nLazyString("Wavy underlines highlight code issues and improvements in Elements tool"),
+        subtitle: i18nLazyString("In most modern IDEs, wavy underlines under text indicate syntax errors. Now, wavy underlines display under HTML in the DOM view of the Elements tool"),
+        link: 'https://docs.microsoft.com/en-us/microsoft-edge/devtools-guide-chromium/whats-new/2021/04/devtools#wavy-underlines-highlight-code-issues-and-improvements-in-elements-tool',
+    },
+    {
+        title: i18nLazyString("Learn about DevTools with informative tooltips"),
+        subtitle: i18nLazyString("The DevTools Tooltips feature helps you learn about all the different tools and panes in DevTools. Toggle on with 'CTRL/CMD + SHIFT + H' and Toggle off with 'Esc'"),
+        link: 'https://docs.microsoft.com/en-us/microsoft-edge/devtools-guide-chromium/whats-new/2021/04/devtools#learn-about-devtools-with-informative-tooltips',
     },
 ],`;

--- a/src/host/polyfills/simpleView.ts
+++ b/src/host/polyfills/simpleView.ts
@@ -18,7 +18,7 @@ const enum KeepMatchedText {
     AtEnd = 2
 }
 
-const isDrawerEnabled = '(Root.Runtime.vscodeSettings.enableNetwork || Root.Runtime.vscodeSettings.whatsNew)';
+const isDrawerEnabled = '(Root.Runtime.vscodeSettings.enableNetwork || Root.Runtime.vscodeSettings.welcome)';
 
 function replaceInSourceCode(content: string, pattern: RegExp, replacementText: string, keepMatchedText?: KeepMatchedText): string | null {
     const match = pattern.exec(content);
@@ -219,14 +219,14 @@ export function applyRemoveBreakOnContextMenuItem(content: string): string | nul
 export function applyShowDrawerTabs(content: string): string | null {
     // Appends the Request Blocking tab or Whats New tab in the drawer even if it is not open.
     const pattern = /if\s*\(!view\.isCloseable\(\)\)/;
-    const replacementText = "if(!view.isCloseable()||id==='network.blocked-urls'||id==='release-note')";
+    const replacementText = "if(!view.isCloseable()||id==='network.blocked-urls')";
     return replaceInSourceCode(content, pattern, replacementText);
 }
 
 export function applyPersistTabs(content: string): string | null {
     // Removes the close button from the Request blocking and Whats New tab tab by making the tab non-closeable.
     const pattern = /this\._closeable\s*=\s*closeable;/;
-    const replacementText = "this._closeable= (id==='network.blocked-urls' || id === 'release-note' || id === 'network')?false:closeable;";
+    const replacementText = "this._closeable= (id==='network.blocked-urls' || id === 'network')?false:closeable;";
     return replaceInSourceCode(content, pattern, replacementText);
 }
 
@@ -270,8 +270,8 @@ export function applyAppendTabConditionsPatch(content: string): string | null {
         appendTab(id, tabTitle, view, tabTooltip, userGesture, isCloseable, index) {
             let patchedCondition = ${condition};
             ${applyEnableNetworkPatch()}
-            if(Root.Runtime.vscodeSettings.whatsNew) {
-              patchedCondition = patchedCondition && (id !== "release-note");
+            if(Root.Runtime.vscodeSettings.welcome) {
+              patchedCondition = patchedCondition && (id !== "welcome");
             }
             if (!patchedCondition) {
                 this.appendTabOverride(id, tabTitle, view, tabTooltip, userGesture, isCloseable, index);

--- a/src/host/toolsHost.ts
+++ b/src/host/toolsHost.ts
@@ -160,7 +160,7 @@ export class ToolsHost {
         this.fireGetHostCallback(id, {
             enableNetwork: vscodeObject.enableNetwork,
             theme,
-            whatsNew: vscodeObject.whatsNew,
+            welcome: vscodeObject.welcome,
             isHeadless: vscodeObject.isHeadless,
         });
     }

--- a/test/devtoolsPanel.test.ts
+++ b/test/devtoolsPanel.test.ts
@@ -484,7 +484,7 @@ describe("devtoolsPanel", () => {
 
             it("calls getVscodeSettings", async () => {
                 const expectedId = { id: 0 };
-                const expectedState = { enableNetwork: true, themeString: "System preference", whatsNew: true, isHeadless: false};
+                const expectedState = { enableNetwork: true, themeString: "System preference", welcome: true, isHeadless: false};
                 (context.workspaceState.get as jest.Mock).mockReturnValue(expectedState);
 
                 const dtp = await import("../src/devtoolsPanel");
@@ -497,7 +497,7 @@ describe("devtoolsPanel", () => {
                     {
                         themeString: expectedState.themeString,
                         enableNetwork: expectedState.enableNetwork,
-                        whatsNew: expectedState.whatsNew,
+                        welcome: expectedState.welcome,
                         isHeadless: expectedState.isHeadless,
                         id: expectedId.id,
                     },

--- a/test/helpers/helpers.ts
+++ b/test/helpers/helpers.ts
@@ -78,7 +78,7 @@ export function createFakeVSCode() {
                                 return true;
                             case "themes":
                                 return "System preference";
-                            case "whatsNew":
+                            case "welcome":
                                 return true;
                             case "isHeadless":
                                 return false;
@@ -92,7 +92,7 @@ export function createFakeVSCode() {
                                 return {defaultValue: true};
                             case "themes":
                                 return {defaultValue: "Light"};
-                            case "whatsNew":
+                            case "welcome":
                                 return {defaultValue: false};
                             case "isHeadless":
                                 return {defaultValue: false};

--- a/test/host/polyfills/releaseNote.test.ts
+++ b/test/host/polyfills/releaseNote.test.ts
@@ -1,44 +1,36 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-import { getTextFromFile } from "../../helpers/helpers";
+import { testPatch } from "../../helpers/helpers";
 import * as ReleaseNotePatch from "../../../src/host/polyfills/releaseNote";
 
 describe("Release notes text replacement", () => {
     it("verifies that applyReleaseNotePatch correctly replaces what's new content", async () => {
         const filePath = "panels/help/ReleaseNoteText.js";
-        const fileContents = getTextFromFile(filePath);
-        if (!fileContents) {
-            throw new Error(`Could not find file: ${filePath}`);
-        }
+        const patch = ReleaseNotePatch.applyReleaseNotePatch;
+        const expectedStrings = ["Highlights from the latest version of Microsoft Edge Developer Tools for Visual Studio Code"];
 
-        const result = ReleaseNotePatch.applyReleaseNotePatch(fileContents);
-        expect(result).toEqual(
-            expect.stringContaining(
-                `Highlights from the latest version of Microsoft Edge Developer Tools for Visual Studio Code`));
-    });
-    it("verifies that applyGithubLinksPatch correctly replaces GitHub links at the bottom of the tab", async () => {
-        const filePath = "panels/help/ReleaseNoteView.js";
-        const fileContents = getTextFromFile(filePath);
-        if (!fileContents) {
-            throw new Error(`Could not find file: ${filePath}`);
-        }
-
-        const result = ReleaseNotePatch.applyGithubLinksPatch(fileContents);
-        expect(result).toEqual(
-            expect.stringContaining(
-                `const githubLink`));
+        await testPatch(filePath, patch, expectedStrings);
     });
     it("verifies that applyAnnouncementNamePatch correctly replaces the section headers", async () => {
-        const filePath = "panels/help/ReleaseNoteView.js";
-        const fileContents = getTextFromFile(filePath);
-        if (!fileContents) {
-            throw new Error(`Could not find file: ${filePath}`);
-        }
+        const filePath = "welcome/WelcomePanel.js";
+        const patch = ReleaseNotePatch.applyAnnouncementNamePatch;
+        const expectedStrings = ["New in Developer Tools"];
 
-        const result = ReleaseNotePatch.applyAnnouncementNamePatch(fileContents);
-        expect(result).toEqual(
-            expect.stringContaining(
-                `New extension features`));
+        await testPatch(filePath, patch, expectedStrings);
+    });
+    it("verifies that applyShowMorePatch correctly replaces the section headers", async () => {
+        const filePath = "welcome/WhatsNewList.js";
+        const patch = ReleaseNotePatch.applyShowMorePatch;
+        const unexpectedStrings = ["href=\"\""];
+
+        await testPatch(filePath, patch, undefined, unexpectedStrings);
+    });
+    it("verifies that applySettingsCheckboxPatch correctly replaces the section headers", async () => {
+        const filePath = "welcome/WelcomePanel.js";
+        const patch = ReleaseNotePatch.applySettingsCheckboxPatch;
+        const unexpectedStrings = ["titleContainer.appendChild(this.startupCheckBox);"];
+
+        await testPatch(filePath, patch, undefined, unexpectedStrings);
     });
 });

--- a/test/host/polyfills/simpleView.test.ts
+++ b/test/host/polyfills/simpleView.test.ts
@@ -122,7 +122,7 @@ describe("simpleView", () => {
     it("applyShowDrawerTabs correctly changes text", async () => {
         const filePath = "ui/legacy/ViewManager.js";
         const patch = SimpleView.applyShowDrawerTabs;
-        const expectedStrings = ["if(!view.isCloseable()||id==='network.blocked-urls'||id==='release-note')"];
+        const expectedStrings = ["if(!view.isCloseable()||id==='network.blocked-urls')"];
 
         await testPatch(filePath, patch, expectedStrings);
     });
@@ -130,7 +130,7 @@ describe("simpleView", () => {
     it("applyPersistTabs correctly changes text", async () => {
         const filePath = "ui/legacy/TabbedPane.js";
         const patch = SimpleView.applyPersistTabs;
-        const expectedStrings = ["this._closeable= (id==='network.blocked-urls' || id === 'release-note' || id === 'network')?false:closeable;"];
+        const expectedStrings = ["this._closeable= (id==='network.blocked-urls' || id === 'network')?false:closeable;"];
 
         await testPatch(filePath, patch, expectedStrings);
     });

--- a/test/host/polyfills/simpleView.test.ts
+++ b/test/host/polyfills/simpleView.test.ts
@@ -58,7 +58,7 @@ describe("simpleView", () => {
     it("applyInspectorViewShowDrawerPatch correctly changes _showDrawer text", async () => {
         const filePath = "ui/legacy/InspectorView_edge.js";
         const patch = SimpleView.applyInspectorViewShowDrawerPatch;
-        const expectedStrings = ["if (!(Root.Runtime.vscodeSettings.enableNetwork || Root.Runtime.vscodeSettings.whatsNew)) {return false;}"];
+        const expectedStrings = ["if (!(Root.Runtime.vscodeSettings.enableNetwork || Root.Runtime.vscodeSettings.welcome)) {return false;}"];
 
         await testPatch(filePath, patch, expectedStrings);
     });

--- a/test/utils.test.ts
+++ b/test/utils.test.ts
@@ -997,7 +997,7 @@ describe("utils", () => {
                     fillerPropertyOne: 'Need to add filler values since the extension related telemetry functions removes the first 4 entries to create an array of extension settings',
                     fillerPropertyTwo: 'The first 4 entries for a workspaceConfiguration object are class related functions, the rest are all extension related settings.',
                     themes: 'System preference',
-                    whatsNew: 'true',
+                    welcome: 'true',
                     enableNetwork: 'false',
                 }
             });
@@ -1009,7 +1009,7 @@ describe("utils", () => {
         it('correctly records all changed extension settings', async () => {
             const reporter = createFakeTelemetryReporter();
             utils.reportExtensionSettings(reporter);
-            expect(reporter.sendTelemetryEvent).toBeCalledWith('user/settingsChangedAtLaunch', { themes: 'System preference', whatsNew: 'true', enableNetwork: 'false' });
+            expect(reporter.sendTelemetryEvent).toBeCalledWith('user/settingsChangedAtLaunch', { themes: 'System preference', welcome: 'true', enableNetwork: 'false' });
         });
 
         it('correctly sends telemetry event for changed event', async () => {


### PR DESCRIPTION
This PR reformats and updates the `releaseNote` patches to work with the new Welcome tab introduced in Edge DevTools version 89.  It also contains new release notes that cover the biggest changes since version 1.1.9 and from the DevTools versions 89, 90 and 91.