### PR TITLE
[Telemetry]: Modifying workspace/metadata telemetry to track only relevant file types

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -691,17 +691,25 @@ export async function reportFileExtensionTypes(telemetryReporter: Readonly<Telem
         ['scss', 0],
         ['json', 0],
         ['mjs', 0],
+        ['other', 0],
     ]);
     for (const file of files) {
         const extension: string | undefined = file.path.split('.').pop();
-        if (extension && extensionMap.has(extension)) {
-            const currentValue = extensionMap.get(extension);
-            if (currentValue !== undefined) {
-                extensionMap.set(extension, currentValue + 1);
+        if (extension) {
+            if (extensionMap.has(extension)) {
+                const currentValue = extensionMap.get(extension);
+                if (currentValue !== undefined) {
+                    extensionMap.set(extension, currentValue + 1);
+                }
+            } else {
+                const otherCount = extensionMap.get('other');
+                if (otherCount !== undefined) {
+                    extensionMap.set('other', otherCount + 1);
+                }
             }
         }
     }
-    extensionMap.set('totalWorkspaceSize', files.length);
+    extensionMap.set('total', files.length);
 
     // Creates Object from map
     const fileTypes: {[key: string]: number} = {};

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -682,19 +682,26 @@ export function reportUrlType(url: string, telemetryReporter: Readonly<Telemetry
 
 export async function reportFileExtensionTypes(telemetryReporter: Readonly<TelemetryReporter>): Promise<void> {
     const files = await vscode.workspace.findFiles('**/*.*', '**/node_modules/**');
-    const extensionMap: Map<string, number> = new Map<string, number>();
+    const extensionMap: Map<string, number> = new Map<string, number>([
+        ['html', 0],
+        ['css', 0],
+        ['js', 0],
+        ['ts', 0],
+        ['jsx', 0],
+        ['scss', 0],
+        ['json', 0],
+        ['mjs', 0],
+    ]);
     for (const file of files) {
         const extension: string | undefined = file.path.split('.').pop();
-        if (extension) {
+        if (extension && extensionMap.has(extension)) {
             const currentValue = extensionMap.get(extension);
-            if (currentValue) {
+            if (currentValue !== undefined) {
                 extensionMap.set(extension, currentValue + 1);
-            } else {
-                extensionMap.set(extension, 1);
             }
         }
     }
-    extensionMap.set('total', files.length);
+    extensionMap.set('totalWorkspaceSize', files.length);
 
     // Creates Object from map
     const fileTypes: {[key: string]: number} = {};

--- a/test/utils.test.ts
+++ b/test/utils.test.ts
@@ -982,7 +982,7 @@ describe("utils", () => {
         it('correctly lists extension types in the workspace', async () => {
             const reporter = createFakeTelemetryReporter();
             await utils.reportFileExtensionTypes(reporter);
-            expect(reporter.sendTelemetryEvent).toBeCalledWith('workspace/metadata', undefined, {"css": 1, "js": 1, "json": 1, "jsx": 1, "total": 4});
+            expect(reporter.sendTelemetryEvent).toBeCalledWith('workspace/metadata', undefined, {"css": 1, "html": 0, "js": 1, "json": 1, "jsx": 1, "mjs": 0, "scss": 0, "totalWorkspaceSize": 4, "ts": 0});
         });
     });
 

--- a/test/utils.test.ts
+++ b/test/utils.test.ts
@@ -982,7 +982,7 @@ describe("utils", () => {
         it('correctly lists extension types in the workspace', async () => {
             const reporter = createFakeTelemetryReporter();
             await utils.reportFileExtensionTypes(reporter);
-            expect(reporter.sendTelemetryEvent).toBeCalledWith('workspace/metadata', undefined, {"css": 1, "html": 0, "js": 1, "json": 1, "jsx": 1, "mjs": 0, "scss": 0, "totalWorkspaceSize": 4, "ts": 0});
+            expect(reporter.sendTelemetryEvent).toBeCalledWith('workspace/metadata', undefined, {"css": 1, "html": 0, "js": 1, "json": 1, "jsx": 1, "mjs": 0, "other": 0, "scss": 0, "total": 4, "ts": 0});
         });
     });
 


### PR DESCRIPTION
Our previous implementation of the `workspace/metadata` telemetry would send a count of every file extension type in the user's workspace. This created thousands of different properties that needed to be categorized for this telemetry event due to the vast number of file extension types.

To reduce the # of properties for this telemetry event, this PR scopes down to only track the relevant file types.  An example of the new event property would look something like this:
`{"css": 1, "html": 0, "js": 1, "json": 1, "jsx": 1, "mjs": 0, "scss": 0, "totalWorkspaceSize": 10, "ts": 0}`

Note that the `totalWorkspaceSize` property will still track the total # of files, not just the total of relevant file types