### PR TITLE
[Feature]: Enable console in DevTools

### DIFF
--- a/src/JsDebugProxyPanelSocket.ts
+++ b/src/JsDebugProxyPanelSocket.ts
@@ -26,6 +26,7 @@ export class JsDebugProxyPanelSocket extends PanelSocket {
                 events: [
                 'Runtime.*',
                 'DOM.*',
+                'Console.*',
                 'CSS.*',
                 'DOMDebugger.*',
                 'Network.*',

--- a/src/JsDebugProxyPanelSocket.ts
+++ b/src/JsDebugProxyPanelSocket.ts
@@ -26,7 +26,6 @@ export class JsDebugProxyPanelSocket extends PanelSocket {
                 events: [
                 'Runtime.*',
                 'DOM.*',
-                'Console.*',
                 'CSS.*',
                 'DOMDebugger.*',
                 'Network.*',

--- a/src/common/webviewEvents.ts
+++ b/src/common/webviewEvents.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 export type WebviewEvent = 'getState' | 'getUrl' | 'openInEditor' | 'cssMirrorContent' | 'ready' | 'setState' | 'telemetry' | 'websocket'
-| 'getVscodeSettings' | 'copyText' | 'focusEditor' | 'focusEditorGroup' | 'openUrl' | 'toggleScreencast' | 'toggleInspect';
+| 'getVscodeSettings' | 'copyText' | 'focusEditor' | 'focusEditorGroup' | 'openUrl' | 'toggleScreencast' | 'toggleInspect' | 'replayConsoleMessages';
 export const webviewEventNames: WebviewEvent[] = [
     'getState',
     'getUrl',
@@ -19,10 +19,11 @@ export const webviewEventNames: WebviewEvent[] = [
     'openUrl',
     'toggleScreencast',
     'toggleInspect',
+    'replayConsoleMessages',
 ];
 
 export type FrameToolsEvent = 'sendMessageToBackend' | 'openInNewTab' | 'recordEnumeratedHistogram' |
-'recordPerformanceHistogram' | 'reportError' | 'openInEditor' | 'cssMirrorContent' | 'toggleScreencast';
+'recordPerformanceHistogram' | 'reportError' | 'openInEditor' | 'cssMirrorContent' | 'toggleScreencast' | 'replayConsoleMessages';
 export const FrameToolsEventNames: FrameToolsEvent[] = [
     'sendMessageToBackend',
     'openInNewTab',
@@ -32,6 +33,7 @@ export const FrameToolsEventNames: FrameToolsEvent[] = [
     'recordPerformanceHistogram',
     'reportError',
     'toggleScreencast',
+    'replayConsoleMessages',
 ];
 
 export type WebSocketEvent = 'open' | 'close' | 'error' | 'message';

--- a/src/devtoolsPanel.ts
+++ b/src/devtoolsPanel.ts
@@ -157,7 +157,7 @@ export class DevToolsPanel {
                 this.telemetryReporter.sendTelemetryEvent(`websocket/${e}`);
                 break;
         }
-        if (this.collectConsoleMessages && message && message.indexOf('Runtime.consoleAPICalled') !== -1) {
+        if (this.collectConsoleMessages && message && message.includes('Runtime.consoleAPICalled')) {
             this.consoleMessages.push(message);
         } else {
             encodeMessageForChannel(msg => this.panel.webview.postMessage(msg) as unknown as void, 'websocket', { event: e, message });

--- a/src/host/messageRouter.ts
+++ b/src/host/messageRouter.ts
@@ -95,7 +95,10 @@ export class MessageRouter {
                 this.sendMessageToBackend(cdpMessage);
                 return true;
             case 'toggleScreencast':
-                this.toggleScreencast()
+                this.toggleScreencast();
+                return true;
+            case 'replayConsoleMessages':
+                this.replayConsoleMessages();
                 return true;
             default:
                 // TODO: handle other types of messages from devtools
@@ -163,6 +166,11 @@ export class MessageRouter {
     private toggleScreencast(): void {
         // Forward the data to the extension
         encodeMessageForChannel(msg => vscode.postMessage(msg, '*'), 'toggleScreencast');
+    }
+
+    private replayConsoleMessages(): void {
+        // Forward the data to the extension
+        encodeMessageForChannel(msg => vscode.postMessage(msg, '*'), 'replayConsoleMessages');
     }
 
     private cssMirrorContent(url: string, newContent: string): void {


### PR DESCRIPTION
This PR implements the extension side flow for `replayConsoleMessages`. This method stores any console messages until the DevTools indicates it is ready to receive them and then it replays the messages to the DevTools.

Testing this feature completely requires the nightly build of JS-Debug which can be found here: https://github.com/microsoft/vscode-js-debug/blob/main/README.md#nightly-extension