### PR TITLE
Adding required changes to implement getVsCodeSettings

### DIFF
--- a/src/common/webviewEvents.ts
+++ b/src/common/webviewEvents.ts
@@ -20,7 +20,7 @@ export const webviewEventNames: WebviewEvent[] = [
 ];
 
 export type FrameToolsEvent = 'sendMessageToBackend' | 'openInNewTab' | 'recordEnumeratedHistogram' |
-'recordPerformanceHistogram' | 'reportError' | 'openInEditor';
+'recordPerformanceHistogram' | 'reportError' | 'openInEditor' | 'getVscodeSettings';
 export const FrameToolsEventNames: FrameToolsEvent[] = [
     'sendMessageToBackend',
     'openInNewTab',
@@ -28,6 +28,7 @@ export const FrameToolsEventNames: FrameToolsEvent[] = [
     'recordEnumeratedHistogram',
     'recordPerformanceHistogram',
     'reportError',
+    'getVscodeSettings',
 ];
 
 export type WebSocketEvent = 'open' | 'close' | 'error' | 'message';

--- a/src/devtoolsPanel.ts
+++ b/src/devtoolsPanel.ts
@@ -232,7 +232,7 @@ export class DevToolsPanel {
             encodeMessageForChannel(msg => this.panel.webview.postMessage(msg) as unknown as void, 'getVscodeSettings',
                 {
                     themeString: SettingsProvider.instance.getThemeSettings(),
-                    isHeadless: SettingsProvider.instance.getHeadlessSettings()
+                    isHeadless: SettingsProvider.instance.getHeadlessSettings(),
                 });
         } else {
             const { id } = JSON.parse(message) as { id: number };
@@ -241,7 +241,7 @@ export class DevToolsPanel {
                 themeString: SettingsProvider.instance.getThemeSettings(),
                 welcome: SettingsProvider.instance.getWelcomeSettings(),
                 isHeadless: SettingsProvider.instance.getHeadlessSettings(),
-                id
+                id,
             });
         }
     }

--- a/src/devtoolsPanel.ts
+++ b/src/devtoolsPanel.ts
@@ -226,13 +226,24 @@ export class DevToolsPanel {
     }
 
     private onSocketGetVscodeSettings(message: string) {
-        const { id } = JSON.parse(message) as { id: number };
-        encodeMessageForChannel(msg => this.panel.webview.postMessage(msg) as unknown as void, 'getVscodeSettings', {
-            enableNetwork: SettingsProvider.instance.isNetworkEnabled(),
-            themeString: SettingsProvider.instance.getThemeSettings(),
-            welcome: SettingsProvider.instance.getWelcomeSettings(),
-            isHeadless: SettingsProvider.instance.getHeadlessSettings(),
-            id });
+        // TODO: When non CDN version is removed it is safe to delete the
+        // the second path.
+        if (this.config.isCdnHostedTools) {
+            encodeMessageForChannel(msg => this.panel.webview.postMessage(msg) as unknown as void, 'getVscodeSettings',
+                {
+                    themeString: SettingsProvider.instance.getThemeSettings(),
+                    isHeadless: SettingsProvider.instance.getHeadlessSettings()
+                });
+        } else {
+            const { id } = JSON.parse(message) as { id: number };
+            encodeMessageForChannel(msg => this.panel.webview.postMessage(msg) as unknown as void, 'getVscodeSettings', {
+                enableNetwork: SettingsProvider.instance.isNetworkEnabled(),
+                themeString: SettingsProvider.instance.getThemeSettings(),
+                welcome: SettingsProvider.instance.getWelcomeSettings(),
+                isHeadless: SettingsProvider.instance.getHeadlessSettings(),
+                id
+            });
+        }
     }
 
     private onSocketSetState(message: string) {


### PR DESCRIPTION
Implementing getVsCode Settings for extension with CDN support.
After this PR CDN devtoolswill be able to query for settings in VS Code. I added only two settings by default that seem relevant to the CDN implementation but it can be easily tweaked.