### PR TITLE
Fix recalculating screencast height when shrinking vertically

### DIFF
--- a/src/screencast/screencast.ts
+++ b/src/screencast/screencast.ts
@@ -24,6 +24,7 @@ export class Screencast {
     private urlInput: HTMLInputElement;
     private screencastImage: HTMLImageElement;
     private screencastWrapper: HTMLElement;
+    private toolbar: HTMLElement;
     private deviceSelect: HTMLSelectElement;
     private inactiveOverlay: HTMLElement;
     private fixedWidth = 0;
@@ -33,12 +34,13 @@ export class Screencast {
     constructor() {
         this.backButton = document.getElementById('back') as HTMLButtonElement;
         this.forwardButton = document.getElementById('forward') as HTMLButtonElement;
-        this.mainWrapper =document.getElementById('main') as HTMLElement;
+        this.mainWrapper = document.getElementById('main') as HTMLElement;
         this.reloadButton = document.getElementById('reload') as HTMLButtonElement;
         this.rotateButton = document.getElementById('rotate') as HTMLButtonElement;
         this.urlInput = document.getElementById('url') as HTMLInputElement;
         this.screencastImage = document.getElementById('canvas') as HTMLImageElement;
         this.screencastWrapper = document.getElementById('canvas-wrapper') as HTMLElement;
+        this.toolbar = document.getElementById('toolbar') as HTMLElement;
         this.deviceSelect = document.getElementById('device') as HTMLSelectElement;
         this.inactiveOverlay = document.getElementById('inactive-overlay') as HTMLElement;
 
@@ -99,7 +101,7 @@ export class Screencast {
     }
 
     get height(): number {
-        return this.fixedHeight || (this.mainWrapper.offsetHeight - 24);
+        return this.fixedHeight || (this.mainWrapper.offsetHeight - this.toolbar.offsetHeight);
     }
 
     private registerInputListeners(): void {

--- a/src/screencast/screencast.ts
+++ b/src/screencast/screencast.ts
@@ -18,6 +18,7 @@ export class Screencast {
     private inputHandler: ScreencastInputHandler;
     private backButton: HTMLButtonElement;
     private forwardButton: HTMLButtonElement;
+    private mainWrapper: HTMLElement;
     private reloadButton: HTMLButtonElement;
     private rotateButton: HTMLButtonElement;
     private urlInput: HTMLInputElement;
@@ -32,6 +33,7 @@ export class Screencast {
     constructor() {
         this.backButton = document.getElementById('back') as HTMLButtonElement;
         this.forwardButton = document.getElementById('forward') as HTMLButtonElement;
+        this.mainWrapper =document.getElementById('main') as HTMLElement;
         this.reloadButton = document.getElementById('reload') as HTMLButtonElement;
         this.rotateButton = document.getElementById('rotate') as HTMLButtonElement;
         this.urlInput = document.getElementById('url') as HTMLInputElement;
@@ -93,11 +95,11 @@ export class Screencast {
     }
 
     get width(): number {
-        return this.fixedWidth || this.screencastWrapper.offsetWidth;
+        return this.fixedWidth || this.mainWrapper.offsetWidth;
     }
 
     get height(): number {
-        return this.fixedHeight || this.screencastWrapper.offsetHeight;
+        return this.fixedHeight || (this.mainWrapper.offsetHeight - 24);
     }
 
     private registerInputListeners(): void {


### PR DESCRIPTION
The screencast wrapper previously used to calculate height would be stretched vertically by taller canvas content, such that when shrinking the screencast panel it never correctly shrunk the content.

Fixed by using an element higher up the ancestor chain as the base for sizing. However, this element includes the toolbar so we have to adjust the resulting size by the toolbar height to compensate.