### PR TITLE
Fix scaling down emulated devices to fit available space

### DIFF
--- a/src/screencast/screencast.ts
+++ b/src/screencast/screencast.ts
@@ -248,7 +248,6 @@ export class Screencast {
         const expectedRatio = this.width / this.height;
         const actualRatio = this.screencastImage.naturalWidth / this.screencastImage.naturalHeight;
         this.screencastImage.src = `data:image/png;base64,${data}`;
-        this.screencastImage.style.width = `${this.width}px`;
         if (expectedRatio !== actualRatio) {
             this.updateEmulation();
         }

--- a/src/screencast/view.css
+++ b/src/screencast/view.css
@@ -46,11 +46,7 @@ body {
   align-items: center;
   justify-content: center;
   width: 100%;
-}
-
-#canvas-wrapper.fill #canvas {
-  max-width: none;
-  max-height: none;
+  height: 100%;
 }
 
 #canvas {

--- a/src/screencast/view.ts
+++ b/src/screencast/view.ts
@@ -48,7 +48,7 @@ export class ScreencastView {
                   <i class="codicon codicon-editor-layout"></i>
               </button>
           </div>
-          <div id="canvas-wrapper" class="fill">
+          <div id="canvas-wrapper">
               <img id="canvas" draggable="false" tabindex="0" />
           </div>
       </div>


### PR DESCRIPTION
Previously these would end up clipped to the available space, making part of the screen inaccessible.