### PR TITLE
[Telemetry]: Use DebugTelemetryReporter for extension development

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -334,7 +334,7 @@ export async function getJsDebugCDPProxyWebsocketUrl(debugSessionId: string): Pr
  * @param context The vscode context
  */
 export function createTelemetryReporter(_context: vscode.ExtensionContext): Readonly<TelemetryReporter> {
-    if (packageJson && vscode.env.machineId !== 'someValue.machineId') {
+    if (packageJson && _context.extensionMode === 1 /* Production */) {
         // Use the real telemetry reporter
         return new TelemetryReporter(packageJson.name, packageJson.version, packageJson.aiKey);
     }


### PR DESCRIPTION
For a while we have been sending telemetry events to our pipeline even when developing. Our original flag for determining whether we were running in production or in development was to use:
`vscode.env.machineId !== 'someValue.machineId'`

This is outdated as `vscode.env.machineId` will no longer point to `someValue.machineId` while developing. This PR updates our code to use `context.extensionMode` instead.

See the [ExtensionMode enum](https://github.com/microsoft/vscode/blob/c20b68a62d198e73df34de5f95671eb63c8b5ff2/src/vs/workbench/api/common/extHostTypes.ts#L3389) for details on each context.extensionMode values