### PR TITLE
Fix resizing and scaling screencast

### DIFF
--- a/src/screencast/dimensionComponent.ts
+++ b/src/screencast/dimensionComponent.ts
@@ -15,7 +15,7 @@ export default class DimensionComponent {
     width: number;
     height: number;
     heightOffset: number;
-    updateOnResize = false;
+    updateOnResize = true;
     onUpdateDimensions: (width: number, height: number) => void;
     container: HTMLElement | undefined;
 
@@ -32,6 +32,7 @@ export default class DimensionComponent {
         window.addEventListener('resize', this.#onResize.bind(this));
 
         this.update();
+        this.onUpdateDimensions(this.width, this.height);
     }
 
     template() {
@@ -61,6 +62,7 @@ export default class DimensionComponent {
         this.height = this.screenCastView.offsetHeight - this.heightOffset;
 
         this.update();
+        this.onUpdateDimensions(this.width, this.height);
     }
 
     #onRotate = () => {

--- a/src/screencast/screencast.ts
+++ b/src/screencast/screencast.ts
@@ -26,6 +26,7 @@ export class Screencast {
     private urlInput: HTMLInputElement;
     private screencastImage: HTMLImageElement;
     private toolbar: HTMLElement;
+    private emulationBar: HTMLElement;
     private inactiveOverlay: HTMLElement;
     private emulatedWidth = 0;
     private emulatedHeight = 0;
@@ -43,6 +44,7 @@ export class Screencast {
         this.urlInput = document.getElementById('url') as HTMLInputElement;
         this.screencastImage = document.getElementById('canvas') as HTMLImageElement;
         this.toolbar = document.getElementById('toolbar') as HTMLElement;
+        this.emulationBar = document.getElementById('emulation-bar') as HTMLElement;
         this.inactiveOverlay = document.getElementById('inactive-overlay') as HTMLElement;
 
         this.backButton.addEventListener('click', () => this.onBackClick());
@@ -80,7 +82,7 @@ export class Screencast {
         DimensionComponent.render({
             width: this.mainWrapper.offsetWidth,
             height: this.mainWrapper.offsetHeight,
-            heightOffset: this.toolbar.offsetHeight,
+            heightOffset: this.toolbar.offsetHeight + this.emulationBar.offsetHeight,
             onUpdateDimensions: this.onUpdateDimensions
         }, 'emulation-bar-center');
 
@@ -241,7 +243,7 @@ export class Screencast {
         let isTouchMode = false;
         if (isResponsive) {
             this.emulatedWidth = this.mainWrapper.offsetWidth;
-            this.emulatedHeight = (this.mainWrapper.offsetHeight - this.toolbar.offsetHeight);
+            this.emulatedHeight = (this.mainWrapper.offsetHeight - this.toolbar.offsetHeight - this.emulationBar.offsetHeight);
             this.deviceUserAgent = '';
         } else {
             const device = getEmulatedDeviceDetails(value);

--- a/src/screencast/view.css
+++ b/src/screencast/view.css
@@ -1,5 +1,7 @@
 html,
 body {
+  --toolbar-height: 32px;
+  --emulation-bar-height: 32px;
   position: absolute;
   top: 0;
   left: 0;
@@ -21,9 +23,9 @@ body {
 #toolbar {
   display: flex;
   width: 100%;
-  padding-bottom: 4px;
-  height: 28px;
+  height: var(--toolbar-height);
   border-bottom: 1px solid var(--vscode-editorGroup-border);
+  box-sizing: border-box;
 }
 
 #toolbar>button,
@@ -36,9 +38,13 @@ body {
 #url {
   flex: 1;
   background-color: var(--vscode-input-background);
+  border-color: var(--vscode-input-background);
   border-style: solid;
   border-width: 1px;
   color: var(--vscode-input-foreground);
+  margin-bottom: 4px;
+  margin-right: 4px;
+  margin-top: 4px;
 }
 
 #canvas-wrapper {
@@ -46,12 +52,8 @@ body {
   display: flex;
   align-items: center;
   justify-content: center;
-  overflow: auto;
-}
-
-#canvas-wrapper.fill #canvas {
-  max-width: none;
-  max-height: none;
+  width: 100%;
+  height: calc(100% - var(--toolbar-height) - var(--emulation-bar-height));
 }
 
 #canvas {
@@ -83,9 +85,10 @@ body {
 
 #emulation-bar {
   background-color: var(--vscode-editor-background);
+  box-sizing: border-box;
   display: flex;
   justify-content: space-between;
-  height: 32px;
+  height: var(--emulation-bar-height);
   width: 100%;
 }
 


### PR DESCRIPTION
Cleaned up some CSS so heights would be consistent to avoid pushing the emulation bar down (and some minor additional touches to align the top toolbar more closely with the design mocks). Plumbed offsets for the emulation and toolbar heights through the dimension component when in responsive mode. Set the correct initial responsive state and width/height. 