### PR TITLE
Removing unused strings.js reference

### DIFF
--- a/src/devtoolsPanel.ts
+++ b/src/devtoolsPanel.ts
@@ -324,13 +324,11 @@ export class DevToolsPanel {
     }
 
     private getHtmlForWebview() {
-        // stringsUri and inspectorUri are the files that used to be loaded in inspector.html
+        // inspectorUri is the file that used to be loaded in inspector.html
         // They are being loaded directly into the webview.
         // local resource loading inside iframes was deprecated in these commits:
         // https://github.com/microsoft/vscode/commit/de9887d9e0eaf402250d2735b3db5dc340184b74
         // https://github.com/microsoft/vscode/commit/d05ded6d3b64fed4a3cc74106f9b6c72243b18de
-        const stringsPath = vscode.Uri.file(path.join(this.extensionPath, 'out/tools/front_end', 'strings.js'));
-        const stringsUri = this.panel.webview.asWebviewUri(stringsPath);
 
         const inspectorPath = vscode.Uri.file(path.join(this.extensionPath, 'out/tools/front_end', 'inspector.js'));
         const inspectorUri = this.panel.webview.asWebviewUri(inspectorPath);
@@ -359,7 +357,6 @@ export class DevToolsPanel {
                 <meta name="referrer" content="no-referrer">
                 <link href="${stylesUri}" rel="stylesheet"/>
                 <script src="${hostUri}"></script>
-                <script src="${stringsUri}"></script>
                 <script type="module" src="${inspectorUri}"></script>
             </head>
             <body>


### PR DESCRIPTION
Issue:
string.js was removed in Edge 091 but our code still tries to reach to it:
![image](https://user-images.githubusercontent.com/43078681/125982075-bed3833c-259a-4a8d-a21d-cad11c23f503.png)

Fix:
Remove string.js references.