### PR TITLE
Supporting following CSS links on WSL remotes

### DIFF
--- a/src/devtoolsPanel.ts
+++ b/src/devtoolsPanel.ts
@@ -319,13 +319,13 @@ export class DevToolsPanel {
         // Convert the workspace path into a VS Code url
         let uri: vscode.Uri | undefined;
         try {
-            uri = vscode.Uri.file(sourcePath);
-        } catch {
-            try {
+            if (vscode.env.remoteName) {
                 uri = vscode.Uri.parse(sourcePath, true);
-            } catch {
-                uri = undefined;
+            } else {
+                uri = vscode.Uri.file(sourcePath);
             }
+        } catch {
+            uri = undefined;
         }
 
         // Finally open the document if it exists

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -524,6 +524,9 @@ export function applyPathMapping(
         // replacement pattern, and return the result.
         const wildcardValue = overridePatternMatches[1];
         let mappedPath = rightPattern.replace(/\*/g, wildcardValue);
+        if (vscode.env.remoteName) {
+            return mappedPath;
+        }
         mappedPath = debugCore.utils.properJoin(mappedPath); // Fix any ..'s
         mappedPath = replaceWorkSpaceFolderPlaceholder(mappedPath);
         return mappedPath;

--- a/test/devtoolsPanel.test.ts
+++ b/test/devtoolsPanel.test.ts
@@ -492,7 +492,6 @@ describe("devtoolsPanel", () => {
                 };
 
                 const mockVsCode = jest.requireMock("vscode");
-                mockVsCode.Uri.file = jest.fn(() => { throw new Error(); });
 
                 const mockUtils = {
                     applyPathMapping: jest.fn().mockImplementation((x) => x),


### PR DESCRIPTION
This addresses #436 by doing a check for whether there is a remote, and if so, being more fluid on the way the files are discovered.

I've tested this on WSL and non-remote (Windows) and it worked as expected,