### PR TITLE
Disabling virtual workspaces.

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,8 @@
         "untrustedWorkspaces": {
             "supported": "limited",
             "description": "Workspace trust is needed to configure and debug projects"
-        }
+        },
+        "virtualWorkspaces": false
     },
     "contributes": {
         "commands": [


### PR DESCRIPTION
Edge Devtools for VSCode does not currently plan to support virtual workspaces. We can always revisit this decision if we find that there is enough user push for it.