### PR TITLE
Stop debugging session on a headless target when both DevToolsPanel and Screencast are closed

### DIFF
--- a/src/devtoolsPanel.ts
+++ b/src/devtoolsPanel.ts
@@ -150,6 +150,9 @@ export class DevToolsPanel {
                 d.dispose();
             }
         }
+        if (this.isHeadless && !ScreencastPanel.instance) {
+            void vscode.commands.executeCommand('workbench.action.debug.stop');
+        }
     }
 
     private postToDevTools(e: WebSocketEvent, message?: string) {
@@ -520,8 +523,10 @@ export class DevToolsPanel {
         this.currentRevision = msg.revision || CDN_FALLBACK_REVISION;
         this.devtoolsBaseUri = `https://devtools.azureedge.net/serve_file/${this.currentRevision}/vscode_app.html`;
         this.isHeadless = msg.isHeadless;
+        if (ScreencastPanel.instance) {
+            ScreencastPanel.instance.setHeadless(this.isHeadless);
+        }
         this.update();
-
         if (this.isHeadless) {
             if (!ScreencastPanel.instance) {
                 ScreencastPanel.createOrShow(this.context, this.telemetryReporter, this.targetUrl, this.config.isJsDebugProxiedCDPConnection);
@@ -529,6 +534,9 @@ export class DevToolsPanel {
         }
     }
 
+    getHeadless(): boolean {
+        return this.isHeadless;
+    }
 
     static createOrShow(
         context: vscode.ExtensionContext,

--- a/src/devtoolsPanel.ts
+++ b/src/devtoolsPanel.ts
@@ -34,6 +34,7 @@ import {
 import { ErrorReporter } from './errorReporter';
 import { ErrorCodes } from './common/errorCodes';
 import { ScreencastPanel } from './screencastPanel';
+import { providedHeadlessDebugConfig } from './launchConfigManager';
 
 export class DevToolsPanel {
     private readonly config: IRuntimeConfig;
@@ -150,7 +151,7 @@ export class DevToolsPanel {
                 d.dispose();
             }
         }
-        if (this.isHeadless && !ScreencastPanel.instance) {
+        if (!ScreencastPanel.instance && vscode.debug.activeDebugSession?.name.includes(providedHeadlessDebugConfig.name)) {
             void vscode.commands.executeCommand('workbench.action.debug.stop');
         }
     }
@@ -523,19 +524,13 @@ export class DevToolsPanel {
         this.currentRevision = msg.revision || CDN_FALLBACK_REVISION;
         this.devtoolsBaseUri = `https://devtools.azureedge.net/serve_file/${this.currentRevision}/vscode_app.html`;
         this.isHeadless = msg.isHeadless;
-        if (ScreencastPanel.instance) {
-            ScreencastPanel.instance.setHeadless(this.isHeadless);
-        }
         this.update();
+
         if (this.isHeadless) {
             if (!ScreencastPanel.instance) {
                 ScreencastPanel.createOrShow(this.context, this.telemetryReporter, this.targetUrl, this.config.isJsDebugProxiedCDPConnection);
             }
         }
-    }
-
-    getHeadless(): boolean {
-        return this.isHeadless;
     }
 
     static createOrShow(

--- a/src/launchConfigManager.ts
+++ b/src/launchConfigManager.ts
@@ -27,7 +27,7 @@ export const providedDebugConfig: vscode.DebugConfiguration = {
     },
 };
 
-const providedHeadlessDebugConfig: vscode.DebugConfiguration = {
+export const providedHeadlessDebugConfig: vscode.DebugConfiguration = {
     type: 'pwa-msedge',
     name: 'Launch Microsoft Edge in headless mode',
     request: 'launch',

--- a/src/screencastPanel.ts
+++ b/src/screencastPanel.ts
@@ -16,6 +16,7 @@ import {
     SETTINGS_SCREENCAST_WEBVIEW_NAME,
 } from './utils';
 import TelemetryReporter from 'vscode-extension-telemetry';
+import { DevToolsPanel } from './devtoolsPanel';
 
 export class ScreencastPanel {
     private readonly context: vscode.ExtensionContext;
@@ -26,6 +27,7 @@ export class ScreencastPanel {
     private panelSocket: PanelSocket;
     private screencastStartTime;
     static instance: ScreencastPanel | undefined;
+    private isHeadless = false;
 
     private constructor(
         panel: vscode.WebviewPanel,
@@ -69,6 +71,10 @@ export class ScreencastPanel {
         }, this);
 
         this.recordEnumeratedHistogram('DevTools.ScreencastToggle', 1);
+
+        if (DevToolsPanel.instance) {
+            this.isHeadless = DevToolsPanel.instance.getHeadless();
+        }
     }
 
     private recordEnumeratedHistogram(actionName: string, actionCode: number) {
@@ -93,6 +99,13 @@ export class ScreencastPanel {
 
         this.panel.dispose();
         this.panelSocket.dispose();
+        if (!DevToolsPanel.instance && this.isHeadless) {
+            void vscode.commands.executeCommand('workbench.action.debug.stop');
+        }
+    }
+
+    setHeadless(headless: boolean): void {
+        this.isHeadless = headless;
     }
 
     toggleInspect(enabled: boolean): void {

--- a/src/screencastPanel.ts
+++ b/src/screencastPanel.ts
@@ -17,6 +17,7 @@ import {
 } from './utils';
 import TelemetryReporter from 'vscode-extension-telemetry';
 import { DevToolsPanel } from './devtoolsPanel';
+import { providedHeadlessDebugConfig } from './launchConfigManager';
 
 export class ScreencastPanel {
     private readonly context: vscode.ExtensionContext;
@@ -27,7 +28,6 @@ export class ScreencastPanel {
     private panelSocket: PanelSocket;
     private screencastStartTime;
     static instance: ScreencastPanel | undefined;
-    private isHeadless = false;
 
     private constructor(
         panel: vscode.WebviewPanel,
@@ -71,10 +71,6 @@ export class ScreencastPanel {
         }, this);
 
         this.recordEnumeratedHistogram('DevTools.ScreencastToggle', 1);
-
-        if (DevToolsPanel.instance) {
-            this.isHeadless = DevToolsPanel.instance.getHeadless();
-        }
     }
 
     private recordEnumeratedHistogram(actionName: string, actionCode: number) {
@@ -99,13 +95,9 @@ export class ScreencastPanel {
 
         this.panel.dispose();
         this.panelSocket.dispose();
-        if (!DevToolsPanel.instance && this.isHeadless) {
+        if (!DevToolsPanel.instance && vscode.debug.activeDebugSession?.name.includes(providedHeadlessDebugConfig.name)) {
             void vscode.commands.executeCommand('workbench.action.debug.stop');
         }
-    }
-
-    setHeadless(headless: boolean): void {
-        this.isHeadless = headless;
     }
 
     toggleInspect(enabled: boolean): void {

--- a/test/helpers/helpers.ts
+++ b/test/helpers/helpers.ts
@@ -55,7 +55,8 @@ export function createFakeVSCode() {
         debug: {
             registerDebugConfigurationProvider: jest.fn(),
             activeDebugSession: {
-                id: 'vscode-session-debug-id'
+                id: 'vscode-session-debug-id',
+                name: 'someName',
             }
         },
         extensions: {


### PR DESCRIPTION
This PR introduces the behavior where the debugging session ends for a headless target when both the DevToolsPanel and Screencast are disposed. This only stops the debugging session if the active session name matches our launch Edge headless config.

Changes:
- add logic to both DevToolsPanel and ScreencastPanel `dispose` methods that will stop debugging session if the target is headless and both panels are closed.