### PR TITLE
Remove legacy Edge Debugger to address potential target list bug

### DIFF
--- a/package.json
+++ b/package.json
@@ -228,11 +228,6 @@
                     "description": "Use JavaScript source maps (if they exist)",
                     "default": true
                 },
-                "vscode-edge-devtools.autoAttachViaDebuggerForEdge": {
-                    "type": "boolean",
-                    "description": "Auto attach the Microsoft Edge Tools extension when you launch a browser with the Debugger For Microsoft Edge debug adapter extension",
-                    "default": true
-                },
                 "vscode-edge-devtools.enableNetwork": {
                     "type": "boolean",
                     "description": "Enable network panel (requires relaunching extension)",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -293,7 +293,7 @@ export async function attach(
 
     // If there is no response after the timeout then throw an exception
     if (responseArray.length === 0) {
-        void ErrorReporter.showInformationDialog({
+        void ErrorReporter.showErrorDialog({
             errorCode: ErrorCodes.Error,
             title: 'Error while fetching list of available targets',
             message: exceptionStack || 'No available targets to attach.',

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -293,7 +293,7 @@ export async function attach(
 
     // If there is no response after the timeout then throw an exception
     if (responseArray.length === 0) {
-        void ErrorReporter.showErrorDialog({
+        void ErrorReporter.showInformationDialog({
             errorCode: ErrorCodes.Error,
             title: 'Error while fetching list of available targets',
             message: exceptionStack || 'No available targets to attach.',

--- a/src/launchConfigManager.ts
+++ b/src/launchConfigManager.ts
@@ -52,7 +52,7 @@ export class LaunchConfigManager {
             // Check if there is a supported debug config
             const configs = vscode.workspace.getConfiguration('launch', workspaceUri).get('configurations') as vscode.DebugConfiguration[];
             for (const config of configs) {
-                if (config.type === 'vscode-edge-devtools.debug' || config.type === 'msedge' || config.type === 'edge') {
+                if (config.type === 'vscode-edge-devtools.debug' || config.type === 'pwa-msedge') {
                     void vscode.commands.executeCommand('setContext', 'launchJsonStatus', 'Supported');
                     this.launchConfig = config;
                     this.isValidConfig = true;

--- a/src/launchDebugProvider.ts
+++ b/src/launchDebugProvider.ts
@@ -5,8 +5,6 @@ import * as vscode from 'vscode';
 import TelemetryReporter from 'vscode-extension-telemetry';
 import {
     IUserConfig,
-    SETTINGS_DEFAULT_ATTACH_INTERVAL,
-    SETTINGS_DEFAULT_EDGE_DEBUGGER_PORT,
     SETTINGS_STORE_NAME,
 } from './utils';
 import { providedDebugConfig } from './launchConfigManager';
@@ -59,21 +57,8 @@ export class LaunchDebugProvider implements vscode.DebugConfigurationProvider {
                 this.telemetryReporter.sendTelemetryEvent('debug/launch');
                 void this.launch(this.context, targetUri, userConfig);
             }
-        } else if (config && (config.type === 'edge' || config.type === 'msedge')) {
-            const settings = vscode.workspace.getConfiguration(SETTINGS_STORE_NAME);
-            if (settings.get('autoAttachViaDebuggerForEdge')) {
-                if (!userConfig.port) {
-                    userConfig.port = SETTINGS_DEFAULT_EDGE_DEBUGGER_PORT;
-                }
-                if (userConfig.urlFilter) {
-                    userConfig.url = userConfig.urlFilter;
-                }
-
-                // Allow the debugger to actually launch the browser before attaching
-                setTimeout(() => {
-                    void this.attach(this.context, userConfig.url, userConfig, /* useRetry=*/ true);
-                }, SETTINGS_DEFAULT_ATTACH_INTERVAL);
-            }
+        } else if (config && config.type === 'pwa-msedge') {
+            // Launch using JsDebugger
             return Promise.resolve(config);
         } else {
             this.telemetryReporter.sendTelemetryEvent('debug/error/config_not_found');

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -224,7 +224,8 @@ export async function getListOfTargets(hostname: string, port: number, useHttps:
             if (jsonResponse) {
                 break;
             }
-        } catch (e) {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        } catch (e: any) {
             // localhost might not be ready as the user might not have a server running
             // so just show an error dialog for any other condition.
             // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -228,8 +228,6 @@ export async function getListOfTargets(hostname: string, port: number, useHttps:
             // localhost might not be ready as the user might not have a server running
             // so just show an error dialog for any other condition.
             // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-            // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-            // @ts-ignore specific case for ECONNREFUSED.
             if (e && e.code && e.code === 'ECONNREFUSED'){
                 continue;
             }

--- a/test/launchDebugProvider.test.ts
+++ b/test/launchDebugProvider.test.ts
@@ -51,32 +51,6 @@ describe("launchDebugProvider", () => {
             expect(attach).toHaveBeenCalled();
         });
 
-        it("calls attach on edge debugger", async () => {
-            jest.useFakeTimers();
-
-            // Mock out the settings
-            const expectedSettings = {
-                autoAttachViaDebuggerForEdge: true,
-                debugAttachTimeoutMs: 3000,
-            };
-            const configMock = {
-                get: (name: string) => (expectedSettings as any)[name],
-            };
-            const vscodeMock = await jest.requireMock("vscode");
-            vscodeMock.workspace.getConfiguration.mockImplementationOnce(() => configMock);
-
-            // Use an edge debugger config
-            const mockConfig = {
-                name: "config",
-                request: "launch",
-                type: "edge",
-                urlFilter: "http://localhost/index.html",
-            };
-            await host.resolveDebugConfiguration(undefined, mockConfig, undefined);
-            jest.runAllTimers();
-            expect(attach).toHaveBeenCalledWith(expect.any(Object), mockConfig.urlFilter, mockConfig, true);
-        });
-
         it("calls launch", async () => {
             const mockConfig = {
                 name: "config",


### PR DESCRIPTION
This PR removes support for the legacy Debugger for Edge extension from the Tools extension. I believe this will help mitigate the occurences of the "No available targets found" error when attempting to use the "attach" entrypoint as described in: https://github.com/microsoft/vscode-edge-devtools/issues/501

