### PR TITLE
Warn and pause mirroring CSS if it would override local edits

### DIFF
--- a/src/devtoolsPanel.ts
+++ b/src/devtoolsPanel.ts
@@ -363,7 +363,7 @@ export class DevToolsPanel {
             const textEditor = await this.openEditorFromUri(uri);
             if (textEditor) {
                 const fullRange = this.getDocumentFullRange(textEditor);
-                const isSnapshotSameAsLastMirroredCSS = this.mirroredCSS.get(url) == textEditor.document.getText();
+                const isSnapshotSameAsLastMirroredCSS = this.mirroredCSS.get(url) === textEditor.document.getText();
                 if (!textEditor.document.isDirty || isSnapshotSameAsLastMirroredCSS)
                 {
                     this.mirroredCSS.set(url, newContent);

--- a/src/devtoolsPanel.ts
+++ b/src/devtoolsPanel.ts
@@ -40,6 +40,7 @@ export class DevToolsPanel {
     private readonly context: vscode.ExtensionContext;
     private readonly disposables: vscode.Disposable[] = [];
     private readonly extensionPath: string;
+    private readonly mirroredCSS = new Map<string, string>();
     private readonly panel: vscode.WebviewPanel;
     private readonly telemetryReporter: Readonly<TelemetryReporter>;
     private readonly targetUrl: string;
@@ -362,9 +363,18 @@ export class DevToolsPanel {
             const textEditor = await this.openEditorFromUri(uri);
             if (textEditor) {
                 const fullRange = this.getDocumentFullRange(textEditor);
-                void textEditor.edit(editBuilder => {
-                    editBuilder.replace(fullRange, newContent);
-                });
+                const isSnapshotSameAsLastMirroredCSS = this.mirroredCSS.get(url) == textEditor.document.getText();
+                if (!textEditor.document.isDirty || isSnapshotSameAsLastMirroredCSS)
+                {
+                    this.mirroredCSS.set(url, newContent);
+                    void textEditor.edit(editBuilder => {
+                        editBuilder.replace(fullRange, newContent);
+                    });
+                }
+                else
+                {
+                    void vscode.window.showWarningMessage('DevTools will not mirror CSS changes while there are unsaved direct edits. Save your changes then refresh the target page to re-enable.');
+                }
             }
         } else {
             await ErrorReporter.showErrorDialog({


### PR DESCRIPTION
Currently if a user makes local edits to a CSS file, then makes a change in DevTools without saving and rebuilding, the unsaved changes will be overwritten when mirroring CSS content.

This change adds a check to verify the content in the editor either (1) doesn't have any unsaved changes or (2) has only unsaved changes that match what was previously mirrored from DevTools. If these conditions are not met, then the change from DevTools will not be mirrored and a warning notification will be displayed to the user asking them to save and reload the target page (undoing local changes and retrying will also work).

![image](https://user-images.githubusercontent.com/785009/161619807-cd691aab-ef64-4431-a478-18fa68534a75.png)
