### PR TITLE
Deprecate console output in favor of JSDebugger

### DIFF
--- a/src/devtoolsPanel.ts
+++ b/src/devtoolsPanel.ts
@@ -54,18 +54,13 @@ export class DevToolsPanel {
         this.config = config;
         this.timeStart = null;
         this.consoleOutput = vscode.window.createOutputChannel('DevTools Console');
-        if (config.isJsDebugProxiedCDPConnection) {
-            // Direct users to the Debug Console
-            this.consoleOutput.appendLine('// Microsoft Edge Devtools Extension:');
-            this.consoleOutput.appendLine('// You have connected to a target using Visual Studio Code\'s JavaScript Debugger.');
-            this.consoleOutput.appendLine('// Please use the "Debug Console" to view console messages from your webpage and evaluate expressions.');
-        } else {
-            // Provide 1-way console when attached to a target that is not the current debug target
-            this.consoleOutput.appendLine('// Microsoft Edge Devtools Extension:');
-            this.consoleOutput.appendLine('// This Output window displays the DevTools extension\'s console output in text format.');
-            this.consoleOutput.appendLine('// Note that this feature is only unidirectional and cannot communicate back to the DevTools.');
-            this.consoleOutput.appendLine('');
-        }
+
+        // Deprecated console
+        // Direct users to the Debug Console. This message with be removed in a the next update
+        this.consoleOutput.appendLine('// Microsoft Edge Devtools Extension:');
+        this.consoleOutput.appendLine('// The Microsoft Edge DevTools Extension will be deprecating console output in the next update.');
+        this.consoleOutput.appendLine('// To receive full REPL console functionality, please use Visual Studio Code\'s included JavaScript Debugger to attach to your target.');
+        this.consoleOutput.appendLine('// Then use the "Debug Console" to view console messages from your webpage and evaluate expressions.');
 
         // Hook up the socket events
         if (this.config.isJsDebugProxiedCDPConnection) {

--- a/src/devtoolsPanel.ts
+++ b/src/devtoolsPanel.ts
@@ -61,6 +61,7 @@ export class DevToolsPanel {
         this.consoleOutput.appendLine('// The Microsoft Edge DevTools Extension will be deprecating console output in the next update.');
         this.consoleOutput.appendLine('// To receive full REPL console functionality, please use Visual Studio Code\'s included JavaScript Debugger to attach to your target.');
         this.consoleOutput.appendLine('// Then use the "Debug Console" to view console messages from your webpage and evaluate expressions.');
+        this.consoleOutput.appendLine('// For more information, visit https://docs.microsoft.com/en-us/microsoft-edge/visual-studio-code/microsoft-edge-devtools-extension#browser-debugging-with-microsoft-edge-developer-tools-integration-in-visual-studio-code');
 
         // Hook up the socket events
         if (this.config.isJsDebugProxiedCDPConnection) {


### PR DESCRIPTION
This PR updates our Console output to inform users that it will be deprecated and direct folks to use JSDebugger instead.