### PR TITLE
[Revert]: Revert unintended webpack sourcemapping change

### DIFF
--- a/package.json
+++ b/package.json
@@ -176,8 +176,6 @@
                     "type": "object",
                     "description": "A set of mappings to override the locations of source map files.",
                     "default": {
-                        "webpack://./*": "${webRoot}/*",
-                        "webpack://*": "${webRoot}/*",
                         "webpack:///./*": "${webRoot}/*",
                         "webpack:///src/*": "${webRoot}/*",
                         "webpack:///*": "*",

--- a/src/devtoolsPanel.ts
+++ b/src/devtoolsPanel.ts
@@ -342,7 +342,7 @@ export class DevToolsPanel {
                     style-src 'self' 'unsafe-inline' ${this.panel.webview.cspSource};
                     script-src 'self' 'unsafe-eval' ${this.panel.webview.cspSource};
                     frame-src 'self' ${this.panel.webview.cspSource};
-                    connect-src 'self' data: ${this.panel.webview.cspSource};
+                    connect-src 'self' ${this.panel.webview.cspSource};
                 ">
                 <meta name="referrer" content="no-referrer">
                 <link href="${stylesUri}" rel="stylesheet"/>


### PR DESCRIPTION
A WiP sourcemapping change was accidentally included in this PR: https://github.com/microsoft/vscode-edge-devtools/pull/406

This PR removes this change.