### PR TITLE
[Screencast]: Adding spacing and border to standalone screencast toolbar

### DIFF
--- a/src/screencast/view.css
+++ b/src/screencast/view.css
@@ -21,6 +21,8 @@ body {
 #toolbar {
   display: flex;
   width: 100%;
+  padding-bottom: 4px;
+  border-bottom: 1px solid var(--vscode-editorGroup-border);
 }
 
 #toolbar>button,
@@ -28,7 +30,6 @@ body {
   background-color: var(--vscode-editor-background);
   border: none;
   color: var(--vscode-editor-foreground);
-  padding-bottom: 4px;
 }
 
 #url {


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/14304598/136869130-5afd86fd-f493-4910-ba0a-908fbd2e89ab.png)
![image](https://user-images.githubusercontent.com/14304598/136869082-2100459f-9230-4b41-97e0-1574a6da2a47.png)

After:
![image](https://user-images.githubusercontent.com/14304598/136868975-0bc98941-a9d3-4d6a-a3a9-2888e1851f57.png)
![image](https://user-images.githubusercontent.com/14304598/136869036-7e208b27-db21-4b0b-88b2-b59a1e1c0779.png)
