### PR TITLE
[Screencast] Handle user-agent emulation

### DIFF
--- a/src/screencast/screencast.ts
+++ b/src/screencast/screencast.ts
@@ -147,6 +147,12 @@ export class Screencast {
             maxTouchPoints: 1,
         };
 
+        if (this.deviceUserAgent().length > 0) {
+            this.cdpConnection.sendMessageToBackend('Emulation.setUserAgentOverride', {
+                userAgent: this.deviceUserAgent(),
+            });
+        }
+
         this.cdpConnection.sendMessageToBackend('Emulation.setDeviceMetricsOverride', deviceMetricsParams);
         this.cdpConnection.sendMessageToBackend('Emulation.setTouchEmulationEnabled', touchEmulationParams);
         this.toggleTouchMode();
@@ -174,6 +180,14 @@ export class Screencast {
     private isDeviceTouch(){
         const selectedOption = this.deviceSelect[this.deviceSelect.selectedIndex];
         return selectedOption.getAttribute('touch') === 'true' || selectedOption.getAttribute('mobile') === 'true';
+    }
+
+    private deviceUserAgent() {
+        if (this.deviceSelect.value.toLowerCase() === 'desktop') {
+            return navigator.userAgent;
+        }
+        const selectedOption = this.deviceSelect[this.deviceSelect.selectedIndex];
+        return unescape(selectedOption.getAttribute('userAgent') || '');
     }
 
     private updateScreencast(): void {

--- a/src/screencast/screencast.ts
+++ b/src/screencast/screencast.ts
@@ -147,12 +147,9 @@ export class Screencast {
             maxTouchPoints: 1,
         };
 
-        if (this.deviceUserAgent().length > 0) {
-            this.cdpConnection.sendMessageToBackend('Emulation.setUserAgentOverride', {
-                userAgent: this.deviceUserAgent(),
-            });
-        }
-
+        this.cdpConnection.sendMessageToBackend('Emulation.setUserAgentOverride', {
+            userAgent: this.deviceUserAgent(),
+        });
         this.cdpConnection.sendMessageToBackend('Emulation.setDeviceMetricsOverride', deviceMetricsParams);
         this.cdpConnection.sendMessageToBackend('Emulation.setTouchEmulationEnabled', touchEmulationParams);
         this.toggleTouchMode();
@@ -184,7 +181,7 @@ export class Screencast {
 
     private deviceUserAgent() {
         if (this.deviceSelect.value.toLowerCase() === 'desktop') {
-            return navigator.userAgent;
+            return '';
         }
         const selectedOption = this.deviceSelect[this.deviceSelect.selectedIndex];
         return unescape(selectedOption.getAttribute('userAgent') || '');

--- a/src/screencast/view.ts
+++ b/src/screencast/view.ts
@@ -71,7 +71,7 @@ export class ScreencastView {
 
         for (const device of devicesArray) {
             // @ts-ignore ignoring as this is a static template.
-            templatedString += `<option deviceWidth=${device.screen.vertical.width} deviceHeight=${device.screen.vertical.height} ${ScreencastView.getDeviceCapabilities(device.capabilities)} value="${ScreencastView.getDeviceValueFromTitle(device.title)}">${device.title}</option>`;
+            templatedString += `<option deviceWidth=${device.screen.vertical.width} deviceHeight=${device.screen.vertical.height} ${ScreencastView.getDeviceCapabilities(device.capabilities)} userAgent=${escape(device['user-agent'])} value="${ScreencastView.getDeviceValueFromTitle(device.title)}">${device.title}</option>`;
         }
 
         return templatedString;


### PR DESCRIPTION
This patch sends `user-agent` overrides to the debug target when device
is changed in standalone screencast.