### PR TITLE
Bug Fix: create userDataDir if it doesn't exist

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -275,6 +275,9 @@ export function getRemoteEndpointSettings(config: Partial<IUserConfig> = {}): ID
     if (userDataDir === true || (typeof userDataDir === 'undefined' && browserPathSet === 'Default')) {
         // Generate a temp directory
         userDataDir = path.join(os.tmpdir(), `vscode-edge-devtools-userdatadir_${port}`);
+        if (!fse.pathExistsSync(userDataDir)) {
+            fse.mkdirSync(userDataDir);
+        }
     } else if (!userDataDir) {
         // Explicit opt-out
         userDataDir = '';


### PR DESCRIPTION
This fixes the issue where the userDataDir is not found when attempting to launch the Edge instance.  This results in a failure and aborts the launch process.  This only repros when launching the browser instance from our extension (since the failure is from puppeteer and we use puppeteer to launch) and when the user's userDataDir does not exist.
(e.g. `C:\Users\{username}\AppData\Local\Temp\vscode-edge-devtools-userdatadir_9222`)

close #861 