### PR TITLE
Minification: add ability to skip minification on problematic files

### DIFF
--- a/scripts/minifyDevtools.js
+++ b/scripts/minifyDevtools.js
@@ -12,6 +12,11 @@ const uglifyOptions = {
     compress: true,
 };
 
+// List of files that need to skip minification due to issues with uglify.js
+const skippedFiles = [
+  'core/host/ResourceLoader.js',
+];
+
 const usageMessage =
 `
 Script to uglify all devtools-frontend files needed for extension
@@ -45,11 +50,18 @@ const main = async function(){
     const relPath = path.relative(inputDir, file);
     await fs.ensureDir(path.join(outputDir, relDir), {recursive: true});
     const inputCode = fs.readFileSync(file, "utf-8");
-    const code = uglify.minify(
-        {file: inputCode},
-        uglifyOptions
-    ).code;
-    fs.writeFileSync(path.join(outputDir, relPath), code);
+    if (skippedFiles.includes(relPath.replace(/\\/g, '/'))) {
+      // Move file directly to output without minification
+      console.log(`Skipping minification on ${relPath}`);
+      fs.writeFileSync(path.join(outputDir, relPath), inputCode);
+    } else {
+      // Minify and output to outputDir
+      const code = uglify.minify(
+          {file: inputCode},
+          uglifyOptions
+      ).code;
+      fs.writeFileSync(path.join(outputDir, relPath), code);
+    }
   }
   console.log("Done");
 }


### PR DESCRIPTION
This PR adds the ability to skip files that don't work with the uglify.js minification module we are using. This addresses an issue in ResourceLoader.js that was preventing proper source map resolution.