### PR TITLE
Fix Min-Browser Version Comparison

### DIFF
--- a/src/versionSocketConnection.ts
+++ b/src/versionSocketConnection.ts
@@ -70,8 +70,8 @@ export class BrowserVersionDetectionSocket extends EventEmitter {
         const productParts = (data.result.product as string).split('/');
         const isHeadless = productParts[0].includes('Headless');
         const versionNum = productParts[1];
-        const currentVersion = versionNum.split('.').map((part) => Number(part));
-        const minSupportedVersion = MIN_SUPPORTED_VERSION.split('.').map((part) => Number(part));
+        const currentVersion = versionNum.split('.').map(part => Number(part));
+        const minSupportedVersion = MIN_SUPPORTED_VERSION.split('.').map(part => Number(part));
         const currentRevision = data.result.revision || '';
         for (let i = 0; i < currentVersion.length; i++) {
             // Loop through from Major to minor numbers

--- a/src/versionSocketConnection.ts
+++ b/src/versionSocketConnection.ts
@@ -70,8 +70,8 @@ export class BrowserVersionDetectionSocket extends EventEmitter {
         const productParts = (data.result.product as string).split('/');
         const isHeadless = productParts[0].includes('Headless');
         const versionNum = productParts[1];
-        const currentVersion = versionNum.split('.');
-        const minSupportedVersion = MIN_SUPPORTED_VERSION.split('.');
+        const currentVersion = versionNum.split('.').map((part) => Number(part));
+        const minSupportedVersion = MIN_SUPPORTED_VERSION.split('.').map((part) => Number(part));
         const currentRevision = data.result.revision || '';
         for (let i = 0; i < currentVersion.length; i++) {
             // Loop through from Major to minor numbers


### PR DESCRIPTION
This patch fixes a bug with the version comparison logic used to
determine which revision of the DevTools frontend to fetch from the CDN.

The previous version comparison logic did not appropriately cast to int
the product could get into a situation where browser version "100" > min_ver.

Fixes #878 