### PR TITLE
CSS mirroring UI for early feedback

### DIFF
--- a/package.json
+++ b/package.json
@@ -561,6 +561,11 @@
                     "name": "Targets"
                 },
                 {
+                    "id": "vscode-edge-devtools-view.mirror-editing",
+                    "name": "CSS Mirror Editing",
+                    "when": "config.vscode-edge-devtools.browserFlavor == Canary"
+                },
+                {
                     "id": "vscode-edge-devtools-view.help-links",
                     "name": "Helpful links"
                 }
@@ -591,6 +596,24 @@
                 "view": "vscode-edge-devtools-view.targets",
                 "contents": "Launch an instance of Microsoft Edge to begin inspecting and modifying your site.\n[Launch Project](command:vscode-edge-devtools-view.launchProject)",
                 "when": "launchJsonStatus == Supported && isWorkspaceTrusted"
+            },
+            {
+                "view": "vscode-edge-devtools-view.mirror-editing",
+                "contents": "CSS mirror editing is an experimental feature that automatically applies changes made in the DevTools panel to CSS files in your workspace."
+            },
+            {
+                "view": "vscode-edge-devtools-view.mirror-editing",
+                "contents": "[Toggle Mirror Editing ON](command:vscode-edge-devtools-view.toggleMirrorEditingOn)",
+                "when": "!config.vscode-edge-devtools.mirrorEdits"
+            },
+            {
+                "view": "vscode-edge-devtools-view.mirror-editing",
+                "contents": "[Toggle Mirror Editing OFF](command:vscode-edge-devtools-view.toggleMirrorEditingOff)",
+                "when": "config.vscode-edge-devtools.mirrorEdits"
+            },
+            {
+                "view": "vscode-edge-devtools-view.mirror-editing",
+                "contents": "Please help us improve this feature by [leaving feedback here](https://github.com/microsoft/vscode-edge-devtools/issues/new?title=[CSS%20Mirror%20Editing])."
             },
             {
                 "view": "vscode-edge-devtools-view.help-links",


### PR DESCRIPTION
This PR
- Adds UI to surface the new feature (#462), give a brief explanation, and prompts the user to provide feedback. This UI is temporary, as we eventually want to move UI for this feature into the DevTools, but will allow us to collect feedback in the mean time.
- Only shows the UI when the user is targeting Canary

![mirror-ui-beta](https://user-images.githubusercontent.com/80795982/130533881-beab5751-5e5a-407d-891c-dac5cc3128a1.gif)

A few remaining questions around the pre-populating the issue that linked for feedback:
- Should we add a label like "feedback" in case the user ends up deleting the pre-populated title?
- Do we want to pre-populate any questions into the issue body? (e.g. asking their ideal workflow with the feature)