### PR TITLE
[Screencast]: Update screencast emulation when target is resized

### DIFF
--- a/src/screencast/screencast.ts
+++ b/src/screencast/screencast.ts
@@ -64,7 +64,7 @@ export class Screencast {
             this.updateEmulation();
         });
 
-        this.cdpConnection.registerForEvent('Page.domContentEventFired', () => this.onDomContentEventFired());
+        this.cdpConnection.registerForEvent('Page.frameNavigated', result => this.onFrameNavigated(result));
         this.cdpConnection.registerForEvent('Page.screencastFrame', result => this.onScreencastFrame(result));
 
         this.inputHandler = new ScreencastInputHandler(this.cdpConnection);
@@ -182,14 +182,16 @@ export class Screencast {
         }
     }
 
-    private onDomContentEventFired(): void {
-        setTimeout(() => this.updateEmulation(), 100);
-    }
-
     private onForwardClick(): void {
         if (this.historyIndex < this.history.length - 1) {
             const entryId = this.history[this.historyIndex + 1].id;
             this.cdpConnection.sendMessageToBackend('Page.navigateToHistoryEntry', {entryId})
+        }
+    }
+
+    private onFrameNavigated({frame}: any): void {
+        if (!frame.parentId) {
+            this.updateHistory();
         }
     }
 


### PR DESCRIPTION
Issue:
- When in non-headless mode, resizing the target window will result in an unexpected viewport for the screencast.  In general, we can fix this by resizing, refreshing or turning the screencast off/on.

Changes:
- The screencast now properly resizes when the returned screencast image size is not the expected viewport size.
- Deleted frame navigated logic, as this fix should cover navigation cases as well.

![focus-resize-fix2](https://user-images.githubusercontent.com/14304598/137413579-df5a8c39-f4b8-4aff-b239-30619826d936.gif)


