### PR TITLE
[Settings]: Remove theme settings + add auto-detection for light/dark theme for unsupported vscode themes

### DIFF
--- a/package.json
+++ b/package.json
@@ -289,43 +289,6 @@
                         "Microsoft Edge Tools for VS Code will use Microsoft Edge Canary version"
                     ]
                 },
-                "vscode-edge-devtools.themes": {
-                    "type": "string",
-                    "description": "Set the theme of the Microsoft Edge Tools extension (reload required after changing).",
-                    "enum": [
-                        "System Preference",
-                        "Light",
-                        "Dark",
-                        "Chromium Light",
-                        "Chromium Dark",
-                        "Monokai",
-                        "Monokai Dimmed",
-                        "Solarized Light",
-                        "Solarized Dark",
-                        "Red",
-                        "Quiet Light",
-                        "Abyss",
-                        "Kimbie Dark",
-                        "Tomorrow Night Blue"
-                    ],
-                    "enumDescriptions": [
-                        "Microsoft Edge Tools for VS Code will use the system preferred setting for themes",
-                        "Microsoft Edge Tools for VS Code will use the Edge DevTools Light theme",
-                        "Microsoft Edge Tools for VS Code will use the Edge DevTools Dark theme",
-                        "Microsoft Edge Tools for VS Code will use the Chromium Light theme",
-                        "Microsoft Edge Tools for VS Code will use the Chromium Dark theme",
-                        "Microsoft Edge Tools for VS Code will use the VSCode Monkai theme",
-                        "Microsoft Edge Tools for VS Code will use the VSCode Monkai Dimmed theme",
-                        "Microsoft Edge Tools for VS Code will use the VSCode Solarized Light theme",
-                        "Microsoft Edge Tools for VS Code will use the VSCode Solarized Dark theme",
-                        "Microsoft Edge Tools for VS Code will use the VSCode Red theme",
-                        "Microsoft Edge Tools for VS Code will use the VSCode Quiet Light theme",
-                        "Microsoft Edge Tools for VS Code will use the VSCode Abyss theme",
-                        "Microsoft Edge Tools for VS Code will use the VSCode Kimbie Dark theme",
-                        "Microsoft Edge Tools for VS Code will use the VSCode Tomorrow Night Blue theme"
-
-                    ]
-                },
                 "vscode-edge-devtools.cssMirrorContent": {
                     "type": "boolean",
                     "default": false,

--- a/src/common/settingsProvider.ts
+++ b/src/common/settingsProvider.ts
@@ -2,7 +2,6 @@
 // Licensed under the MIT License.
 import * as vscode from 'vscode';
 import { SETTINGS_STORE_NAME } from '../utils';
-import { ThemeString } from './webviewEvents';
 
 const SUPPORTED_THEMES = new Map<string, string>([
   ['Default Light+', 'default'],
@@ -34,21 +33,17 @@ export class SettingsProvider {
     return networkEnabled;
   }
 
-  // Legacy only: this function returns the theme for the legacy bundled DevTools
-  getThemeSettings(): ThemeString {
-    const settings = vscode.workspace.getConfiguration(SETTINGS_STORE_NAME);
-    const themeString: ThemeString = settings.get('themes') || 'System preference';
-    return themeString;
-  }
-
   // This function returns the theme for the new frame hosted DevTools by:
   // 1. Fetching the User configured Global VSCode theme, return it if supported
   // 2. Fall back to the extension Theme setting selector (light, dark, system preference)
   // 3. Fall back to system preference
   getThemeFromUserSetting(): string {
       const themeSetting = vscode.workspace.getConfiguration().get('workbench.colorTheme') as string;
-      const legacySetting = (vscode.workspace.getConfiguration(SETTINGS_STORE_NAME).get('themes') || '') as string;
-      return SUPPORTED_THEMES.get(themeSetting) || SUPPORTED_THEMES.get(legacySetting) || 'systemPreferred';
+      let theme = SUPPORTED_THEMES.get(themeSetting);
+      if (!theme) {
+        theme = vscode.window.activeColorTheme.kind === 1 ? 'default' : 'dark';
+      }
+      return theme;
   }
 
   getWelcomeSettings(): boolean {

--- a/src/common/settingsProvider.ts
+++ b/src/common/settingsProvider.ts
@@ -41,7 +41,16 @@ export class SettingsProvider {
       const themeSetting = vscode.workspace.getConfiguration().get('workbench.colorTheme') as string;
       let theme = SUPPORTED_THEMES.get(themeSetting);
       if (!theme) {
-        theme = vscode.window.activeColorTheme.kind === 1 ? 'default' : 'dark';
+        switch (vscode.window.activeColorTheme.kind as number) {
+          case 1: // Light theme
+          case 4: // Light high contrast theme
+            theme = 'default';
+          case 2: // Dark theme
+          case 3: // Dark high contrast theme
+            theme = 'dark';
+          default:
+            theme = 'systemPreferred';
+        }
       }
       return theme;
   }

--- a/src/common/webviewEvents.ts
+++ b/src/common/webviewEvents.ts
@@ -48,8 +48,6 @@ export const webSocketEventNames: WebSocketEvent[] = [
     'message',
 ];
 
-export type ThemeString = 'System preference' | 'Light' | 'Dark';
-
 export type TelemetryEvent = 'enumerated' | 'performance' | 'error';
 
 export interface ITelemetryMeasures { [key: string]: number; }

--- a/src/devtoolsPanel.ts
+++ b/src/devtoolsPanel.ts
@@ -291,7 +291,6 @@ export class DevToolsPanel {
         const { id } = JSON.parse(message) as { id: number };
         encodeMessageForChannel(msg => this.panel.webview.postMessage(msg) as unknown as void, 'getVscodeSettings', {
             enableNetwork: SettingsProvider.instance.isNetworkEnabled(),
-            themeString: SettingsProvider.instance.getThemeSettings(),
             welcome: SettingsProvider.instance.getWelcomeSettings(),
             isHeadless: SettingsProvider.instance.getHeadlessSettings(),
             id });

--- a/test/common/settingsProvider.test.ts
+++ b/test/common/settingsProvider.test.ts
@@ -30,14 +30,5 @@ describe("settingsProvider", () => {
       const result = instance.isNetworkEnabled();
       expect(result).toEqual(true);
     });
-
-    it("test that the right value is retrieved for themeString configuration", async () => {
-      jest.requireMock("vscode");
-      const settingsProvider = await import("../../src/common/settingsProvider");
-      const instance = settingsProvider.SettingsProvider.instance;
-      expect(instance).not.toEqual(null);
-      const result = instance.getThemeSettings();
-      expect(result).toEqual("System preference");
-    });
   });
 });

--- a/test/devtoolsPanel.test.ts
+++ b/test/devtoolsPanel.test.ts
@@ -671,7 +671,7 @@ describe("devtoolsPanel", () => {
             it("calls getVscodeSettings", async () => {
                 jest.dontMock("../src/common/settingsProvider.ts");
                 const expectedId = { id: 0 };
-                const expectedState = { enableNetwork: true, themeString: "System preference", welcome: true, isHeadless: false};
+                const expectedState = { enableNetwork: true, welcome: true, isHeadless: false};
                 (context.workspaceState.get as jest.Mock).mockReturnValue(expectedState);
                 const mockUtils = {
                     isHeadlessEnabled: jest.fn(),
@@ -685,7 +685,6 @@ describe("devtoolsPanel", () => {
                     expect.any(Function),
                     "getVscodeSettings",
                     {
-                        themeString: expectedState.themeString,
                         enableNetwork: expectedState.enableNetwork,
                         welcome: expectedState.welcome,
                         isHeadless: expectedState.isHeadless,

--- a/test/helpers/helpers.ts
+++ b/test/helpers/helpers.ts
@@ -99,8 +99,6 @@ export function createFakeVSCode() {
                         switch(name) {
                             case "enableNetwork":
                                 return true;
-                            case "themes":
-                                return "System preference";
                             case "welcome":
                                 return true;
                             case "isHeadless":
@@ -115,8 +113,6 @@ export function createFakeVSCode() {
                         switch(name) {
                             case "enableNetwork":
                                 return {defaultValue: true};
-                            case "themes":
-                                return {defaultValue: "Light"};
                             case "welcome":
                                 return {defaultValue: false};
                             case "isHeadless":

--- a/test/utils.test.ts
+++ b/test/utils.test.ts
@@ -1016,7 +1016,6 @@ describe("utils", () => {
             vscodeMock.workspace.getConfiguration.mockImplementation(() => {
                 return {
                     ...originalWorkspaceMockConfig,
-                    themes: 'System preference',
                     welcome: 'true',
                     enableNetwork: 'false',
                 }
@@ -1029,7 +1028,7 @@ describe("utils", () => {
         it('correctly records all changed extension settings', async () => {
             const reporter = createFakeTelemetryReporter();
             utils.reportExtensionSettings(reporter);
-            expect(reporter.sendTelemetryEvent).toBeCalledWith('user/settingsChangedAtLaunch', { themes: 'System preference', welcome: 'true', enableNetwork: 'false' });
+            expect(reporter.sendTelemetryEvent).toBeCalledWith('user/settingsChangedAtLaunch', { welcome: 'true', enableNetwork: 'false' });
         });
 
         it('correctly sends telemetry event for changed event', async () => {


### PR DESCRIPTION
The extension's DevTools theme would prioritize the user's VSCode theme over the extension's theme settings in VSCode which rendered it useless in most cases.  The only time it would take precedence is if the user had a non-supported vscode theme that we could not apply to the DevTools. To fill in that functionality, this PR falls back to detecting whether the custom theme is light/dark and sets the DevTools theme to the default light/dark theme accordingly.

closes https://github.com/microsoft/vscode-edge-devtools/issues/531