### PR TITLE
[Screencast]: Fix incorrectly prefixing full URLs with http://

### DIFF
--- a/src/screencast/screencast.ts
+++ b/src/screencast/screencast.ts
@@ -232,7 +232,7 @@ export class Screencast {
     private onUrlKeyDown(event: KeyboardEvent): void {
         let url = this.urlInput.value;
         if (event.key === 'Enter' && url) {
-            if (!url.startsWith('http') || !url.startsWith('file')) {
+            if (!url.startsWith('http') && !url.startsWith('file')) {
                 url = 'http://' + url;
             }
 


### PR DESCRIPTION
Fix #642 

Corrects a minor logic error which was causing http:// to always be added on every check.