### PR TITLE
Silently handle target discovery failures

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -226,19 +226,7 @@ export async function getListOfTargets(hostname: string, port: number, useHttps:
             }
         } catch (e) {
             // localhost might not be ready as the user might not have a server running
-            // so just show an error dialog for any other condition.
-            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-            // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-            // @ts-ignore specific case for ECONNREFUSED.
-            if (e && e.code && e.code === 'ECONNREFUSED'){
-                continue;
-            }
-
-            void ErrorReporter.showErrorDialog({
-                errorCode: ErrorCodes.Error,
-                title: 'Error while getting the list of targets',
-                message: e,
-            });
+            // user may also have changed settings making the endpoint invalid
         }
     }
 


### PR DESCRIPTION
A review of the `Error while getting the list of targets` failures shows the vast majority are various forms of connection errors beyond the current check (followed by a few explicit misconfigurations). These are already gracefully handled. Removing this specific report as a result since it is not leading to the discovery of underlying issues in the extension.