### PR TITLE
fix open folder link to be a button

### DIFF
--- a/package.json
+++ b/package.json
@@ -628,7 +628,7 @@
             },
             {
                 "view": "vscode-edge-devtools-view.targets",
-                "contents": "To customize your launch experience, [open a folder](command:vscode.openFolder) and create a launch.json file.",
+                "contents": "To customize your launch experience, open a folder and create a launch.json file. \n[Open Folder](command:vscode.openFolder)",
                 "when": "workbenchState == empty"
             },
             {


### PR DESCRIPTION
Open a folder link was solely identifiable using only color, adding a button helps it be more identifiable. 