### PR TITLE
[Bug Fix]: Unhide close drawer button

### DIFF
--- a/postBuildStep.ts
+++ b/postBuildStep.ts
@@ -20,6 +20,7 @@ import {
     applyInspectorCommonContextMenuPatch,
     applyInspectorCommonCssPatch,
     applyInspectorCommonCssRightToolbarPatch,
+    applyUnhideRightToolbarElementsPatch,
     applyInspectorCommonCssTabSliderPatch,
     applyInspectorCommonNetworkPatch,
     applyInspectorViewCloseDrawerPatch,
@@ -102,6 +103,7 @@ async function patchFilesForWebView(toolsOutDir: string) {
     await patchFileForWebViewWrapper('shell.js', toolsOutDir, [
         applyInspectorCommonContextMenuPatch,
         applyInspectorCommonCssRightToolbarPatch,
+        applyUnhideRightToolbarElementsPatch,
         applyInspectorCommonCssPatch,
         applyInspectorCommonNetworkPatch,
         applyInspectorCommonCssTabSliderPatch,

--- a/src/host/polyfills/simpleView.ts
+++ b/src/host/polyfills/simpleView.ts
@@ -343,14 +343,14 @@ export function applyInspectorCommonCssPatch(content: string): string | null {
             display: none !important;
         }`.replace(/\n/g, separator);
 
-    const unHideScreenCastBtn =
+    const unhideScreenCastBtn =
         `.toolbar-button[aria-label='Toggle screencast'] {
             visibility: visible !important;
         }`.replace(/\n/g, separator);
 
     const topHeaderCSS =
         hideMoreToolsBtn +
-        unHideScreenCastBtn;
+        unhideScreenCastBtn;
 
     const pattern = /\.platform-mac,/g;
     const replacementText = `${topHeaderCSS}${separator}`;
@@ -358,7 +358,7 @@ export function applyInspectorCommonCssPatch(content: string): string | null {
 }
 
 export function applyInspectorCommonNetworkPatch(content: string): string | null {
-    // Hides export HAR button and pretty print button and reveals the Network search close button in the Network Panel.
+    // Hides export HAR button and pretty print button.
     const separator = '\\n';
 
     const hideExportHarBtn =
@@ -371,19 +371,34 @@ export function applyInspectorCommonNetworkPatch(content: string): string | null
             display: none !important;
         }`.replace(/\n/g, separator);
 
-    // Search close button initially hidden by applyInspectorCommonCssRightToolbarPatch
-    const unHideSearchCloseButton =
+    const networkCSS =
+        hideExportHarBtn +
+        hidePrettyPrintBtn;
+
+    const pattern = /\.platform-mac,/g;
+    const replacementText = `${networkCSS}${separator}`;
+    return replaceInSourceCode(content, pattern, replacementText, KeepMatchedText.AtEnd);
+}
+
+export function applyUnhideRightToolbarElementsPatch(content: string): string | null {
+    // This patch unhides certain elements that were hidden with the blanket applyInspectorCommonCssRightToolbarPatch.
+    const separator = '\\n';
+    const unhideSearchCloseButton =
         `.toolbar-button[aria-label='Close'] {
             visibility: visible !important;
         }`.replace(/\n/g, separator);
 
-    const networkCSS =
-        hideExportHarBtn +
-        hidePrettyPrintBtn +
-        unHideSearchCloseButton;
+    const unhideDrawerCloseButton =
+    `.toolbar-button[aria-label='Close drawer'] {
+        visibility: visible !important;
+    }`.replace(/\n/g, separator);
+
+    const unhideCSS =
+        unhideSearchCloseButton +
+        unhideDrawerCloseButton;
 
     const pattern = /\.platform-mac,/g;
-    const replacementText = `${networkCSS}${separator}`;
+    const replacementText = `${unhideCSS}${separator}`;
     return replaceInSourceCode(content, pattern, replacementText, KeepMatchedText.AtEnd);
 }
 

--- a/test/host/polyfills/simpleView.test.ts
+++ b/test/host/polyfills/simpleView.test.ts
@@ -154,7 +154,7 @@ describe("simpleView", () => {
     it("applyInspectorCommonNetworkPatch correctly changes text", async () => {
         const filePath = "shell.js";
         const patch = SimpleView.applyInspectorCommonNetworkPatch;
-        const expectedStrings = [".toolbar-button[aria-label='Export HAR...']", ".toolbar-button[aria-label='Pretty print']", ".toolbar-button[aria-label='Close']"];
+        const expectedStrings = [".toolbar-button[aria-label='Export HAR...']", ".toolbar-button[aria-label='Pretty print']"];
 
         await testPatch(filePath, patch, expectedStrings);
     });
@@ -171,6 +171,14 @@ describe("simpleView", () => {
         const filePath = "shell.js";
         const patch = SimpleView.applyInspectorCommonCssRightToolbarPatch;
         const expectedStrings = [".tabbed-pane-right-toolbar {\\n            visibility: hidden !important;\\n        }"];
+
+        await testPatch(filePath, patch, expectedStrings);
+    });
+
+    it("applyUnhideRightToolbarElementsPatch correctly changes tabbed-pane-right-toolbar", async () => {
+        const filePath = "shell.js";
+        const patch = SimpleView.applyUnhideRightToolbarElementsPatch;
+        const expectedStrings = [".toolbar-button[aria-label='Close']", ".toolbar-button[aria-label='Close drawer']"];
 
         await testPatch(filePath, patch, expectedStrings);
     });


### PR DESCRIPTION
This PR unhides the drawer's close button.

Other related changes:

- Created `applyUnhideRightToolbarElementsPatch` that unhides the network search close button and the close drawer button
- Removed `unHideSearchCloseButton` from `applyInspectorCommonNetworkPatch` and added it to `applyUnhideRightToolbarElementsPatch` to consolidate right toolbar unhiding patching.
- renamed all instances of `unHide` to `unhide`
- updated tests

![image](https://user-images.githubusercontent.com/14304598/123345511-16def880-d50b-11eb-8b8b-046fbc7d2397.png)

closes #394
