### PR TITLE
[Launch.json]: Update auto-generated launch.json to use current workflows

### DIFF
--- a/src/launchDebugProvider.ts
+++ b/src/launchDebugProvider.ts
@@ -54,7 +54,7 @@ export class LaunchDebugProvider implements vscode.DebugConfigurationProvider {
             const targetUri: string = this.getUrlFromConfig(folder, config);
             if (config.request && config.request === 'attach') {
                 this.telemetryReporter.sendTelemetryEvent('debug/attach');
-                void this.attach(this.context, targetUri, userConfig);
+                void this.attach(this.context, targetUri, userConfig, true);
             } else if (config.request && config.request === 'launch') {
                 this.telemetryReporter.sendTelemetryEvent('debug/launch');
                 void this.launch(this.context, targetUri, userConfig);

--- a/test/launchConfigManager.test.ts
+++ b/test/launchConfigManager.test.ts
@@ -86,7 +86,7 @@ describe("launchConfigManager", () => {
 
         it('inserts a comment after the url property', async () => {
             const fse = jest.requireMock("fs-extra");
-            const expectedText = "startpage\\\\index.html\", // Provide your project's url to finish configuring";
+            const expectedText = '// Provide your project\'s url to finish configuring';
             fse.readFileSync.mockImplementation(() => JSON.stringify(providedDebugConfig));
             const launchConfigManager = LaunchConfigManager.instance;
             await launchConfigManager.configureLaunchJson();

--- a/test/launchConfigManager.test.ts
+++ b/test/launchConfigManager.test.ts
@@ -86,7 +86,7 @@ describe("launchConfigManager", () => {
 
         it('inserts a comment after the url property', async () => {
             const fse = jest.requireMock("fs-extra");
-            const expectedText = '\"url\":\"' + providedDebugConfig.url + '\" // Provide your project\'s url to finish configuring';
+            const expectedText = "startpage\\\\index.html\", // Provide your project's url to finish configuring";
             fse.readFileSync.mockImplementation(() => JSON.stringify(providedDebugConfig));
             const launchConfigManager = LaunchConfigManager.instance;
             await launchConfigManager.configureLaunchJson();

--- a/test/launchDebugProvider.test.ts
+++ b/test/launchDebugProvider.test.ts
@@ -36,7 +36,7 @@ describe("launchDebugProvider", () => {
             const result = await host.provideDebugConfigurations(undefined, undefined);
             expect(result).toBeDefined();
             expect(result![0].request).toEqual("launch");
-            expect(result![0].type).toEqual(`${SETTINGS_STORE_NAME}.debug`);
+            expect(result![0].type).toEqual('pwa-msedge');
         });
     });
 


### PR DESCRIPTION
This PR updates the auto-generated launch.json to include two compound configs and three hidden helper configs.

Hidden Configs:
- `Launch Microsoft Edge` - Launches an instance of MSEdge in remote debugging
- `Launch Microsoft Edge in headless mode` - Same as above but in headless mode
- `Open Edge DevTools` - Launches the DevTools and attaches to a URL

Visible Compound Configs:
- `Launch Edge and attach DevTools` - Compounds `Launch Microsoft Edge` and `Open Edge DevTools`
- `Launch Edge in headless mode and attach DevTools ` - Compounds `Launch Microsoft Edge in headless mode` and `Open Edge DevTools`

The end result looks like this:
![image](https://user-images.githubusercontent.com/14304598/158491968-553f0d5b-8be4-438f-b48e-c7f99df69b02.png)
![launchjson-working](https://user-images.githubusercontent.com/14304598/158492164-15b5497d-d115-454a-97c0-75ee3abc1f82.gif)

