### PR TITLE
Use 'known good' revision for all current Edge versions

### DIFF
--- a/src/versionSocketConnection.ts
+++ b/src/versionSocketConnection.ts
@@ -16,7 +16,8 @@ export interface BrowserVersionCdpResponse {
 }
 
 // Minimum supported version of Edge for source-mapped CSS mirroring
-export const MIN_SUPPORTED_VERSION = '102.0.1235.1';
+// TODO: Remove temporary fix to force all current versions to a "known good" revision.
+export const MIN_SUPPORTED_VERSION = '104.0.0.0';
 export const MIN_SUPPORTED_REVISION = '@a41122be052fe9616f0def5fe6842fa942930d46';
 
 export class BrowserVersionDetectionSocket extends EventEmitter {


### PR DESCRIPTION
Avoids a known issue with CSS source-mapped mirroring in Canary.
A follow-up PR will narrow the range once a new Canary is available with a fix.