### PR TITLE
Use webRoot config for source path resolution

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -76,8 +76,8 @@ export function activate(context: vscode.ExtensionContext): void {
         void launch(context);
     }));
 
-    context.subscriptions.push(vscode.commands.registerCommand(`${SETTINGS_STORE_NAME}.attachToCurrentDebugTarget`, (debugSessionId): void => {
-        void attachToCurrentDebugTarget(context, debugSessionId);
+    context.subscriptions.push(vscode.commands.registerCommand(`${SETTINGS_STORE_NAME}.attachToCurrentDebugTarget`, (debugSessionId, config): void => {
+        void attachToCurrentDebugTarget(context, debugSessionId, config);
     }));
 
     // Register the launch provider
@@ -398,7 +398,7 @@ export async function attach(
     }
 }
 
-export async function attachToCurrentDebugTarget(context: vscode.ExtensionContext, debugSessionId?: string): Promise<void> {
+export async function attachToCurrentDebugTarget(context: vscode.ExtensionContext, debugSessionId?: string, config?: Partial<IUserConfig>): Promise<void> {
     if (!telemetryReporter) {
         telemetryReporter = createTelemetryReporter(context);
     }
@@ -421,7 +421,7 @@ export async function attachToCurrentDebugTarget(context: vscode.ExtensionContex
     } else if (targetWebsocketUrl) {
         // Auto connect to found target
         telemetryReporter.sendTelemetryEvent('command/attachToCurrentDebugTarget/devtools');
-        const runtimeConfig = getRuntimeConfig();
+        const runtimeConfig = getRuntimeConfig(config);
         runtimeConfig.isJsDebugProxiedCDPConnection = true;
         DevToolsPanel.createOrShow(context, telemetryReporter, targetWebsocketUrl, runtimeConfig);
     } else {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -471,6 +471,11 @@ export function getRuntimeConfig(config: Partial<IUserConfig> = {}): IRuntimeCon
         }
     }
 
+    // The webRoot config is equivalent to a pathMapping entry of { '/': '${webRoot}' }.
+    if (!pathMapping.hasOwnProperty('/')) {
+        pathMapping['/'] = webRoot;
+    }
+
     // replace workspaceFolder with local paths
     const resolvedMappingOverrides: IStringDictionary<string> = {};
     for (const customPathMapped in pathMapping) {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -472,7 +472,7 @@ export function getRuntimeConfig(config: Partial<IUserConfig> = {}): IRuntimeCon
     }
 
     // The webRoot config is equivalent to a pathMapping entry of { '/': '${webRoot}' }.
-    if (!pathMapping.hasOwnProperty('/')) {
+    if (webRoot) {
         pathMapping['/'] = webRoot;
     }
 

--- a/test/utils.test.ts
+++ b/test/utils.test.ts
@@ -721,24 +721,25 @@ describe("utils", () => {
         it("uses user config with workspace", async () => {
             const config = {
                 pathMapping: {
-                    "/app": "${workspaceFolder}/out",
+                    "/app": "${workspaceFolder}/out/app",
                 },
                 sourceMapPathOverrides: {
                     "webpack:///./*": "${webRoot}/*",
                 },
                 sourceMaps: false,
-                webRoot: "/out",
+                webRoot: "${workspaceFolder}/out",
             };
 
             const expectedConfig = {
                 pathMapping: {
-                    "/app": `g:\\GIT\\testPage\\out`,
+                    "/app": `g:\\GIT\\testPage\\out\\app`,
+                    "/": `g:\\GIT\\testPage\\out`
                 },
                 sourceMapPathOverrides: {
-                    "webpack:///./*": "/out/*",
+                    "webpack:///./*": "g:\\GIT\\testPage\\out\\*",
                 },
                 sourceMaps: false,
-                webRoot: "/out",
+                webRoot: "g:\\GIT\\testPage\\out",
             };
 
             const { pathMapping, sourceMapPathOverrides, sourceMaps, webRoot } = utils.getRuntimeConfig(config);
@@ -763,6 +764,7 @@ describe("utils", () => {
             const expectedConfig = {
                 pathMapping: {
                     "/app": `c:\\user\\test\\out`,
+                    "/": `/out`
                 },
                 sourceMapPathOverrides: {
                     "webpack:///./*": "/out/*",


### PR DESCRIPTION
Fixes #787 

The `webRoot` config was not being considered when mapping a URL to a path on the filesystem. This prevented file links in the devtools from successfully opening files in the editor. The fix is to treat `webRoot` as an entry in `pathMapping`.

This fixes the `webRoot` property in Microsoft Edge DevTools' own extension settings, but the extension isn't currently aware of `webRoot` and `pathMapping` properties found in `launch.json` configs. A separate PR https://github.com/microsoft/vscode-js-debug/pull/1206 plumbs those through to our extension so they will work as expected.