### PR TITLE
Remote CDN connection logic for devtools

### DIFF
--- a/package.json
+++ b/package.json
@@ -601,7 +601,7 @@
         "build": "npm run build-wp && npm run build-post",
         "build-min": "npm run build-wp && npm run build-post && npm run minify-devtools",
         "build-debug": "npm run build-wp && ts-node postBuildStep.ts debug",
-        "build-edge-watch": "webpack --env debug",
+        "build-edge-watch": "webpack --env debug --env devtoolsBaseUri=http://localhost:3000/vscode_app.html",
         "build-wp": "webpack",
         "build-post": "ts-node postBuildStep.ts",
         "build-watch": "npm run build && npm run watch",

--- a/src/devtoolsPanel.ts
+++ b/src/devtoolsPanel.ts
@@ -394,6 +394,8 @@ export class DevToolsPanel {
     }
 
     private getCdnHtmlForWebview() {
+        // Default to config provided base uri
+        const cdnBaseUri = this.config.devtoolsBaseUri || this.devtoolsBaseUri;
         const hostPath = vscode.Uri.file(path.join(this.extensionPath, 'out', 'host_beta', 'host.bundle.js'));
         const hostUri = this.panel.webview.asWebviewUri(hostPath);
 
@@ -416,12 +418,12 @@ export class DevToolsPanel {
                     img-src 'self' data: ${this.panel.webview.cspSource};
                     style-src 'self' 'unsafe-inline' ${this.panel.webview.cspSource};
                     script-src 'self' 'unsafe-eval' ${this.panel.webview.cspSource};
-                    frame-src 'self' ${this.panel.webview.cspSource} ${this.devtoolsBaseUri};
+                    frame-src 'self' ${this.panel.webview.cspSource} ${cdnBaseUri};
                     connect-src 'self' data: ${this.panel.webview.cspSource};
                 ">
             </head>
             <body>
-                <iframe id="devtools-frame" frameBorder="0" src="${this.devtoolsBaseUri}?experiments=true&theme=${theme}"></iframe>
+                <iframe id="devtools-frame" frameBorder="0" src="${cdnBaseUri}?experiments=true&theme=${theme}"></iframe>
             </body>
             </html>
             `;

--- a/src/devtoolsPanel.ts
+++ b/src/devtoolsPanel.ts
@@ -17,6 +17,7 @@ import {
 } from './common/webviewEvents';
 import { JsDebugProxyPanelSocket } from './JsDebugProxyPanelSocket';
 import { PanelSocket } from './panelSocket';
+import { BrowserVersionDetectionSocket } from './versionSocketConnection';
 import {
     applyPathMapping,
     fetchUri,
@@ -37,6 +38,7 @@ export class DevToolsPanel {
     private readonly telemetryReporter: Readonly<TelemetryReporter>;
     private readonly targetUrl: string;
     private panelSocket: PanelSocket;
+    private versionDetectionSocket: BrowserVersionDetectionSocket;
     private consoleOutput: vscode.OutputChannel;
     private timeStart: number | null;
 
@@ -91,6 +93,13 @@ export class DevToolsPanel {
             this.panelSocket.on('consoleOutput', msg => this.onSocketConsoleOutput(msg));
         }
 
+        // This Websocket is only used on initial connection to determine the browser version.
+        // The browser version is used to select between CDN and bundled tools
+        // Future versions of the extension will remove this socket and only use CDN
+        this.versionDetectionSocket = new BrowserVersionDetectionSocket(this.targetUrl);
+        this.versionDetectionSocket.on('setBrowserRevision', revision => this.setBrowserRevision(revision));
+
+
         // Handle closing
         this.panel.onDidDispose(() => {
             this.dispose();
@@ -99,7 +108,13 @@ export class DevToolsPanel {
         // Handle view change
         this.panel.onDidChangeViewState(_e => {
             if (this.panel.visible) {
-                this.update();
+                if (this.panelSocket.isConnectedToTarget) {
+                    // Connection type determined already
+                    this.update();
+                } else {
+                    // Use version socket to determine which Webview/Tools to use
+                    this.versionDetectionSocket.detectVersion();
+                }
             }
         }, this, this.disposables);
 
@@ -124,6 +139,7 @@ export class DevToolsPanel {
         this.panel.dispose();
         this.panelSocket.dispose();
         this.consoleOutput.dispose();
+        this.versionDetectionSocket.dispose();
         if (this.timeStart !== null) {
             const timeEnd = performance.now();
             const sessionTime = timeEnd - this.timeStart;
@@ -329,7 +345,8 @@ export class DevToolsPanel {
     }
 
     private update() {
-        this.panel.webview.html = this.config.isCdnHostedTools ? this.getCdnHtmlForWebview() : this.getHtmlForWebview();
+        // Check to see which version of devtools we need to launch
+        this.panel.webview.html = (this.config.isCdnHostedTools || this.config.useLocalEdgeWatch) ? this.getCdnHtmlForWebview() : this.getHtmlForWebview();
     }
 
     private getHtmlForWebview() {
@@ -375,12 +392,7 @@ export class DevToolsPanel {
     }
 
     private getCdnHtmlForWebview() {
-        let cdnBaseUrl = this.config.devtoolsBaseUri;
-        if (!cdnBaseUrl) {
-            // Not provided, calculate based on config
-            // TODO: CDP call to determine actual hash and stuff
-            cdnBaseUrl = this.config.useLocalEdgeWatch ? 'http://localhost:3000/vscode_app.html' : 'https://devtools.invalid';
-        }
+        const cdnBaseUrl = this.config.devtoolsBaseUri;
         const hostPath = vscode.Uri.file(path.join(this.extensionPath, 'out', 'host_beta', 'host.bundle.js'));
         const hostUri = this.panel.webview.asWebviewUri(hostPath);
 
@@ -413,6 +425,17 @@ export class DevToolsPanel {
             </html>
             `;
     }
+
+    private setBrowserRevision(revision: string) {
+        if (revision !== '') {
+            this.config.isCdnHostedTools = true;
+            this.config.devtoolsBaseUri = this.config.devtoolsBaseUri || `https://devtools.azureedge.net/serve_file/${revision}/vscode_app.html`;
+        } else {
+            this.config.isCdnHostedTools = false;
+        }
+        this.update();
+    }
+
 
     static createOrShow(
         context: vscode.ExtensionContext,

--- a/src/devtoolsPanel.ts
+++ b/src/devtoolsPanel.ts
@@ -110,7 +110,7 @@ export class DevToolsPanel {
         // Handle view change
         this.panel.onDidChangeViewState(_e => {
             if (this.panel.visible) {
-                if (this.panelSocket.isConnectedToTarget || this.config.devtoolsBaseUri) {
+                if (this.panelSocket.isConnectedToTarget) {
                     // Connection type determined already
                     this.update();
                 } else {

--- a/src/panelSocket.ts
+++ b/src/panelSocket.ts
@@ -67,7 +67,7 @@ export class PanelSocket extends EventEmitter {
         return this.emit(eventName, args);
     }
 
-    private connectToTarget() {
+    private connectToTarget(): void {
         // Create the websocket
         this.socket = new WebSocket(this.targetUrl);
         this.socket.onopen = () => this.onOpen();

--- a/src/versionSocketConnection.ts
+++ b/src/versionSocketConnection.ts
@@ -1,0 +1,86 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import { EventEmitter } from 'events';
+import WebSocket from 'ws';
+import { WebSocketEvent } from './common/webviewEvents';
+
+export type IDevToolsPostMessageCallback = (e: WebSocketEvent, message?: string) => void;
+
+export interface BrowserVersionCdpResponse {
+   id: number;
+   result?: {
+       product?: string;
+       revision?: string;
+   }
+}
+
+const MIN_SUPPORTED_VERSION = '94.0.975.0';
+
+export class BrowserVersionDetectionSocket extends EventEmitter {
+    private readonly targetUrl: string;
+    private socket: WebSocket | undefined;
+
+    constructor(targetUrl: string) {
+        super();
+        this.targetUrl = targetUrl;
+    }
+
+    dispose(): void {
+        if (this.socket) {
+            this.socket.close();
+            this.socket = undefined;
+        }
+    }
+
+    detectVersion(): void {
+        // Connect to target to determine browser version
+        this.socket = new WebSocket(this.targetUrl);
+        this.socket.onopen = () => this.onOpen();
+        this.socket.onmessage = ev => this.onMessage(ev);
+    }
+
+    private onOpen(): void {
+        // Send request to get browser version
+        const requestMessage = {
+            id: 0,
+            method: 'Browser.getVersion',
+            params: {},
+        };
+        if (this.socket) {
+            this.socket.send(JSON.stringify(requestMessage));
+        }
+    }
+
+    private onMessage(message: { data: WebSocket.Data }) {
+        // Determine if this is the browser.getVersion response and send revision hash to devtoolsPanel
+        const data = JSON.parse(message.data.toString()) as BrowserVersionCdpResponse;
+        this.emit('setBrowserRevision', this.calcBrowserRevision(data));
+        // Dispose socket after version is determined
+        this.dispose();
+        return;
+    }
+
+    private calcBrowserRevision(data: BrowserVersionCdpResponse): string {
+        if (data.id !== 0 || !data.result || !data.result.product && !data.result.revision) {
+            return '';
+        }
+        // product in the form [Edg, HeadlessEdg]/#.#.#.#
+        const versionNum = (data.result.product as string).split('/')[1];
+        const currentVersion = versionNum.split('.');
+        const minSupportedVersion = MIN_SUPPORTED_VERSION.split('.');
+        const currentRevision = data.result.revision || '';
+        for (let i = 0; i < currentVersion.length; i++) {
+            // Loop through from Major to minor numbers
+            if (currentVersion[i] > minSupportedVersion[i]) {
+                return currentRevision;
+            }
+            if (currentVersion[i] < minSupportedVersion[i]) {
+                return '';
+            }
+            // Continue to the next number
+        }
+        // All numbers matched, return supported revision
+        return currentRevision;
+    }
+}

--- a/test/versionDetectionSocket.test.ts
+++ b/test/versionDetectionSocket.test.ts
@@ -1,0 +1,67 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import WebSocket from "ws";
+import { Mocked } from "./helpers/helpers";
+import type {BrowserVersionCdpResponse} from "../src/versionSocketConnection";
+
+describe("versionDetectionSocket", () => {
+    let mockWebSocket: Mocked<WebSocket>;
+    beforeEach(() => {
+        mockWebSocket = {
+            close: jest.fn(),
+            onclose: jest.fn(),
+            onerror: jest.fn(),
+            onmessage: jest.fn(),
+            onopen: jest.fn(),
+            send: jest.fn(),
+        } as Mocked<WebSocket>;
+
+        // We need to use a non-arrow function here as it is used as a constructor.
+        // tslint:disable-next-line: object-literal-shorthand only-arrow-functions
+        jest.doMock("ws", () => function() { return mockWebSocket; });
+        jest.resetModules();
+    });
+
+    it("creates a new websocket on connection", async () => {
+        const expected = {
+            onmessage: mockWebSocket.onmessage,
+            onopen: mockWebSocket.onopen,
+        };
+        const vs = await import("../src/versionSocketConnection");
+        const versionSocket = new vs.BrowserVersionDetectionSocket("");
+
+        versionSocket.detectVersion();
+        expect(mockWebSocket.onmessage).not.toEqual(expected.onmessage);
+        expect(mockWebSocket.onopen).not.toEqual(expected.onopen);
+    });
+
+    it("calculates revision correctly", async () => {
+        const vs = await import("../src/versionSocketConnection");
+        const versionSocket = new vs.BrowserVersionDetectionSocket("");
+
+        const revisions: string[] = [];
+        versionSocket.on("setBrowserRevision", (msg: string) => {
+            if (msg !== ""){
+                revisions.push(msg);
+            }
+        });
+
+        const versionMessages: BrowserVersionCdpResponse[] = [
+            { id: 0, result: { revision: "FAIL", product: "Edg/92.0.0.0"}},
+            { id: 0, result: { revision: "PASS", product: "Edg/95.0.0.0"}},
+            { id: 0, result: { revision: "PASS", product: "Edg/94.0.975.0"}},
+            { id: 0, result: { revision: "FAIL", product: "Edg/94.0.100.0"}},
+        ]
+
+        for (const version of versionMessages) {
+            versionSocket.detectVersion();
+            mockWebSocket.onmessage.call(mockWebSocket, { data: JSON.stringify(version)});
+        }
+
+        expect(revisions.length).toEqual(2);
+        for (const rev of revisions) {
+            expect(rev).toEqual("PASS");
+        }
+    });
+});


### PR DESCRIPTION
This PR adds the ability for the extension to choose the legacy (inbox) or CDN based connection to a debug target based on it's version.

It adds a new versionDetectionSocket that sends a single message: CDP's browser.getVersion in order to determine which version of the tools to load, then informs the devtoolsPanel and disposes itself