### PR TITLE
Fix padding around 'x' icon in Dimension component

### DIFF
--- a/src/screencast/view.css
+++ b/src/screencast/view.css
@@ -127,6 +127,10 @@ body {
   border-radius: 4px;
 }
 
+#emulation-bar .codicon-close {
+  padding: 0px 4px;
+}
+
 #emulation-bar button:last-child {
   margin-right: 4px;
 }


### PR DESCRIPTION
**Before**
![image](https://user-images.githubusercontent.com/3802753/166554607-19f05cb3-5eec-4162-a26d-3cc9473b95a6.png)

**After**
![image](https://user-images.githubusercontent.com/3802753/166554548-a9648f30-2b28-4f90-8796-eaf6b130eff9.png)
