### PR TITLE
Add "forwardToUi" param when requesting jsdebug proxy connection

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -280,6 +280,7 @@ export function getActiveDebugSessionId(): string|undefined {
 export async function getJsDebugCDPProxyWebsocketUrl(debugSessionId: string): Promise<string|Error|undefined> {
     try {
         // TODO: update to query location when workspace support added
+        // https://github.com/microsoft/vscode-edge-devtools/issues/383
         const forwardToUi = true;
         const addr: IRequestCDPProxyResult|undefined = await vscode.commands.executeCommand(
         'extension.js-debug.requestCDPProxy',

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -279,9 +279,12 @@ export function getActiveDebugSessionId(): string|undefined {
  */
 export async function getJsDebugCDPProxyWebsocketUrl(debugSessionId: string): Promise<string|Error|undefined> {
     try {
+        // TODO: update to query location when workspace support added
+        const forwardToUi = true;
         const addr: IRequestCDPProxyResult|undefined = await vscode.commands.executeCommand(
         'extension.js-debug.requestCDPProxy',
         debugSessionId,
+        forwardToUi
         );
         if (addr) {
             return `ws://${addr.host}:${addr.port}${addr.path || ''}`;


### PR DESCRIPTION
Currently, Edge devtools is unable to use the JsDebug integration when jsdbug is in a remote workspace. This PR adds a new parameter to the request for a CDP proxy connection to indicate that JsDebug should forward CDP calls to the local UI instance of the Devtools extension.

Addresses #413

More information:
https://github.com/microsoft/vscode-js-debug/issues/1024
https://github.com/microsoft/vscode-js-debug/commit/7afc5b2bb68029296d94d2eb79c0852820e61f10
