### PR TITLE
Fully remove Console Output

### DIFF
--- a/src/common/webviewEvents.ts
+++ b/src/common/webviewEvents.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 export type WebviewEvent = 'getState' | 'getUrl' | 'openInEditor' | 'ready' | 'setState' | 'telemetry' | 'websocket'
-| 'getVscodeSettings' | 'copyText' | 'focusEditor' | 'focusEditorGroup' | 'openUrl' | 'consoleOutput';
+| 'getVscodeSettings' | 'copyText' | 'focusEditor' | 'focusEditorGroup' | 'openUrl';
 export const webviewEventNames: WebviewEvent[] = [
     'getState',
     'getUrl',
@@ -16,7 +16,6 @@ export const webviewEventNames: WebviewEvent[] = [
     'focusEditor',
     'focusEditorGroup',
     'openUrl',
-    'consoleOutput',
 ];
 
 export type FrameToolsEvent = 'sendMessageToBackend' | 'openInNewTab' | 'recordEnumeratedHistogram' |

--- a/src/host/toolsHost.ts
+++ b/src/host/toolsHost.ts
@@ -92,10 +92,6 @@ export class ToolsHost {
         encodeMessageForChannel(msg => vscode.postMessage(msg, '*'), 'getVscodeSettings', {id});
     }
 
-    sendToVscodeOutput(consoleMessage: string): void {
-        encodeMessageForChannel(msg => vscode.postMessage(msg, '*'), 'consoleOutput', {consoleMessage});
-    }
-
     copyText(clipboardData: string): void {
         encodeMessageForChannel(msg => vscode.postMessage(msg, '*'), 'copyText', {clipboardData});
     }


### PR DESCRIPTION
Now that the deprecation message has shipped with 1.3.0, this PR fully removes the console output in favor of the debug console