### PR TITLE
[LaunchConfigManager]: Improve logic for configuring existing launch.json

### DIFF
--- a/src/launchConfigManager.ts
+++ b/src/launchConfigManager.ts
@@ -7,7 +7,7 @@ import {
     SETTINGS_STORE_NAME,
     SETTINGS_DEFAULT_URL,
 } from './utils';
-export type LaunchConfig = 'None' | 'Unsupported' | vscode.DebugConfiguration;
+export type LaunchConfig = 'None' | 'Unsupported' | string;
 export type CompoundConfig = {
     name: string,
     configurations: string[],
@@ -64,6 +64,17 @@ const providedCompoundDebugConfigHeadless: CompoundConfig = {
     ],
 };
 
+export const extensionCompoundConfigs: CompoundConfig[] = [
+    providedCompoundDebugConfigHeadless,
+    providedCompoundDebugConfig,
+];
+
+export const extensionConfigs: vscode.DebugConfiguration[] = [
+    providedDebugConfig,
+    providedHeadlessDebugConfig,
+    providedLaunchDevToolsConfig,
+];
+
 export class LaunchConfigManager {
     private launchConfig: LaunchConfig;
     private isValidConfig: boolean;
@@ -102,13 +113,12 @@ export class LaunchConfigManager {
         if (fse.pathExistsSync(filePath)) {
             // Check if there is a supported debug config
             const configs = vscode.workspace.getConfiguration('launch', workspaceUri).get('configurations') as vscode.DebugConfiguration[];
-            for (const config of configs) {
-                if (config.type === 'vscode-edge-devtools.debug' || config.type === 'msedge' || config.type === 'edge') {
-                    void vscode.commands.executeCommand('setContext', 'launchJsonStatus', 'Supported');
-                    this.launchConfig = config;
-                    this.isValidConfig = true;
-                    return;
-                }
+            const compoundConfigs = vscode.workspace.getConfiguration('launch', workspaceUri).get('compounds') as CompoundConfig[];
+            if (this.getMissingConfigs(configs, extensionConfigs).length === 0 && this.getMissingConfigs(compoundConfigs, extensionCompoundConfigs).length === 0) {
+                void vscode.commands.executeCommand('setContext', 'launchJsonStatus', 'Supported');
+                this.launchConfig = extensionCompoundConfigs[0].name; // extensionCompoundConfigs[0].name => 'Launch Edge Headless and attach DevTools'
+                this.isValidConfig = true;
+                return;
             }
             void vscode.commands.executeCommand('setContext', 'launchJsonStatus', 'Unsupported');
             this.launchConfig = 'Unsupported';
@@ -138,10 +148,19 @@ export class LaunchConfigManager {
         // Append a supported debug config to their list of configurations and update workspace configuration
         const launchJson = vscode.workspace.getConfiguration('launch', workspaceUri);
         const configs = launchJson.get('configurations') as vscode.DebugConfiguration[];
-        configs.push(providedDebugConfig);
-        configs.push(providedHeadlessDebugConfig);
-        configs.push(providedLaunchDevToolsConfig);
+        const missingConfigs = this.getMissingConfigs(configs, extensionConfigs);
+        for (const missingConfig of missingConfigs) {
+            configs.push((missingConfig as vscode.DebugConfiguration));
+        }
         await launchJson.update('configurations', configs) as unknown as Promise<void>;
+
+        // Add compound configs
+        const compounds = launchJson.get('compounds') as CompoundConfig[];
+        const missingCompoundConfigs = this.getMissingConfigs(compounds, extensionCompoundConfigs);
+        for (const missingCompoundConfig of missingCompoundConfigs) {
+            compounds.push((missingCompoundConfig as CompoundConfig));
+        }
+        await launchJson.update('compounds', compounds) as unknown as Promise<void>;
 
         // Insert instruction comment
         let launchText = fse.readFileSync(workspaceUri.fsPath + relativePath).toString();
@@ -151,12 +170,6 @@ export class LaunchConfigManager {
         launchText = launchText.replace(re, `${match ? match[0] : ''}${instructions}`);
         fse.writeFileSync(workspaceUri.fsPath + relativePath, launchText);
 
-        // Add compound configs
-        const compounds = launchJson.get('compounds') as CompoundConfig[];
-        compounds.push(providedCompoundDebugConfigHeadless);
-        compounds.push(providedCompoundDebugConfig);
-        await launchJson.update('compounds', compounds) as unknown as Promise<void>;
-
         // Open launch.json in editor
         void vscode.commands.executeCommand('vscode.open', vscode.Uri.joinPath(workspaceUri, relativePath));
         this.updateLaunchConfig();
@@ -164,5 +177,42 @@ export class LaunchConfigManager {
 
     isValidLaunchConfig(): boolean {
         return this.isValidConfig;
+    }
+
+    getMissingConfigs(userConfigs: Record<string, unknown>[], extensionConfigs: Record<string, unknown>[]): Record<string, unknown>[] {
+        const missingConfigs: Record<string, unknown>[] = [];
+        for (const extensionConfig of extensionConfigs) {
+            let configExists = false;
+            for (const userConfig of userConfigs) {
+                if (this.compareConfigs(userConfig, extensionConfig)) {
+                    configExists = true;
+                    break;
+                }
+            }
+            if (!configExists) {
+                missingConfigs.push(extensionConfig);
+            }
+        }
+
+        return missingConfigs;
+    }
+
+    compareConfigs(userConfig: Record<string, unknown>, extensionConfig: Record<string, unknown>): boolean {
+        for (const property of Object.keys(extensionConfig)) {
+            if (property === 'url' || property === 'presentation') {
+                continue;
+            }
+            if (Array.isArray(extensionConfig[property]) && Array.isArray(userConfig[property])) {
+                const userPropertySet = new Set((userConfig[property] as Array<string>));
+                for (const extensionConfigProperty of (extensionConfig[property] as Array<string>)) {
+                    if (!userPropertySet.has(extensionConfigProperty)) {
+                        return false;
+                    }
+                }
+            } else if (userConfig[property] !== extensionConfig[property]) {
+                return false;
+            }
+        }
+        return true;
     }
 }

--- a/test/launchConfigManager.test.ts
+++ b/test/launchConfigManager.test.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 import {createFakeVSCode} from "./helpers/helpers";
-import { LaunchConfigManager, providedDebugConfig} from "../src/launchConfigManager";
+import { extensionCompoundConfigs, extensionConfigs, LaunchConfigManager, providedDebugConfig } from "../src/launchConfigManager";
 
 jest.mock("vscode", () => createFakeVSCode(), { virtual: true });
 jest.mock("fs-extra");
@@ -44,11 +44,17 @@ describe("launchConfigManager", () => {
             fse.pathExistsSync.mockImplementation(() => true);
             vscodeMock.workspace.getConfiguration.mockImplementation(() => {
                 return {
-                    get: (name: string) => [{type: 'vscode-edge-devtools.debug'}]
+                    get: (name: string) => {
+                        if (name === 'configurations') {
+                            return extensionConfigs;
+                        } else {
+                            return extensionCompoundConfigs;
+                        }
+                    }
                 }
             });
             const launchConfigManager = LaunchConfigManager.instance;
-            expect(launchConfigManager.getLaunchConfig()).toEqual({type: 'vscode-edge-devtools.debug'});
+            expect(launchConfigManager.getLaunchConfig()).toEqual('Launch Edge Headless and attach DevTools');
             expect(vscodeMock.commands.executeCommand).toBeCalledWith('setContext', 'launchJsonStatus', 'Supported');
         });
 


### PR DESCRIPTION
Issue:
- Due to the LaunchConfigManager changes in https://github.com/microsoft/vscode-edge-devtools/pull/927, configuring existing `launch.json` files would result in either duplicate or missing entries.

Changes:
- Improve logic for checking for missing configs
    - We now cross reference the user's `launch.json` configuration with our expected configurations.  This allows us to add only the missing configs.
    - This improvement is also passed into the logic to determine if a user's `launch.json` configuration is supported or not unsupported.

Things to test:
- Try running `Configure launch.json` against various `launch.json` files.
    - this includes missing `launch.json`, `launch.json` with some of the configurations, `launch.json` with none of the configurations, etc.
![image](https://user-images.githubusercontent.com/14304598/160506154-84ddd652-75fc-496e-a55b-348e6d649b32.png)
- With the different `launch.json` files, see which ones generate the `Configure launch.json` button. Assuming that all of the extension configs exist, this button shouldn't show up.