### PR TITLE
Show overlay when screencast is inactive

### DIFF
--- a/src/screencast/screencast.ts
+++ b/src/screencast/screencast.ts
@@ -24,6 +24,7 @@ export class Screencast {
     private screencastImage: HTMLImageElement;
     private screencastWrapper: HTMLElement;
     private deviceSelect: HTMLSelectElement;
+    private inactiveOverlay: HTMLElement;
     private fixedWidth = 0;
     private fixedHeight = 0;
     private inspectMode = false;
@@ -37,6 +38,7 @@ export class Screencast {
         this.screencastImage = document.getElementById('canvas') as HTMLImageElement;
         this.screencastWrapper = document.getElementById('canvas-wrapper') as HTMLElement;
         this.deviceSelect = document.getElementById('device') as HTMLSelectElement;
+        this.inactiveOverlay = document.getElementById('inactive-overlay') as HTMLElement;
 
         this.backButton.addEventListener('click', () => this.onBackClick());
         this.forwardButton.addEventListener('click', () => this.onForwardClick());
@@ -67,6 +69,7 @@ export class Screencast {
 
         this.cdpConnection.registerForEvent('Page.frameNavigated', result => this.onFrameNavigated(result));
         this.cdpConnection.registerForEvent('Page.screencastFrame', result => this.onScreencastFrame(result));
+        this.cdpConnection.registerForEvent('Page.screencastVisibilityChanged', result => this.onScreencastVisibilityChanged(result));
 
         // This message comes from the DevToolsPanel instance.
         this.cdpConnection.registerForEvent('DevTools.toggleInspect', result => this.onToggleInspect(result));
@@ -235,6 +238,10 @@ export class Screencast {
             this.updateEmulation();
         }
         this.cdpConnection.sendMessageToBackend('Page.screencastFrameAck', {sessionId});
+    }
+
+    private onScreencastVisibilityChanged({visible}: {visible: boolean}): void {
+        this.inactiveOverlay.hidden = visible;
     }
 
     private onToggleInspect({ enabled }: any): void {

--- a/src/screencast/view.css
+++ b/src/screencast/view.css
@@ -60,3 +60,22 @@ body {
 #canvas.touch {
   cursor: -webkit-image-set(url('../../resources/Images/touchCursor.png') 1x, url('../../resources/Images/touchCursor_2x.png') 2x), default;
 }
+
+#inactive-overlay {
+  backdrop-filter: blur(2px);
+  background-color: rgba(0,0,0,0.5);
+  font-size: 200%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  text-shadow: 2px 2px 5px #000;
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+}
+
+#inactive-overlay[hidden] {
+  display: none;
+}

--- a/src/screencast/view.ts
+++ b/src/screencast/view.ts
@@ -52,6 +52,9 @@ export class ScreencastView {
               <img id="canvas" draggable="false" tabindex="0" />
           </div>
       </div>
+      <div id="inactive-overlay" hidden>
+        The tab is inactive
+      </div>
   </body>
   </html>
   `;


### PR DESCRIPTION
Listens for screencast visibility to change via CDP and toggles an overlay to clearly indicate when the tab is inactive. This matches the built-in screencast for devtools and avoids user confusion trying to interact with the screencast when it won't work.

![image](https://user-images.githubusercontent.com/785009/139112605-bba577c0-de4d-4522-9d4b-e2ede848f399.png)
