### PR TITLE
Switch to headless by default

### DIFF
--- a/package.json
+++ b/package.json
@@ -263,7 +263,7 @@
                 "vscode-edge-devtools.headless": {
                     "type": "boolean",
                     "description": "Launch Microsoft Edge in headless mode. (requires relaunching Visual Studio Code)",
-                    "default": false
+                    "default": true
                 },
                 "vscode-edge-devtools.browserArgs": {
                     "type": "array",

--- a/src/devtoolsPanel.ts
+++ b/src/devtoolsPanel.ts
@@ -23,7 +23,6 @@ import {
     addEntrypointIfNeeded,
     applyPathMapping,
     fetchUri,
-    isHeadlessEnabled,
     IRuntimeConfig,
     SETTINGS_PREF_DEFAULTS,
     SETTINGS_PREF_NAME,
@@ -482,6 +481,12 @@ export class DevToolsPanel {
         this.devtoolsBaseUri = `https://devtools.azureedge.net/serve_file/${msg.revision || CDN_FALLBACK_REVISION}/vscode_app.html`;
         this.isHeadless = msg.isHeadless;
         this.update();
+
+        if (this.isHeadless) {
+            if (!ScreencastPanel.instance) {
+                ScreencastPanel.createOrShow(this.context, this.telemetryReporter, this.targetUrl);
+            }
+        }
     }
 
 
@@ -505,11 +510,6 @@ export class DevToolsPanel {
             });
 
             DevToolsPanel.instance = new DevToolsPanel(panel, context, telemetryReporter, targetUrl, config);
-            if (isHeadlessEnabled()) {
-                if (!ScreencastPanel.instance) {
-                    ScreencastPanel.createOrShow(context, telemetryReporter, targetUrl);
-                }
-            }
         }
     }
 }


### PR DESCRIPTION
Updates the default value of the headless setting to launch new Edge instances as headless by default, which will automatically trigger the standalone screencast experience. Also fixes opening the screencast when attaching to an existing instance based on whether the instance is headless (instead of the state of the setting). 