### PR TITLE
[Webhint]: Update version to 1.6.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6398,9 +6398,9 @@
             "integrity": "sha512-8TEXQxlldWAuIODdukIb+TR5s+9Ds40eSJrw+1iDDA9IFORPjMELarNQE3myz5XIkWWpdprmJjm1/SxMlWOC8A=="
         },
         "vscode-webhint": {
-            "version": "1.6.0",
-            "resolved": "https://registry.npmjs.org/vscode-webhint/-/vscode-webhint-1.6.0.tgz",
-            "integrity": "sha512-Wib0fMSrQATj1RTREQ28yLcNKzxmN5h0k3AZCYbXkyHZFYOveAzIGgnsTHQCYYo1PvVAF5w0J7zNtPOdw/Y+iw=="
+            "version": "1.6.3",
+            "resolved": "https://registry.npmjs.org/vscode-webhint/-/vscode-webhint-1.6.3.tgz",
+            "integrity": "sha512-s3xagYt+CrEswOnzQCm3AqXJEv1qX36IB6JG7BZAkV24a7HOxL0VTi0CbDQUwMY4ewwNqxvhMg3XWIRq3toMmg=="
         },
         "w3c-hr-time": {
             "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -708,7 +708,7 @@
         "utf-8-validate": "5.0.6",
         "vscode-chrome-debug-core": "6.8.11",
         "vscode-extension-telemetry": "0.4.1",
-        "vscode-webhint": "1.6.0",
+        "vscode-webhint": "1.6.3",
         "ws": "8.2.2",
         "xmlhttprequest": "1.8.0"
     },


### PR DESCRIPTION
Updating webhint to version 1.6.3 to fix bug where static analysis squigglies would only underline the first character of the report instead of the entire word