### PR TITLE
[Bug Fix]: Updating webview CSP + webpack sourcemapping overrides

### DIFF
--- a/examples/sourcemaps.md
+++ b/examples/sourcemaps.md
@@ -13,6 +13,7 @@ Note: These are the mappings that are included by default out of the box, with e
     "webpack:///./*": "${webRoot}/*",
     "webpack:///*": "*",
     "webpack:///src/*": "${webRoot}/*",
+     "webpack://*": "${webRoot}/*",
     "meteor://💻app/*": "${webRoot}/*"
 }
 ```
@@ -26,15 +27,18 @@ See the following examples for each entry in the default mappings (`webRoot = /U
 Example:
 "webpack:///./~/querystring/index.js"
 -> "/Users/me/project/node_modules/querystring/index.js"
-"webpack:///./*":   "${webRoot}/*" 
+"webpack:///./*":   "${webRoot}/*"
 Example:
 "webpack:///./src/app.js" -> "/Users/me/project/src/app.js"
-"webpack:///*": "*" 
+"webpack:///*": "*"
 Example:
 "webpack:///project/app.ts" -> "/project/app.ts"
-"webpack:///src/*": "${webRoot}/*" 
+"webpack:///src/*": "${webRoot}/*"
 Example:
 "webpack:///src/app.js" -> "/Users/me/project/app.js"
+"webpack://*": "${webRoot}/*"
+Example:
+"webpack://src/app.js" -> "/Users/me/project/src/app.js"
 "meteor://💻app/*": "${webRoot}/*"
 Example:
 "meteor://💻app/main.ts"` -> `"/Users/me/project/main.ts"

--- a/package.json
+++ b/package.json
@@ -180,6 +180,7 @@
                         "webpack:///src/*": "${webRoot}/*",
                         "webpack:///*": "*",
                         "webpack:///./~/*": "${webRoot}/node_modules/*",
+                        "webpack://*": "${webRoot}/*",
                         "meteor://💻app/*": "${webRoot}/*"
                     }
                 },
@@ -335,6 +336,7 @@
                                     "webpack:///src/*": "${webRoot}/*",
                                     "webpack:///*": "*",
                                     "webpack:///./~/*": "${webRoot}/node_modules/*",
+                                    "webpack://*": "${webRoot}/*",
                                     "meteor://💻app/*": "${webRoot}/*"
                                 }
                             },
@@ -417,6 +419,7 @@
                                     "webpack:///src/*": "${webRoot}/*",
                                     "webpack:///*": "*",
                                     "webpack:///./~/*": "${webRoot}/node_modules/*",
+                                    "webpack://*": "${webRoot}/*",
                                     "meteor://💻app/*": "${webRoot}/*"
                                 }
                             },

--- a/src/devtoolsPanel.ts
+++ b/src/devtoolsPanel.ts
@@ -342,7 +342,7 @@ export class DevToolsPanel {
                     style-src 'self' 'unsafe-inline' ${this.panel.webview.cspSource};
                     script-src 'self' 'unsafe-eval' ${this.panel.webview.cspSource};
                     frame-src 'self' ${this.panel.webview.cspSource};
-                    connect-src 'self' ${this.panel.webview.cspSource};
+                    connect-src 'self' data: ${this.panel.webview.cspSource};
                 ">
                 <meta name="referrer" content="no-referrer">
                 <link href="${stylesUri}" rel="stylesheet"/>

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -90,6 +90,7 @@ export const SETTINGS_DEFAULT_PATH_OVERRIDES: IStringDictionary<string> = {
     'webpack:///./*': '${webRoot}/*',
     'webpack:///./~/*': '${webRoot}/node_modules/*',
     'webpack:///src/*': '${webRoot}/*',
+    'webpack://*': '${webRoot}/*',
 };
 export const SETTINGS_DEFAULT_WEB_ROOT = '${workspaceFolder}';
 export const SETTINGS_DEFAULT_SOURCE_MAPS = true;

--- a/test/utils.test.ts
+++ b/test/utils.test.ts
@@ -706,7 +706,8 @@ describe("utils", () => {
                 "webpack:///./*": `${testPath}\\*`,
                 "webpack:///./~/*": `${testPath}\\node_modules\\*`,
                 "webpack:///*": "*",
-                "webpack:///src/*": `${testPath}\\*`
+                "webpack:///src/*": `${testPath}\\*`,
+                "webpack://*": `${testPath}\\*`
             };
 
             // Ensure the new values are returned


### PR DESCRIPTION
This PR updates the `content-src` CSP to allow URLs with `data:` prefixes.  It also updates webpack sourcemapping to account for `webpack://` resource prefixes.

These changes should help improve compatibility of the extension with projects using webpack.