### PR TITLE
[Screencast]: Register for CDP events when using with js-debug proxy

### DIFF
--- a/src/devtoolsPanel.ts
+++ b/src/devtoolsPanel.ts
@@ -214,7 +214,8 @@ export class DevToolsPanel {
 
     private toggleScreencast() {
         const websocketUrl = this.targetUrl;
-        void vscode.commands.executeCommand(`${SETTINGS_VIEW_NAME}.toggleScreencast`, { websocketUrl });
+        const isJsDebugProxiedCDPConnection = this.config.isJsDebugProxiedCDPConnection;
+        void vscode.commands.executeCommand(`${SETTINGS_VIEW_NAME}.toggleScreencast`, { websocketUrl }, isJsDebugProxiedCDPConnection);
     }
 
     private onSocketTelemetry(message: string) {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -127,7 +127,7 @@ export function activate(context: vscode.ExtensionContext): void {
 
     context.subscriptions.push(vscode.commands.registerCommand(
         `${SETTINGS_VIEW_NAME}.toggleScreencast`,
-        (target?: CDPTarget) => {
+        (target?: CDPTarget, isJsDebugProxiedCDPConnection = false) => {
             if (!target){
                 const errorMessage = 'No target selected';
                 telemetryReporter.sendTelemetryErrorEvent('command/screencast/target', {message: errorMessage});
@@ -135,7 +135,7 @@ export function activate(context: vscode.ExtensionContext): void {
             }
             telemetryReporter.sendTelemetryEvent('user/buttonPress', { 'VSCode.buttonCode': buttonCode.toggleScreencast });
             telemetryReporter.sendTelemetryEvent('view/screencast');
-            ScreencastPanel.createOrShow(context,  telemetryReporter, target.websocketUrl);
+            ScreencastPanel.createOrShow(context,  telemetryReporter, target.websocketUrl, isJsDebugProxiedCDPConnection);
         }));
 
     context.subscriptions.push(vscode.commands.registerCommand(


### PR DESCRIPTION
Fix #687 

Screencast frames were not being received because the corresponding events were not getting forwarded from js-debug over the proxied CDP connection. Sending the js-debug specific request for events fixes the issue per https://github.com/microsoft/vscode-js-debug/blob/main/CDP_SHARE.md, aligning the screencast panel with the existing behavior for the devtools panel.