### PR TITLE
Add theme detection for supported Devtools themes in frame hosted tools

### DIFF
--- a/src/common/settingsProvider.ts
+++ b/src/common/settingsProvider.ts
@@ -4,6 +4,25 @@ import * as vscode from 'vscode';
 import { SETTINGS_STORE_NAME } from '../utils';
 import { ThemeString } from './webviewEvents';
 
+const SUPPORTED_THEMES = new Map<string, string>([
+  ['Default Light+', 'light'],
+  ['Visual Studio Light', 'light'],
+  ['Default Dark+', 'dark'],
+  ['Visual Studio Dark', 'dark'],
+  ['Monokai', 'vscode-monokai'],
+  ['Monokai Dimmed', 'vscode-monokai-dimmed'],
+  ['Solarized Dark', 'vscode-solarized-dark'],
+  ['Solarized Light', 'vscode-solarized-light'],
+  ['Red', 'vscode-red'],
+  ['Quiet Light', 'vscode-quietlight'],
+  ['Abyss', 'vscode-abyss'],
+  ['Kimbie Dark', 'vscode-kimbie-dark'],
+  ['Tomorrow Night Blue', 'vscode-tomorrow-night-blue'],
+  // Legacy Theme string mappings
+  ['Light', 'light'],
+  ['Dark', 'dark'],
+  ['System Preference', 'systemPreference'],
+]);
 export class SettingsProvider {
 
   private static singletonInstance: SettingsProvider;
@@ -18,6 +37,12 @@ export class SettingsProvider {
     const settings = vscode.workspace.getConfiguration(SETTINGS_STORE_NAME);
     const themeString: ThemeString = settings.get('themes') || 'System preference';
     return themeString;
+  }
+
+  getNewThemeSettings(): string {
+      const themeSetting = vscode.workspace.getConfiguration().get('workbench.colorTheme');
+      const legacySetting = vscode.workspace.getConfiguration(SETTINGS_STORE_NAME).get('themes');
+      return SUPPORTED_THEMES.get((themeSetting || legacySetting) as string) || 'systemPreference';
   }
 
   getWelcomeSettings(): boolean {

--- a/src/common/settingsProvider.ts
+++ b/src/common/settingsProvider.ts
@@ -33,13 +33,18 @@ export class SettingsProvider {
     return networkEnabled;
   }
 
+  // Legacy only: this function returns the theme for the legacy bundled DevTools
   getThemeSettings(): ThemeString {
     const settings = vscode.workspace.getConfiguration(SETTINGS_STORE_NAME);
     const themeString: ThemeString = settings.get('themes') || 'System preference';
     return themeString;
   }
 
-  getNewThemeSettings(): string {
+  // This function returns the theme for the new frame hosted DevTools by:
+  // 1. Fetching the User configured Global VSCode theme, return it if supported
+  // 2. Fall back to the extension Theme setting selector (light, dark, system preference)
+  // 3. Fall back to system preference
+  getThemeFromUserSetting(): string {
       const themeSetting = vscode.workspace.getConfiguration().get('workbench.colorTheme');
       const legacySetting = vscode.workspace.getConfiguration(SETTINGS_STORE_NAME).get('themes');
       return SUPPORTED_THEMES.get((themeSetting || legacySetting) as string) || 'systemPreference';

--- a/src/devtoolsPanel.ts
+++ b/src/devtoolsPanel.ts
@@ -109,7 +109,9 @@ export class DevToolsPanel {
         }, this, this.disposables);
 
         vscode.workspace.onDidChangeConfiguration(e => {
-            if (e.affectsConfiguration('workbench.colorTheme') && this.panel.visible) {
+            if (this.config.isCdnHostedTools &&
+            e.affectsConfiguration('workbench.colorTheme') &&
+            this.panel.visible) {
                 this.update();
             }
         });

--- a/src/devtoolsPanel.ts
+++ b/src/devtoolsPanel.ts
@@ -384,7 +384,7 @@ export class DevToolsPanel {
         const stylesPath = vscode.Uri.file(path.join(this.extensionPath, 'out', 'common', 'styles.css'));
         const stylesUri = this.panel.webview.asWebviewUri(stylesPath);
 
-        const theme = SettingsProvider.instance.getNewThemeSettings();
+        const theme = SettingsProvider.instance.getThemeFromUserSetting();
 
         // the added fields for "Content-Security-Policy" allow resource loading for other file types
         return `

--- a/src/devtoolsPanel.ts
+++ b/src/devtoolsPanel.ts
@@ -108,6 +108,7 @@ export class DevToolsPanel {
             this.panelSocket.onMessageFromWebview(message);
         }, this, this.disposables);
 
+        // Update DevTools theme if user changes global theme
         vscode.workspace.onDidChangeConfiguration(e => {
             if (this.config.isCdnHostedTools &&
             e.affectsConfiguration('workbench.colorTheme') &&

--- a/src/devtoolsPanel.ts
+++ b/src/devtoolsPanel.ts
@@ -107,6 +107,12 @@ export class DevToolsPanel {
         this.panel.webview.onDidReceiveMessage(message => {
             this.panelSocket.onMessageFromWebview(message);
         }, this, this.disposables);
+
+        vscode.workspace.onDidChangeConfiguration(e => {
+            if (e.affectsConfiguration('workbench.colorTheme') && this.panel.visible) {
+                this.update();
+            }
+        });
     }
 
     dispose(): void {
@@ -378,6 +384,8 @@ export class DevToolsPanel {
         const stylesPath = vscode.Uri.file(path.join(this.extensionPath, 'out', 'common', 'styles.css'));
         const stylesUri = this.panel.webview.asWebviewUri(stylesPath);
 
+        const theme = SettingsProvider.instance.getNewThemeSettings();
+
         // the added fields for "Content-Security-Policy" allow resource loading for other file types
         return `
             <!doctype html>
@@ -397,7 +405,7 @@ export class DevToolsPanel {
                 ">
             </head>
             <body>
-                <iframe id="devtools-frame" frameBorder="0" src="${cdnBaseUrl}?experiments=true&edgeThemes=true"></iframe>
+                <iframe id="devtools-frame" frameBorder="0" src="${cdnBaseUrl}?experiments=true&theme=${theme}"></iframe>
             </body>
             </html>
             `;


### PR DESCRIPTION
This PR adds support for setting the devtools extension theme if the user switches to a theme that the devtools frontend supports