### PR TITLE
Refine prompt informing users of errors

### DIFF
--- a/src/errorReporter.ts
+++ b/src/errorReporter.ts
@@ -12,43 +12,20 @@ export class ErrorReporter {
   static async showErrorDialog(
     error: ErrorEventInterface): Promise<void> {
 
-    const template = `<!-- Please delete any private information -->
-        **Version:**
-        ${// eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-          vscode.extensions.getExtension('ms-edgedevtools.vscode-edge-devtools')?.packageJSON.version || 'N/A'}
-
-        **OS:**
-        <!-- Add your hosting platform e.g Microsoft Windows, WSL, MacOs or Linux -->
-
-        **Stack :**
-        ${error.message}
-
-        **Additional context:**
-        <!-- Add any other context or about the problem or screenshots here. -->`;
-
     // cannot do multiline due to:
     // https://github.com/Microsoft/vscode/issues/48900
     const answer = await vscode.window
-      .showErrorMessage(
-        `An error occurred: ${error.title} ${error.message}`,
-        ...['File a bug']
+      .showWarningMessage(
+        `${error.title} ${error.message}`,
+        ...['Check settings', 'Search issues']
       );
 
-    if (answer === 'File a bug') {
-      let base = 'https://github.com/microsoft/vscode-edge-devtools/issues/new?';
-      const params: Map<string, string> = new Map<string, string>();
+    if (answer === 'Check settings') {
+      void vscode.commands.executeCommand('workbench.action.openSettings', '@ext:ms-edgedevtools.vscode-edge-devtools');
+    } else if (answer === 'Search issues') {
+      const searchUrl = `https://github.com/microsoft/vscode-edge-devtools/issues?q=is%3Aissue+is%3Aopen+${error.title}`;
 
-      params.set('title',encodeURIComponent(`[${error.errorCode}] ${error.title}`));
-      params.set('body', encodeURIComponent(template));
-      params.set('labels', 'error');
-
-      // As this are GET request params there is no need to take out the last
-      // ampersand
-      params.forEach((value, key) => {
-        base += `${key}=${value}&`;
-      });
-
-      void vscode.env.openExternal(vscode.Uri.parse(base));
+      void vscode.env.openExternal(vscode.Uri.parse(searchUrl));
     }
   }
 

--- a/test/devtoolsPanel.test.ts
+++ b/test/devtoolsPanel.test.ts
@@ -634,7 +634,7 @@ describe("devtoolsPanel", () => {
                 dtp.DevToolsPanel.createOrShow(context, mockTelemetry, "", mockRuntimeConfig);
 
                 await hookedEvents.get("openInEditor")!(JSON.stringify(expectedRequest));
-                expect(mockVsCode.window.showErrorMessage).toHaveBeenCalled();
+                expect(mockVsCode.window.showWarningMessage).toHaveBeenCalled();
             });
 
             it("calls openTextDocument for onSocketCssMirrorContent", async () => {

--- a/test/helpers/helpers.ts
+++ b/test/helpers/helpers.ts
@@ -80,7 +80,7 @@ export function createFakeVSCode() {
             showQuickPick: jest.fn().mockResolvedValue(null),
             showTextDocument: jest.fn(),
             showInformationMessage: jest.fn(),
-            showWarningMessage: jest.fn().mockResolvedValue(new Promise(()=>{})),
+            showWarningMessage: jest.fn().mockResolvedValue({}),
         },
         workspace: {
             createFileSystemWatcher: jest.fn(),


### PR DESCRIPTION
Use a warning as some issues may be transient. Also suggest
checking settings as we've seen some issues are due to
misconfiguration of the extension. Lastly, direct users to a
search of existing issues with the same error message to
discourage filing duplicates.

Example:
![image](https://user-images.githubusercontent.com/785009/148995155-a64240b9-53bd-4424-8feb-b7c0c39aba82.png)
