### PR TITLE
[CSS Mirroring] Support CSS Mirroring Enablement from DevTools frontend

### DIFF
--- a/package.json
+++ b/package.json
@@ -157,15 +157,15 @@
                 "title": "Launch project"
             },
             {
-                "command": "vscode-edge-devtools-view.toggleMirrorEditingOn",
+                "command": "vscode-edge-devtools-view.cssMirrorContentOn",
                 "category": "Microsoft Edge Tools",
-                "enablement": "!mirrorEditingEnabled && titleCommandsRegistered",
+                "enablement": "!cssMirrorContent && titleCommandsRegistered",
                 "title": "Toggle mirror editing on for CSS files in workspace"
             },
             {
-                "command": "vscode-edge-devtools-view.toggleMirrorEditingOff",
+                "command": "vscode-edge-devtools-view.cssMirrorContentOff",
                 "category": "Microsoft Edge Tools",
-                "enablement": "mirrorEditingEnabled && titleCommandsRegistered",
+                "enablement": "cssMirrorContent && titleCommandsRegistered",
                 "title": "Toggle mirror editing off for CSS files in workspace"
             }
         ],
@@ -332,7 +332,7 @@
 
                     ]
                 },
-                "vscode-edge-devtools.mirrorEdits": {
+                "vscode-edge-devtools.cssMirrorContent": {
                     "type": "boolean",
                     "default": false,
                     "description": "Enable edits in the styles pane to be automatically applied to the corresponding stylesheet in the workspace. (Only works when targeting Edge Browser versions 94.0.988.0+)"
@@ -639,10 +639,6 @@
                     "name": "Targets"
                 },
                 {
-                    "id": "vscode-edge-devtools-view.mirror-editing",
-                    "name": "CSS Mirror Editing"
-                },
-                {
                     "id": "vscode-edge-devtools-view.help-links",
                     "name": "Helpful links"
                 }
@@ -673,24 +669,6 @@
                 "view": "vscode-edge-devtools-view.targets",
                 "contents": "Launch an instance of Microsoft Edge to begin inspecting and modifying your site.\n[Launch Project](command:vscode-edge-devtools-view.launchProject)",
                 "when": "launchJsonStatus == Supported && isWorkspaceTrusted"
-            },
-            {
-                "view": "vscode-edge-devtools-view.mirror-editing",
-                "contents": "CSS mirror editing is an experimental feature that automatically applies changes made in the DevTools panel to CSS files in your workspace."
-            },
-            {
-                "view": "vscode-edge-devtools-view.mirror-editing",
-                "contents": "Mirror editing is currently OFF.\n[Toggle Mirror Editing On](command:vscode-edge-devtools-view.toggleMirrorEditingOn)",
-                "when": "!mirrorEditingEnabled"
-            },
-            {
-                "view": "vscode-edge-devtools-view.mirror-editing",
-                "contents": "Mirror editing is currently ON.\n[Toggle Mirror Editing Off](command:vscode-edge-devtools-view.toggleMirrorEditingOff)",
-                "when": "mirrorEditingEnabled"
-            },
-            {
-                "view": "vscode-edge-devtools-view.mirror-editing",
-                "contents": "Please help us improve this feature by [leaving feedback here](https://github.com/microsoft/vscode-edge-devtools/issues/476)."
             },
             {
                 "view": "vscode-edge-devtools-view.help-links",

--- a/package.json
+++ b/package.json
@@ -157,16 +157,10 @@
                 "title": "Launch project"
             },
             {
-                "command": "vscode-edge-devtools-view.cssMirrorContentOn",
+                "command": "vscode-edge-devtools-view.cssMirrorContent",
                 "category": "Microsoft Edge Tools",
                 "enablement": "!cssMirrorContent && titleCommandsRegistered",
                 "title": "Toggle mirror editing on for CSS files in workspace"
-            },
-            {
-                "command": "vscode-edge-devtools-view.cssMirrorContentOff",
-                "category": "Microsoft Edge Tools",
-                "enablement": "cssMirrorContent && titleCommandsRegistered",
-                "title": "Toggle mirror editing off for CSS files in workspace"
             }
         ],
         "configuration": {

--- a/package.json
+++ b/package.json
@@ -159,7 +159,7 @@
             {
                 "command": "vscode-edge-devtools-view.cssMirrorContent",
                 "category": "Microsoft Edge Tools",
-                "enablement": "!cssMirrorContent && titleCommandsRegistered",
+                "enablement": "titleCommandsRegistered",
                 "title": "Toggle mirror editing on for CSS files in workspace"
             }
         ],

--- a/src/common/settingsProvider.ts
+++ b/src/common/settingsProvider.ts
@@ -70,6 +70,14 @@ export class SettingsProvider {
     return standaloneScreencast;
   }
 
+  getCSSMirrorContentSettings(): boolean {
+    return vscode.workspace.getConfiguration(SETTINGS_STORE_NAME).get('cssMirrorContent') || false;
+  }
+
+  setCSSMirrorContentSettings(isEnabled: boolean): void {
+    void vscode.workspace.getConfiguration(SETTINGS_STORE_NAME).update('cssMirrorContent', isEnabled, true);
+  }
+
   static get instance(): SettingsProvider {
     if (!SettingsProvider.singletonInstance) {
       SettingsProvider.singletonInstance = new SettingsProvider();

--- a/src/common/webviewEvents.ts
+++ b/src/common/webviewEvents.ts
@@ -2,7 +2,8 @@
 // Licensed under the MIT License.
 
 export type WebviewEvent = 'getState' | 'getUrl' | 'openInEditor' | 'cssMirrorContent' | 'ready' | 'setState' | 'telemetry' | 'websocket'
-| 'getVscodeSettings' | 'copyText' | 'focusEditor' | 'focusEditorGroup' | 'openUrl' | 'toggleScreencast' | 'toggleInspect' | 'replayConsoleMessages' | 'devtoolsConnection';
+| 'getVscodeSettings' | 'copyText' | 'focusEditor' | 'focusEditorGroup' | 'openUrl' | 'toggleScreencast' | 'toggleInspect' | 'replayConsoleMessages'
+| 'devtoolsConnection' | 'toggleCSSMirrorContent';
 export const webviewEventNames: WebviewEvent[] = [
     'getState',
     'getUrl',
@@ -21,10 +22,11 @@ export const webviewEventNames: WebviewEvent[] = [
     'toggleInspect',
     'replayConsoleMessages',
     'devtoolsConnection',
+    'toggleCSSMirrorContent',
 ];
 
 export type FrameToolsEvent = 'sendMessageToBackend' | 'openInNewTab' | 'recordEnumeratedHistogram' |
-'recordPerformanceHistogram' | 'reportError' | 'openInEditor' | 'cssMirrorContent' | 'toggleScreencast' | 'replayConsoleMessages';
+'recordPerformanceHistogram' | 'reportError' | 'openInEditor' | 'cssMirrorContent' | 'toggleScreencast' | 'replayConsoleMessages' | 'toggleCSSMirrorContent';
 export const FrameToolsEventNames: FrameToolsEvent[] = [
     'sendMessageToBackend',
     'openInNewTab',
@@ -35,6 +37,7 @@ export const FrameToolsEventNames: FrameToolsEvent[] = [
     'reportError',
     'toggleScreencast',
     'replayConsoleMessages',
+    'toggleCSSMirrorContent',
 ];
 
 export type WebSocketEvent = 'open' | 'close' | 'error' | 'message';
@@ -74,6 +77,10 @@ export interface IOpenEditorData {
 export interface ICssMirrorContentData {
     url: string;
     newContent: string;
+}
+
+export interface IToggleCSSMirrorContentData {
+    isEnabled: boolean;
 }
 
 /**

--- a/src/devtoolsPanel.ts
+++ b/src/devtoolsPanel.ts
@@ -184,12 +184,7 @@ export class DevToolsPanel {
 
     private onToggleCSSMirrorContent(message: string) {
         const { isEnabled } = JSON.parse(message) as IToggleCSSMirrorContentData;
-
-        if (isEnabled) {
-            void vscode.commands.executeCommand(`${SETTINGS_VIEW_NAME}.cssMirrorContentOn`);
-        } else {
-            void vscode.commands.executeCommand(`${SETTINGS_VIEW_NAME}.cssMirrorContentOff`);
-        }
+        void vscode.commands.executeCommand(`${SETTINGS_VIEW_NAME}.cssMirrorContent`, {isEnabled});
     }
 
     private onSocketMessage(message: string) {

--- a/src/devtoolsPanel.ts
+++ b/src/devtoolsPanel.ts
@@ -12,6 +12,7 @@ import {
     IOpenEditorData,
     ITelemetryMeasures,
     ITelemetryProps,
+    IToggleCSSMirrorContentData,
     TelemetryData,
     WebSocketEvent,
 } from './common/webviewEvents';
@@ -91,6 +92,7 @@ export class DevToolsPanel {
         this.panelSocket.on('focusEditorGroup', msg => this.onSocketFocusEditorGroup(msg));
         this.panelSocket.on('replayConsoleMessages', () => this.onSocketReplayConsoleMessages());
         this.panelSocket.on('devtoolsConnection', success => this.onSocketDevToolsConnection(success));
+        this.panelSocket.on('toggleCSSMirrorContent', msg => this.onToggleCSSMirrorContent(msg) as unknown as void);
 
         // This Websocket is only used on initial connection to determine the browser version.
         // The browser version is used to select the correct hashed version of the devtools
@@ -178,6 +180,16 @@ export class DevToolsPanel {
         this.telemetryReporter.sendTelemetryEvent(
             this.panelSocket.isConnectedToTarget ? 'websocket/reconnect' : 'websocket/connect');
         this.timeStart = performance.now();
+    }
+
+    private onToggleCSSMirrorContent(message: string) {
+        const { isEnabled } = JSON.parse(message) as IToggleCSSMirrorContentData;
+
+        if (isEnabled) {
+            void vscode.commands.executeCommand(`${SETTINGS_VIEW_NAME}.cssMirrorContentOn`);
+        } else {
+            void vscode.commands.executeCommand(`${SETTINGS_VIEW_NAME}.cssMirrorContentOff`);
+        }
     }
 
     private onSocketMessage(message: string) {
@@ -341,7 +353,7 @@ export class DevToolsPanel {
     }
 
     private async onSocketCssMirrorContent(message: string) {
-        if (!vscode.workspace.getConfiguration(SETTINGS_STORE_NAME).get('mirrorEdits')) {
+        if (!SettingsProvider.instance.getCSSMirrorContentSettings()) {
             return;
         }
 
@@ -467,6 +479,7 @@ export class DevToolsPanel {
         const stylesUri = this.panel.webview.asWebviewUri(stylesPath);
 
         const theme = SettingsProvider.instance.getThemeFromUserSetting();
+        const cssMirrorContent = SettingsProvider.instance.getCSSMirrorContentSettings();
         const standaloneScreencast = SettingsProvider.instance.getScreencastSettings();
 
         // The headless query param is used to show/hide the DevTools screencast on launch
@@ -493,7 +506,7 @@ export class DevToolsPanel {
                 ">
             </head>
             <body>
-                <iframe id="devtools-frame" frameBorder="0" src="${cdnBaseUri}?experiments=true&theme=${theme}&headless=${enableScreencast}&standaloneScreencast=${standaloneScreencast}"></iframe>
+                <iframe id="devtools-frame" frameBorder="0" src="${cdnBaseUri}?experiments=true&theme=${theme}&headless=${enableScreencast}&standaloneScreencast=${standaloneScreencast}&cssMirrorContent=${cssMirrorContent}"></iframe>
                 <div id="error-message" class="hidden">
                     <h1>Unable to download DevTools for the current target.</h1>
                     <p>Try these troubleshooting steps:</p>

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -211,24 +211,23 @@ export function activate(context: vscode.ExtensionContext): void {
             void vscode.env.openExternal(vscode.Uri.parse('https://docs.microsoft.com/en-us/microsoft-edge/visual-studio-code/microsoft-edge-devtools-extension'));
         }));
 
-    const settingsConfig = vscode.workspace.getConfiguration(SETTINGS_STORE_NAME);
-    const mirrorEditsEnabled = settingsConfig.get('mirrorEdits');
-    void vscode.commands.executeCommand('setContext', 'mirrorEditingEnabled', mirrorEditsEnabled);
-    context.subscriptions.push(vscode.commands.registerCommand(`${SETTINGS_VIEW_NAME}.toggleMirrorEditingOn`, () => {
-            void settingsConfig.update('mirrorEdits', true, true);
-            void vscode.commands.executeCommand('setContext', 'mirrorEditingEnabled', true);
-        }));
-    context.subscriptions.push(vscode.commands.registerCommand(`${SETTINGS_VIEW_NAME}.toggleMirrorEditingOff`, () => {
-        void settingsConfig.update('mirrorEdits', false, true);
-        void vscode.commands.executeCommand('setContext', 'mirrorEditingEnabled', false);
-        }));
-    void settingsConfig.update('mirrorEdits', true, true);
-    void vscode.commands.executeCommand('setContext', 'mirrorEditingEnabled', true);
+    const cssMirrorContent = SettingsProvider.instance.getCSSMirrorContentSettings();
+    void vscode.commands.executeCommand('setContext', 'cssMirrorContent', cssMirrorContent);
+    context.subscriptions.push(vscode.commands.registerCommand(`${SETTINGS_VIEW_NAME}.cssMirrorContentOn`, () => {
+        SettingsProvider.instance.setCSSMirrorContentSettings(true);
+        void vscode.commands.executeCommand('setContext', 'cssMirrorContent', true);
+    }));
+    context.subscriptions.push(vscode.commands.registerCommand(`${SETTINGS_VIEW_NAME}.cssMirrorContentOff`, () => {
+        SettingsProvider.instance.setCSSMirrorContentSettings(false);
+        void vscode.commands.executeCommand('setContext', 'cssMirrorContent', false);
+    }));
+
     void vscode.commands.executeCommand('setContext', 'titleCommandsRegistered', true);
     void reportFileExtensionTypes(telemetryReporter);
     reportExtensionSettings(telemetryReporter);
     vscode.workspace.onDidChangeConfiguration(event => reportChangedExtensionSetting(event, telemetryReporter));
 
+    const settingsConfig = vscode.workspace.getConfiguration(SETTINGS_STORE_NAME);
     if (settingsConfig.get('webhint')) {
         startWebhint(context);
     }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -213,13 +213,9 @@ export function activate(context: vscode.ExtensionContext): void {
 
     const cssMirrorContent = SettingsProvider.instance.getCSSMirrorContentSettings();
     void vscode.commands.executeCommand('setContext', 'cssMirrorContent', cssMirrorContent);
-    context.subscriptions.push(vscode.commands.registerCommand(`${SETTINGS_VIEW_NAME}.cssMirrorContentOn`, () => {
-        SettingsProvider.instance.setCSSMirrorContentSettings(true);
-        void vscode.commands.executeCommand('setContext', 'cssMirrorContent', true);
-    }));
-    context.subscriptions.push(vscode.commands.registerCommand(`${SETTINGS_VIEW_NAME}.cssMirrorContentOff`, () => {
-        SettingsProvider.instance.setCSSMirrorContentSettings(false);
-        void vscode.commands.executeCommand('setContext', 'cssMirrorContent', false);
+    context.subscriptions.push(vscode.commands.registerCommand(`${SETTINGS_VIEW_NAME}.cssMirrorContent`, (args: {isEnabled: boolean}) => {
+        SettingsProvider.instance.setCSSMirrorContentSettings(args.isEnabled);
+        void vscode.commands.executeCommand('setContext', 'cssMirrorContent', args.isEnabled);
     }));
 
     void vscode.commands.executeCommand('setContext', 'titleCommandsRegistered', true);

--- a/src/host/messageRouter.ts
+++ b/src/host/messageRouter.ts
@@ -101,6 +101,10 @@ export class MessageRouter {
             case 'replayConsoleMessages':
                 this.replayConsoleMessages();
                 return true;
+            case 'toggleCSSMirrorContent':
+                const [isEnabled] = args;
+                this.toggleCSSMirrorContent(isEnabled);
+                return true;
             default:
                 // TODO: handle other types of messages from devtools
                 return false;
@@ -167,6 +171,10 @@ export class MessageRouter {
     private toggleScreencast(): void {
         // Forward the data to the extension
         encodeMessageForChannel(msg => vscode.postMessage(msg, '*'), 'toggleScreencast');
+    }
+
+    private toggleCSSMirrorContent(isEnabled: boolean): void {
+        encodeMessageForChannel(msg => vscode.postMessage(msg, '*'), 'toggleCSSMirrorContent', {isEnabled});
     }
 
     private replayConsoleMessages(): void {

--- a/test/devtoolsPanel.test.ts
+++ b/test/devtoolsPanel.test.ts
@@ -649,7 +649,15 @@ describe("devtoolsPanel", () => {
                     fetchUri: jest.fn().mockRejectedValue(null),
                     isHeadlessEnabled: jest.fn(),
                 };
+                const mockSettingsProvider = {
+                    SettingsProvider: {
+                        instance: {
+                            getCSSMirrorContentSettings: jest.fn().mockImplementation(() => true),
+                        }
+                    }
+                };
                 jest.doMock("../src/utils", () => mockUtils);
+                jest.doMock("../src/common/settingsProvider.ts", () => mockSettingsProvider); 
 
                 const dtp = await import("../src/devtoolsPanel");
                 const { TextEncoder } = require('util');
@@ -661,6 +669,7 @@ describe("devtoolsPanel", () => {
             });
 
             it("calls getVscodeSettings", async () => {
+                jest.dontMock("../src/common/settingsProvider.ts");
                 const expectedId = { id: 0 };
                 const expectedState = { enableNetwork: true, themeString: "System preference", welcome: true, isHeadless: false};
                 (context.workspaceState.get as jest.Mock).mockReturnValue(expectedState);

--- a/test/extension.test.ts
+++ b/test/extension.test.ts
@@ -81,8 +81,8 @@ describe("extension", () => {
             // Activation should add the commands as subscriptions on the context
             newExtension.activate(context);
 
-            expect(context.subscriptions.length).toBe(18);
-            expect(commandMock).toHaveBeenCalledTimes(17);
+            expect(context.subscriptions.length).toBe(17);
+            expect(commandMock).toHaveBeenCalledTimes(16);
             expect(commandMock)
                 .toHaveBeenNthCalledWith(1, `${SETTINGS_STORE_NAME}.attach`, expect.any(Function));
             expect(commandMock)


### PR DESCRIPTION
This patch removes the CSS Mirroring view from the extension panel and
implements the `toggleCSSMirrorContent` host method which toggles the
CSS Mirror content feature in the extensions settings.