### PR TITLE
Remove standalone screencast setting and related code

### DIFF
--- a/package.json
+++ b/package.json
@@ -212,11 +212,6 @@
                     },
                     "description": "A set of mappings for rewriting the locations of source files from what the sourcemap says, to their locations on disk"
                 },
-                "vscode-edge-devtools.standaloneScreencast": {
-                    "type": "boolean",
-                    "default": true,
-                    "description": "When selected, screencast will be rendered in an individual screen and enable device emulation."
-                },
                 "vscode-edge-devtools.sourceMapPathOverrides": {
                     "type": "object",
                     "description": "A set of mappings to override the locations of source map files.",
@@ -556,7 +551,7 @@
             "view/item/context": [
                 {
                     "command": "vscode-edge-devtools-view.toggleScreencast",
-                    "when": "view == vscode-edge-devtools-view.targets && viewItem == cdpTarget && standaloneScreencast",
+                    "when": "view == vscode-edge-devtools-view.targets && viewItem == cdpTarget",
                     "group": "inline@0"
                 },
                 {

--- a/src/common/settingsProvider.ts
+++ b/src/common/settingsProvider.ts
@@ -61,13 +61,6 @@ export class SettingsProvider {
     return isHeadless;
   }
 
-  getScreencastSettings(): boolean {
-    const settings = vscode.workspace.getConfiguration(SETTINGS_STORE_NAME);
-    const screencastSetting = settings.get('standaloneScreencast');
-    const standaloneScreencast: boolean = screencastSetting !== undefined ? !!screencastSetting : false;
-    return standaloneScreencast;
-  }
-
   getCSSMirrorContentSettings(): boolean {
     return vscode.workspace.getConfiguration(SETTINGS_STORE_NAME).get('cssMirrorContent') || false;
   }

--- a/src/devtoolsPanel.ts
+++ b/src/devtoolsPanel.ts
@@ -487,12 +487,6 @@ export class DevToolsPanel {
 
         const theme = SettingsProvider.instance.getThemeFromUserSetting();
         const cssMirrorContent = SettingsProvider.instance.getCSSMirrorContentSettings();
-        const standaloneScreencast = SettingsProvider.instance.getScreencastSettings();
-
-        // The headless query param is used to show/hide the DevTools screencast on launch
-        // If the standalone screencast is enabled, we want to hide the DevTools screencast
-        // regardless of the headless setting.
-        const enableScreencast = standaloneScreencast ? false : this.isHeadless;
 
         // the added fields for "Content-Security-Policy" allow resource loading for other file types
         return `
@@ -513,7 +507,7 @@ export class DevToolsPanel {
                 ">
             </head>
             <body>
-                <iframe id="devtools-frame" frameBorder="0" src="${cdnBaseUri}?experiments=true&theme=${theme}&headless=${enableScreencast}&standaloneScreencast=${standaloneScreencast}&cssMirrorContent=${cssMirrorContent}"></iframe>
+                <iframe id="devtools-frame" frameBorder="0" src="${cdnBaseUri}?experiments=true&theme=${theme}&standaloneScreencast=true&cssMirrorContent=${cssMirrorContent}"></iframe>
                 <div id="error-message" class="hidden">
                     <h1>Unable to download DevTools for the current target.</h1>
                     <p>Try these troubleshooting steps:</p>

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -79,10 +79,6 @@ export function activate(context: vscode.ExtensionContext): void {
         },
     });
 
-    // enable/disable standalone screencast target panel icon.
-    const standaloneScreencast = SettingsProvider.instance.getScreencastSettings();
-    void vscode.commands.executeCommand('setContext', 'standaloneScreencast', standaloneScreencast);
-
     // Check if launch.json exists and has supported config to populate side pane welcome message
     LaunchConfigManager.instance.updateLaunchConfig();
     context.subscriptions.push(vscode.commands.registerCommand(`${SETTINGS_STORE_NAME}.attach`, (): void => {


### PR DESCRIPTION
Effectively removes the old screencast in favor of always using the standalone screencast implementation.