### PR TITLE
New stalebot config file

### DIFF
--- a/.github/stale.yaml
+++ b/.github/stale.yaml
@@ -4,7 +4,7 @@
 # Limit this to only issues (not PRs).
 only: issues
 # Number of days of inactivity before an issue becomes stale.
-daysUntilStale: 30
+daysUntilStale: 7
 # Number of days of inactivity before a stale issue is closed.
 daysUntilClose: 7
 # Issues with these labels will never be considered stale.

--- a/.github/stale.yaml
+++ b/.github/stale.yaml
@@ -1,0 +1,23 @@
+# Configuration for stalebot.
+# This bot automatically marks inactive issues as stale, and eventually closes them.
+
+# Limit this to only issues (not PRs).
+only: issues
+# Number of days of inactivity before an issue becomes stale.
+daysUntilStale: 30
+# Number of days of inactivity before a stale issue is closed.
+daysUntilClose: 7
+# Issues with these labels will never be considered stale.
+exemptLabels:
+  - tracked
+# Label to use when marking an issue as stale.
+staleLabel: stale
+# Comment to post when marking an issue as stale. Set to `false` to disable.
+markComment: >
+  This issue has been automatically marked as stale because it hasn't had
+  recent activity. It will be closed if no further activity occurs. Thank you
+  for your contributions.
+# Comment to post when closing a stale issue. Set to `false` to disable.
+closeComment: >
+  This issue has been closed automatically because it hasn't had recent activity.
+  Feel free to re-open it if it's still valid and work is planned.


### PR DESCRIPTION
This is the config file that the Stale github app can rely on if we decide to use it on this repo: https://github.com/apps/stale

Here is how the app works:

* It will consider an issue as stale after 7 days of inactivity (this way if we haven't responded to someone within a week, we get a ping).
* Issues that are considered stale are given the label `stale`.
* After 7 more days of inactivity, the issue is closed.
* Issues with label `tracked` are never considered stale.