### PR TITLE
[Feature]: Save last successful DevTools revision to improve reliability

### DIFF
--- a/package.json
+++ b/package.json
@@ -318,6 +318,11 @@
                     "type": "boolean",
                     "default": true,
                     "description": "Enable feedback from webhint on source files to improve accessibility, compatibility, security and more."
+                },
+                "vscode-edge-devtools.fallbackRevision": {
+                    "type": "string",
+                    "default": "@c438621746b2932668109129d137a7e3a22ef4fd",
+                    "description": "Last known good revision used for when we fail to connect to the CDN with the current target revision."
                 }
             }
         },

--- a/src/common/webviewEvents.ts
+++ b/src/common/webviewEvents.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 export type WebviewEvent = 'getState' | 'getUrl' | 'openInEditor' | 'cssMirrorContent' | 'ready' | 'setState' | 'telemetry' | 'websocket'
-| 'getVscodeSettings' | 'copyText' | 'focusEditor' | 'focusEditorGroup' | 'openUrl' | 'toggleScreencast' | 'toggleInspect' | 'replayConsoleMessages';
+| 'getVscodeSettings' | 'copyText' | 'focusEditor' | 'focusEditorGroup' | 'openUrl' | 'toggleScreencast' | 'toggleInspect' | 'replayConsoleMessages' | 'devtoolsConnection';
 export const webviewEventNames: WebviewEvent[] = [
     'getState',
     'getUrl',
@@ -20,6 +20,7 @@ export const webviewEventNames: WebviewEvent[] = [
     'toggleScreencast',
     'toggleInspect',
     'replayConsoleMessages',
+    'devtoolsConnection',
 ];
 
 export type FrameToolsEvent = 'sendMessageToBackend' | 'openInNewTab' | 'recordEnumeratedHistogram' |

--- a/src/devtoolsPanel.ts
+++ b/src/devtoolsPanel.ts
@@ -375,6 +375,9 @@ export class DevToolsPanel {
             // Retry connection with fallback.
             const settingsConfig = vscode.workspace.getConfiguration(SETTINGS_STORE_NAME);
             const fallbackRevision = settingsConfig.get('fallbackRevision') as string;
+            if (this.currentRevision) {
+                this.telemetryReporter.sendTelemetryEvent('websocket/failedConnection', {revision: this.currentRevision});
+            }
             this.setCdnParameters({revision: fallbackRevision, isHeadless: this.isHeadless});
         }
     }

--- a/src/devtoolsPanel.ts
+++ b/src/devtoolsPanel.ts
@@ -5,7 +5,6 @@ import * as vscode from 'vscode';
 import * as debugCore from 'vscode-chrome-debug-core';
 import { performance } from 'perf_hooks';
 import TelemetryReporter from 'vscode-extension-telemetry';
-
 import { SettingsProvider } from './common/settingsProvider';
 import {
     encodeMessageForChannel,
@@ -51,6 +50,7 @@ export class DevToolsPanel {
     static instance: DevToolsPanel | undefined;
     private consoleMessages: string[] = [];
     private collectConsoleMessages = true;
+    private currentRevision: string | undefined;
 
     private constructor(
         panel: vscode.WebviewPanel,
@@ -90,6 +90,7 @@ export class DevToolsPanel {
         this.panelSocket.on('focusEditor', msg => this.onSocketFocusEditor(msg));
         this.panelSocket.on('focusEditorGroup', msg => this.onSocketFocusEditorGroup(msg));
         this.panelSocket.on('replayConsoleMessages', () => this.onSocketReplayConsoleMessages());
+        this.panelSocket.on('devtoolsConnection', success => this.onSocketDevToolsConnection(success));
 
         // This Websocket is only used on initial connection to determine the browser version.
         // The browser version is used to select the correct hashed version of the devtools
@@ -367,6 +368,17 @@ export class DevToolsPanel {
         }
     }
 
+    private onSocketDevToolsConnection(success: string) {
+        if (success === 'true') {
+            void vscode.workspace.getConfiguration(SETTINGS_STORE_NAME).update('fallbackRevision', this.currentRevision, true);
+        } else {
+            // Retry connection with fallback.
+            const settingsConfig = vscode.workspace.getConfiguration(SETTINGS_STORE_NAME);
+            const fallbackRevision = settingsConfig.get('fallbackRevision') as string;
+            this.setCdnParameters({revision: fallbackRevision, isHeadless: this.isHeadless});
+        }
+    }
+
     private async openEditorFromUri(uri: vscode.Uri, line?: number, column?: number): Promise<vscode.TextEditor | undefined> {
         try {
             const doc = await vscode.workspace.openTextDocument(uri);
@@ -494,7 +506,8 @@ export class DevToolsPanel {
     }
 
     private setCdnParameters(msg: {revision: string, isHeadless: boolean}) {
-        this.devtoolsBaseUri = `https://devtools.azureedge.net/serve_file/${msg.revision || CDN_FALLBACK_REVISION}/vscode_app.html`;
+        this.currentRevision = msg.revision || CDN_FALLBACK_REVISION;
+        this.devtoolsBaseUri = `https://devtools.azureedge.net/serve_file/${this.currentRevision}/vscode_app.html`;
         this.isHeadless = msg.isHeadless;
         this.update();
 

--- a/src/host/messageRouter.ts
+++ b/src/host/messageRouter.ts
@@ -24,7 +24,8 @@ const vscode = acquireVsCodeApi();
 export class MessageRouter {
     private toolsFrameWindow: Window | null | undefined;
     private errorMessageDiv: HTMLElement | null | undefined;
-    private devtoolsActionReceived: boolean = false;
+    private devtoolsActionReceived = false;
+    private fallbackAttempt = false;
 
     constructor(webviewWindow: Window) {
         webviewWindow.addEventListener('DOMContentLoaded', () => {
@@ -192,6 +193,10 @@ export class MessageRouter {
         encodeMessageForChannel(msg => vscode.postMessage(msg, '*'), 'telemetry', telemetry);
     }
 
+    private sendDevToolsConnectionStatus(success: boolean) {
+        encodeMessageForChannel(msg => vscode.postMessage(msg, '*'), 'devtoolsConnection', success);
+    }
+
     private fireWebSocketCallback(e: WebSocketEvent, message: string) {
         // Send response message to DevTools
         if (this.toolsFrameWindow && e === 'message') {
@@ -201,9 +206,16 @@ export class MessageRouter {
 
     private showLoadingError() {
         if (this.devtoolsActionReceived || !this.errorMessageDiv) {
+            this.sendDevToolsConnectionStatus(true);
+            this.fallbackAttempt = false;
             return;
         }
         // Show the error message if DevTools has failed to record an action
-        this.errorMessageDiv.classList.remove('hidden');
+        if (!this.fallbackAttempt) {
+            this.sendDevToolsConnectionStatus(false);
+            this.fallbackAttempt = true;
+        } else {
+            this.errorMessageDiv.classList.remove('hidden');
+        }
     }
 }


### PR DESCRIPTION
This PR introduces a new setting called `fallbackRevision`.  This setting is updated each time we successfully connect to the DevTools to store the last known working revision. If the DevTools fails to connect to a target, we fallback on using the revision stored in the `fallbackRevision` setting.

This allows users to reliably use the extension offline and when given a faulty revision hash.