### PR TITLE
Warn when using deprecated 'edge' or 'msedge' launch types

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -387,8 +387,8 @@ export async function attach(
         }
     } while (useRetry && Date.now() - startTime < timeout);
 
-    // If there is no response after the timeout then throw an exception
-    if (responseArray.length === 0) {
+    // If there is no response after the timeout then throw an exception (unless for legacy Edge targets which we warned about separately)
+    if (responseArray.length === 0 && config?.type !== 'edge' && config?.type !== 'msedge') {
         void ErrorReporter.showErrorDialog({
             errorCode: ErrorCodes.Error,
             title: 'Error while fetching list of available targets',

--- a/src/launchDebugProvider.ts
+++ b/src/launchDebugProvider.ts
@@ -62,10 +62,10 @@ export class LaunchDebugProvider implements vscode.DebugConfigurationProvider {
         } else if (config && (config.type === 'edge' || config.type === 'msedge')) {
             void vscode.window.showWarningMessage(
                 `Launch type "${config.type}" is deprecated. Update your launch.json to use "pwa-msedge" instead.`, 'Learn More', 'OK'
-            ).then((value) => {
+            ).then(value => {
                 if (value === 'Learn More') {
                     const uri = vscode.Uri.parse('https://code.visualstudio.com/docs/nodejs/browser-debugging');
-                    vscode.env.openExternal(uri);
+                    void vscode.env.openExternal(uri);
                 }
             });
             const settings = vscode.workspace.getConfiguration(SETTINGS_STORE_NAME);

--- a/src/launchDebugProvider.ts
+++ b/src/launchDebugProvider.ts
@@ -60,6 +60,14 @@ export class LaunchDebugProvider implements vscode.DebugConfigurationProvider {
                 void this.launch(this.context, targetUri, userConfig);
             }
         } else if (config && (config.type === 'edge' || config.type === 'msedge')) {
+            void vscode.window.showWarningMessage(
+                `Launch type "${config.type}" is deprecated. Update your launch.json to use "pwa-msedge" instead.`, 'Learn More', 'OK'
+            ).then((value) => {
+                if (value === 'Learn More') {
+                    const uri = vscode.Uri.parse('https://code.visualstudio.com/docs/nodejs/browser-debugging');
+                    vscode.env.openExternal(uri);
+                }
+            });
             const settings = vscode.workspace.getConfiguration(SETTINGS_STORE_NAME);
             if (settings.get('autoAttachViaDebuggerForEdge')) {
                 if (!userConfig.port) {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -50,6 +50,7 @@ export interface IUserConfig {
     sourceMapPathOverrides: IStringDictionary<string>;
     sourceMaps: boolean;
     timeout: number;
+    type: string;
     defaultEntrypoint: string;
 }
 

--- a/test/helpers/helpers.ts
+++ b/test/helpers/helpers.ts
@@ -80,6 +80,7 @@ export function createFakeVSCode() {
             showQuickPick: jest.fn().mockResolvedValue(null),
             showTextDocument: jest.fn(),
             showInformationMessage: jest.fn(),
+            showWarningMessage: jest.fn().mockResolvedValue(new Promise(()=>{})),
         },
         workspace: {
             createFileSystemWatcher: jest.fn(),


### PR DESCRIPTION
Also suppress prompting for error reports for missing targets in these cases as switching to `pwa-msedge` is the correct fix.

Displayed warning (shows "edge" or "msedge" depending on actual target type used):
![image](https://user-images.githubusercontent.com/785009/143140756-bd88cd8c-8766-4f62-8db1-83b2ef67f1b8.png)

The "Learn More" button opens the VS Code documentation on debugging browsers which discusses the correct target types to use: https://code.visualstudio.com/docs/nodejs/browser-debugging