### PR TITLE
Add links to documentation/file an issue to sidebar

### DIFF
--- a/package.json
+++ b/package.json
@@ -577,7 +577,15 @@
             },
             {
                 "view": "vscode-edge-devtools-view.help-links",
-                "contents": "[Documentation](command:vscode-edge-devtools-view.viewDocumentation)\n[File an Issue](https://github.com/microsoft/vscode-edge-devtools/issues/new)"
+                "contents": "[Documentation](command:vscode-edge-devtools-view.viewDocumentation)"
+            },
+            {
+                "view": "vscode-edge-devtools-view.help-links",
+                "contents": "[Report a Bug](https://github.com/microsoft/vscode-edge-devtools/issues/new?template=bug_report.md)"
+            },
+            {
+                "view": "vscode-edge-devtools-view.help-links",
+                "contents": "[Request a Feature](https://github.com/microsoft/vscode-edge-devtools/issues/new?template=feature_request.md)"
             }
         ]
     },

--- a/package.json
+++ b/package.json
@@ -542,6 +542,10 @@
                 {
                     "id": "vscode-edge-devtools-view.targets",
                     "name": "Targets"
+                },
+                {
+                    "id": "vscode-edge-devtools-view.help-links",
+                    "name": "Helpful links"
                 }
             ]
         },
@@ -572,8 +576,8 @@
                 "when": "launchJsonStatus == Supported && isWorkspaceTrusted"
             },
             {
-                "view": "vscode-edge-devtools-view.targets",
-                "contents": "If you have any questions or want to learn more, check the [docs on GitHub](command:vscode-edge-devtools-view.viewDocumentation)."
+                "view": "vscode-edge-devtools-view.help-links",
+                "contents": "[Documentation](command:vscode-edge-devtools-view.viewDocumentation)\n[File an Issue](https://github.com/microsoft/vscode-edge-devtools/issues/new)"
             }
         ]
     },

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -164,7 +164,7 @@ export function activate(context: vscode.ExtensionContext): void {
         }));
     context.subscriptions.push(vscode.commands.registerCommand(`${SETTINGS_VIEW_NAME}.viewDocumentation`, () => {
             telemetryReporter.sendTelemetryEvent('user/buttonPress', { 'VSCode.buttonCode': buttonCode.viewDocumentation });
-            void vscode.env.openExternal(vscode.Uri.parse('https://github.com/microsoft/vscode-edge-devtools/blob/main/README.md'));
+            void vscode.env.openExternal(vscode.Uri.parse('https://docs.microsoft.com/en-us/microsoft-edge/visual-studio-code/microsoft-edge-devtools-extension'));
         }));
     void vscode.commands.executeCommand('setContext', 'titleCommandsRegistered', true);
     void reportFileExtensionTypes(telemetryReporter);


### PR DESCRIPTION
This PR adds a new section to the extension sidebar, which contains links to documentation and the 'New Issue' page in our repo. It also updates the url in the viewDocumentation command from this repo's README to the official Microsoft documentation.

A few challenges posed by the VSCode Extension API
- [By convention, any command links that are on a line by themselves are displayed as a button](https://code.visualstudio.com/api/references/contribution-points#contributes.viewsWelcome), which prevents us from showing these as links instead of buttons
- The initial height of the tree view sections can't be specified (afaik), so the two sections will take up equal amounts of the sidebar the first time the user opens it, which will show a lot of empty space on the bottom section. Afterwards though, VSCode will remember whatever height they set it to.

Open questions:
- How much deviation from the mock up are we okay with?
- What should the title for the new section be?

Before
![sidebar-links-before](https://user-images.githubusercontent.com/80795982/129637118-8d46f51b-da7a-4117-b2b3-21211731f76f.PNG)
After
![sidebar-links-after](https://user-images.githubusercontent.com/80795982/129637146-1458e4df-82f6-4190-91fb-e0b0e96655bb.PNG)
Mockup:
![image](https://user-images.githubusercontent.com/80795982/129637186-4309b8b0-2613-46ef-8d90-fc2e3137d11e.png)
