### PR TITLE
[Bug Fix]: Swap compound config order so headless is the first option

### DIFF
--- a/src/launchConfigManager.ts
+++ b/src/launchConfigManager.ts
@@ -153,8 +153,8 @@ export class LaunchConfigManager {
 
         // Add compound configs
         const compounds = launchJson.get('compounds') as CompoundConfig[];
-        compounds.push(providedCompoundDebugConfig);
         compounds.push(providedCompoundDebugConfigHeadless);
+        compounds.push(providedCompoundDebugConfig);
         await launchJson.update('compounds', compounds) as unknown as Promise<void>;
 
         // Open launch.json in editor


### PR DESCRIPTION
See https://github.com/microsoft/vscode-edge-devtools/pull/927

New config order:
![image](https://user-images.githubusercontent.com/14304598/159359388-32ba503e-7972-4126-a9fe-ecd37faf0274.png)
