### PR TITLE
Create default landing page for webview in case remote devtools fail to load

### DIFF
--- a/src/common/styles.css
+++ b/src/common/styles.css
@@ -9,3 +9,15 @@ html, body, iframe {
     margin: 0;
     overflow: hidden;
 }
+
+#error-message {
+    height: 100%;
+    width: 100%;
+    position: absolute;
+    margin: 10px;
+    z-index: 2;
+}
+
+#error-message.hidden {
+    display: none;
+}

--- a/src/devtoolsPanel.ts
+++ b/src/devtoolsPanel.ts
@@ -99,7 +99,6 @@ export class DevToolsPanel {
         this.versionDetectionSocket = new BrowserVersionDetectionSocket(this.targetUrl);
         this.versionDetectionSocket.on('setCdnParameters', msg => this.setCdnParameters(msg));
 
-
         // Handle closing
         this.panel.onDidDispose(() => {
             this.dispose();
@@ -422,6 +421,15 @@ export class DevToolsPanel {
             </head>
             <body>
                 <iframe id="devtools-frame" frameBorder="0" src="${cdnBaseUri}?experiments=true&theme=${theme}&headless=${this.isHeadless}"></iframe>
+                <div id="error-message" class="hidden">
+                    <h1>Unable to download DevTools for the current target.</h1>
+                    <p>Try these troubleshooting steps:</p>
+                    <ol>
+                    <li>Check your network connection</li>
+                    <li>Close and re-launch the DevTools</li>
+                    </ol>
+                    <p>If this problem continues, please <a target="_blank" href="https://github.com/microsoft/vscode-edge-devtools/issues/new?template=bug_report.md">file an issue.</a></p>
+                </div>
             </body>
             </html>
             `;

--- a/src/host_beta/messageRouter.ts
+++ b/src/host_beta/messageRouter.ts
@@ -22,10 +22,17 @@ const vscode = acquireVsCodeApi();
  */
 export class MessageRouter {
     private toolsFrameWindow: Window | null | undefined;
+    private errorMessageDiv: HTMLElement | null | undefined;
+    private devtoolsActionReceived: boolean = false;
 
     constructor(webviewWindow: Window) {
         webviewWindow.addEventListener('DOMContentLoaded', () => {
             this.toolsFrameWindow = (document.getElementById('devtools-frame') as HTMLIFrameElement).contentWindow;
+            this.toolsFrameWindow?.addEventListener('load', () => {
+                this.devtoolsActionReceived = true;
+            });
+
+            this.errorMessageDiv = document.getElementById('error-message') as HTMLElement;
         });
 
         const extensionMessageCallback = this.onMessageFromChannel.bind(this);
@@ -37,6 +44,8 @@ export class MessageRouter {
             if (!fromExtension) {
                 // Send message from DevTools to Extension
                 this.onMessageFromFrame(messageEvent.data.method as FrameToolsEvent, messageEvent.data.args as any[]);
+                // Record that the DevTools has sent a message to prevent error page from loading
+                this.devtoolsActionReceived = true;
             } else if (this.toolsFrameWindow) {
                 // Send message from Extension to DevTools
                 parseMessageFromChannel(
@@ -50,6 +59,9 @@ export class MessageRouter {
 
         // Inform the extension we are ready to receive messages
         this.sendReady();
+
+        // Set timeout to show error message if devtools has not loaded within 10 seconds
+        setTimeout(() => this.showLoadingError(), 10000);
     }
 
     onMessageFromFrame(e: FrameToolsEvent, args: any[]): boolean {
@@ -158,5 +170,13 @@ export class MessageRouter {
         if (this.toolsFrameWindow && e === 'message') {
             this.toolsFrameWindow.postMessage({method: 'dispatchMessage', args: [message]}, '*');
         }
+    }
+
+    private showLoadingError() {
+        if (this.devtoolsActionReceived || !this.errorMessageDiv) {
+            return;
+        }
+        // Show the error message if DevTools has failed to record an action
+        this.errorMessageDiv.classList.remove('hidden');
     }
 }


### PR DESCRIPTION
This PR adds a default message to the DevTools webview that is only seen if the iframe fails to load anything. This is to address the rare case that the CDN fails on first attempt to debug a new browser version

![image](https://user-images.githubusercontent.com/42152559/129967837-1ec221d8-a84a-4c4d-a918-d23f2c3ca1bc.png)

