### PR TITLE
Add headless query param support to Cdn DevTools

### DIFF
--- a/test/versionDetectionSocket.test.ts
+++ b/test/versionDetectionSocket.test.ts
@@ -41,9 +41,13 @@ describe("versionDetectionSocket", () => {
         const versionSocket = new vs.BrowserVersionDetectionSocket("");
 
         const revisions: string[] = [];
-        versionSocket.on("setBrowserRevision", (msg: string) => {
-            if (msg !== ""){
-                revisions.push(msg);
+        let headlessCount = 0;
+        versionSocket.on("setCdnParameters", (msg: {revision: string, isHeadless: boolean}) => {
+            if (msg.revision !== ""){
+                revisions.push(msg.revision);
+            }
+            if (msg.isHeadless) {
+                headlessCount++;
             }
         });
 
@@ -52,6 +56,10 @@ describe("versionDetectionSocket", () => {
             { id: 0, result: { revision: "PASS", product: "Edg/95.0.0.0"}},
             { id: 0, result: { revision: "PASS", product: "Edg/94.0.975.0"}},
             { id: 0, result: { revision: "FAIL", product: "Edg/94.0.100.0"}},
+            { id: 0, result: { revision: "FAIL", product: "HeadlessEdg/92.0.0.0"}},
+            { id: 0, result: { revision: "PASS", product: "HeadlessEdg/95.0.0.0"}},
+            { id: 0, result: { revision: "PASS", product: "HeadlessEdg/94.0.975.0"}},
+            { id: 0, result: { revision: "FAIL", product: "HeadlessEdg/94.0.100.0"}},
         ]
 
         for (const version of versionMessages) {
@@ -59,7 +67,8 @@ describe("versionDetectionSocket", () => {
             mockWebSocket.onmessage.call(mockWebSocket, { data: JSON.stringify(version)});
         }
 
-        expect(revisions.length).toEqual(2);
+        expect(headlessCount).toEqual(4);
+        expect(revisions.length).toEqual(4);
         for (const rev of revisions) {
             expect(rev).toEqual("PASS");
         }


### PR DESCRIPTION
This PR updates the browser revision calculation socket to also pass a headless query param to allow the DevTools to know if it is attached to a headless target.