### PR TITLE
Remove support for legacy 'edge' and 'msedge' debugger types

### DIFF
--- a/package.json
+++ b/package.json
@@ -229,11 +229,6 @@
                     "description": "Use JavaScript source maps (if they exist)",
                     "default": true
                 },
-                "vscode-edge-devtools.autoAttachViaDebuggerForEdge": {
-                    "type": "boolean",
-                    "description": "Auto attach the Microsoft Edge Tools extension when you launch a browser with the Debugger For Microsoft Edge debug adapter extension",
-                    "default": true
-                },
                 "vscode-edge-devtools.enableNetwork": {
                     "type": "boolean",
                     "description": "Enable network panel (requires relaunching extension)",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -97,12 +97,6 @@ export function activate(context: vscode.ExtensionContext): void {
     vscode.debug.registerDebugConfigurationProvider(`${SETTINGS_STORE_NAME}.debug`,
         new LaunchDebugProvider(context, telemetryReporter, attach, launch));
 
-    // Register the Microsoft Edge debugger types
-    vscode.debug.registerDebugConfigurationProvider('edge',
-        new LaunchDebugProvider(context, telemetryReporter, attach, launch));
-    vscode.debug.registerDebugConfigurationProvider('msedge',
-        new LaunchDebugProvider(context, telemetryReporter, attach, launch));
-
     // Register the side-panel view and its commands
     cdpTargetsProvider = new CDPTargetsProvider(context, telemetryReporter);
     context.subscriptions.push(vscode.window.registerTreeDataProvider(
@@ -399,7 +393,7 @@ export async function attach(
     } while (useRetry && Date.now() - startTime < timeout);
 
     // If there is no response after the timeout then throw an exception (unless for legacy Edge targets which we warned about separately)
-    if (responseArray.length === 0 && config?.type !== 'edge' && config?.type !== 'msedge') {
+    if (responseArray.length === 0) {
         void ErrorReporter.showErrorDialog({
             errorCode: ErrorCodes.Error,
             title: 'Error while fetching list of available targets',

--- a/src/launchDebugProvider.ts
+++ b/src/launchDebugProvider.ts
@@ -5,8 +5,6 @@ import * as vscode from 'vscode';
 import TelemetryReporter from 'vscode-extension-telemetry';
 import {
     IUserConfig,
-    SETTINGS_DEFAULT_ATTACH_INTERVAL,
-    SETTINGS_DEFAULT_EDGE_DEBUGGER_PORT,
     SETTINGS_STORE_NAME,
 } from './utils';
 import { providedDebugConfig } from './launchConfigManager';
@@ -59,30 +57,6 @@ export class LaunchDebugProvider implements vscode.DebugConfigurationProvider {
                 this.telemetryReporter.sendTelemetryEvent('debug/launch');
                 void this.launch(this.context, targetUri, userConfig);
             }
-        } else if (config && (config.type === 'edge' || config.type === 'msedge')) {
-            void vscode.window.showWarningMessage(
-                `Launch type "${config.type}" is deprecated. Update your launch.json to use "pwa-msedge" instead.`, 'Learn More', 'OK'
-            ).then(value => {
-                if (value === 'Learn More') {
-                    const uri = vscode.Uri.parse('https://code.visualstudio.com/docs/nodejs/browser-debugging');
-                    void vscode.env.openExternal(uri);
-                }
-            });
-            const settings = vscode.workspace.getConfiguration(SETTINGS_STORE_NAME);
-            if (settings.get('autoAttachViaDebuggerForEdge')) {
-                if (!userConfig.port) {
-                    userConfig.port = SETTINGS_DEFAULT_EDGE_DEBUGGER_PORT;
-                }
-                if (userConfig.urlFilter) {
-                    userConfig.url = userConfig.urlFilter;
-                }
-
-                // Allow the debugger to actually launch the browser before attaching
-                setTimeout(() => {
-                    void this.attach(this.context, userConfig.url, userConfig, /* useRetry=*/ true);
-                }, SETTINGS_DEFAULT_ATTACH_INTERVAL);
-            }
-            return Promise.resolve(config);
         } else {
             this.telemetryReporter.sendTelemetryEvent('debug/error/config_not_found');
             vscode.window.showErrorMessage('No supported launch config was found.') as Promise<void>;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -102,7 +102,6 @@ export const SETTINGS_DEFAULT_PATH_OVERRIDES: IStringDictionary<string> = {
 };
 export const SETTINGS_DEFAULT_WEB_ROOT = '${workspaceFolder}';
 export const SETTINGS_DEFAULT_SOURCE_MAPS = true;
-export const SETTINGS_DEFAULT_EDGE_DEBUGGER_PORT = 2015;
 export const SETTINGS_DEFAULT_ATTACH_TIMEOUT = 10000;
 export const SETTINGS_DEFAULT_ATTACH_INTERVAL = 200;
 export const SETTINGS_DEFAULT_ENTRY_POINT = 'index.html';

--- a/test/launchDebugProvider.test.ts
+++ b/test/launchDebugProvider.test.ts
@@ -51,32 +51,6 @@ describe("launchDebugProvider", () => {
             expect(attach).toHaveBeenCalled();
         });
 
-        it("calls attach on edge debugger", async () => {
-            jest.useFakeTimers();
-
-            // Mock out the settings
-            const expectedSettings = {
-                autoAttachViaDebuggerForEdge: true,
-                debugAttachTimeoutMs: 3000,
-            };
-            const configMock = {
-                get: (name: string) => (expectedSettings as any)[name],
-            };
-            const vscodeMock = await jest.requireMock("vscode");
-            vscodeMock.workspace.getConfiguration.mockImplementationOnce(() => configMock);
-
-            // Use an edge debugger config
-            const mockConfig = {
-                name: "config",
-                request: "launch",
-                type: "edge",
-                urlFilter: "http://localhost/index.html",
-            };
-            await host.resolveDebugConfiguration(undefined, mockConfig, undefined);
-            jest.runAllTimers();
-            expect(attach).toHaveBeenCalledWith(expect.any(Object), mockConfig.urlFilter, mockConfig, true);
-        });
-
         it("calls launch", async () => {
             const mockConfig = {
                 name: "config",


### PR DESCRIPTION
The `edge` and `msedge` target types should no longer be used now that the "Debugger For Microsoft Edge" extension has been removed from VS Code in favor of jsdebug (which uses `pwa-msedge`). While the legacy extension was still in the marketplace we warned about the deprecation of these target types. Now that it's been removed we can remove support entirely.