### PR TITLE
Adds instruction on how to include extension version

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -12,8 +12,9 @@ assignees: ''
 <!-- Please search existing issues to avoid creating duplicates. -->
 
 **Environment (please complete the following information):**
- - OS: [e.g. iOS]
- - Extension version [e.g. 22]
+ - OS (*e.g.,* Windows 10):
+ - Extension version (*e.g.,* 1.2.3):
+<!-- The extension version can be found by hovering or selecting "Microsoft Edge Tools for VS Code" in the VS Code Extensions Marketplace panel. -->
 
 **Describe the bug:**
 <!-- A clear and concise description of what the bug is -->


### PR DESCRIPTION
Changes iOS as a suggested environment (since I don't believe that one is supported), updates version number sample in #.#.# format, and adds a commented instruction to the user on how to find extension version in VS Code. 

Suggesting this edit because I initially had a hard time finding the version number for the extension when filing a bug, and I accidentally included the version number for the debugger extension instead. 😅