### PR TITLE
[Telemetry]: Re-implement screencast telemetry

### DIFF
--- a/src/devtoolsPanel.ts
+++ b/src/devtoolsPanel.ts
@@ -506,7 +506,7 @@ export class DevToolsPanel {
             DevToolsPanel.instance = new DevToolsPanel(panel, context, telemetryReporter, targetUrl, config);
             if (isHeadlessEnabled()) {
                 if (!ScreencastPanel.instance) {
-                    ScreencastPanel.createOrShow(context, targetUrl);
+                    ScreencastPanel.createOrShow(context, telemetryReporter, targetUrl);
                 }
             }
         }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -135,7 +135,7 @@ export function activate(context: vscode.ExtensionContext): void {
             }
             telemetryReporter.sendTelemetryEvent('user/buttonPress', { 'VSCode.buttonCode': buttonCode.toggleScreencast });
             telemetryReporter.sendTelemetryEvent('view/screencast');
-            ScreencastPanel.createOrShow(context, target.websocketUrl);
+            ScreencastPanel.createOrShow(context,  telemetryReporter, target.websocketUrl);
         }));
 
     context.subscriptions.push(vscode.commands.registerCommand(

--- a/src/screencast/cdp.ts
+++ b/src/screencast/cdp.ts
@@ -27,16 +27,18 @@ export class ScreencastCDPConnection {
             parseMessageFromChannel(e.data, (eventName, args) => {
                 if (eventName === 'websocket') {
                     const { message } = JSON.parse(args) as { message: string };
-                    // Handle event responses
-                    const messageObj = JSON.parse(message) as CdpMessage;
-                    for (const callback of this.eventCallbackMap.get(messageObj.method) || []) {
-                        callback(messageObj.params);
-                    }
-                    // Handle method responses
-                    const methodCallback = this.methodCallbackMap.get(messageObj.id);
-                    if (methodCallback) {
-                        methodCallback(messageObj.result);
-                        this.methodCallbackMap.delete(messageObj.id);
+                    if (message) {
+                        // Handle event responses
+                        const messageObj = JSON.parse(message) as CdpMessage;
+                        for (const callback of this.eventCallbackMap.get(messageObj.method) || []) {
+                            callback(messageObj.params);
+                        }
+                        // Handle method responses
+                        const methodCallback = this.methodCallbackMap.get(messageObj.id);
+                        if (methodCallback) {
+                            methodCallback(messageObj.result);
+                            this.methodCallbackMap.delete(messageObj.id);
+                        }
                     }
                     return true;
                 }

--- a/src/screencastPanel.ts
+++ b/src/screencastPanel.ts
@@ -71,8 +71,6 @@ export class ScreencastPanel {
         this.telemetryReporter.sendTelemetryEvent(
             `devtools/${actionName}`,
             properties);
-        // eslint-disable-next-line no-console
-        console.log({name: `devtools/${actionName}`, properties});
     }
 
     private recordPerformanceHistogram(actionName: string, duration: number) {
@@ -82,8 +80,6 @@ export class ScreencastPanel {
             `devtools/${actionName}`,
             undefined,
             measures);
-        // eslint-disable-next-line no-console
-        console.log({name: `devtools/${actionName}`, measures});
     }
 
     dispose(): void {


### PR DESCRIPTION
This PR re-implements these two telemetry events in the new standalone screencast:

  - `DevTools.ScreencastToggle`
      - This fires on each button press and shows whether the view is shown / hidden
          - Show: `devtools/DevTools.ScreencastToggle: {"DevTools.ScreencastToggle.actionCode":"1"}`
          - Hide: `devtools/DevTools.ScreencastToggle: {"DevTools.ScreencastToggle.actionCode":"0"}`
  - `DevTools.ScreencastDuration`
      - This fires when the screencast is toggled off and shows the session time in ms
          - `devtools/DevTools.ScreencastDuration: undefined, {"DevTools.ScreencastDuration.duration":1001}` 