### PR TITLE
Move CSS mirror editing status from settings to globalState

### DIFF
--- a/package.json
+++ b/package.json
@@ -160,7 +160,7 @@
                 "command": "vscode-edge-devtools-view.cssMirrorContent",
                 "category": "Microsoft Edge Tools",
                 "enablement": "titleCommandsRegistered",
-                "title": "Toggle mirror editing on for CSS files in workspace"
+                "title": "Toggle CSS mirror editing on/off"
             }
         ],
         "configuration": {
@@ -288,11 +288,6 @@
                         "Microsoft Edge Tools for VS Code will use Microsoft Edge Dev version",
                         "Microsoft Edge Tools for VS Code will use Microsoft Edge Canary version"
                     ]
-                },
-                "vscode-edge-devtools.cssMirrorContent": {
-                    "type": "boolean",
-                    "default": true,
-                    "description": "Enable edits in the styles pane to be automatically applied to the corresponding stylesheet in the workspace. (Only works when targeting Edge Browser versions 94.0.988.0+)"
                 },
                 "vscode-edge-devtools.webhint": {
                     "type": "boolean",

--- a/src/common/settingsProvider.ts
+++ b/src/common/settingsProvider.ts
@@ -74,14 +74,6 @@ export class SettingsProvider {
     return standaloneScreencast;
   }
 
-  getCSSMirrorContentSettings(): boolean {
-    return vscode.workspace.getConfiguration(SETTINGS_STORE_NAME).get('cssMirrorContent') || false;
-  }
-
-  setCSSMirrorContentSettings(isEnabled: boolean): void {
-    void vscode.workspace.getConfiguration(SETTINGS_STORE_NAME).update('cssMirrorContent', isEnabled, true);
-  }
-
   static get instance(): SettingsProvider {
     if (!SettingsProvider.singletonInstance) {
       SettingsProvider.singletonInstance = new SettingsProvider();

--- a/src/devtoolsPanel.ts
+++ b/src/devtoolsPanel.ts
@@ -191,7 +191,7 @@ export class DevToolsPanel {
 
     private onToggleCSSMirrorContent(message: string) {
         const { isEnabled } = JSON.parse(message) as IToggleCSSMirrorContentData;
-        setCSSMirrorContentEnabled(this.context, isEnabled);
+        void setCSSMirrorContentEnabled(this.context, isEnabled);
     }
 
     private onSocketMessage(message: string) {

--- a/src/devtoolsPanel.ts
+++ b/src/devtoolsPanel.ts
@@ -30,6 +30,8 @@ import {
     SETTINGS_WEBVIEW_NAME,
     SETTINGS_VIEW_NAME,
     CDN_FALLBACK_REVISION,
+    getCSSMirrorContentEnabled,
+    setCSSMirrorContentEnabled,
 } from './utils';
 import { ErrorReporter } from './errorReporter';
 import { ErrorCodes } from './common/errorCodes';
@@ -189,7 +191,7 @@ export class DevToolsPanel {
 
     private onToggleCSSMirrorContent(message: string) {
         const { isEnabled } = JSON.parse(message) as IToggleCSSMirrorContentData;
-        void vscode.commands.executeCommand(`${SETTINGS_VIEW_NAME}.cssMirrorContent`, {isEnabled});
+        setCSSMirrorContentEnabled(this.context, isEnabled);
     }
 
     private onSocketMessage(message: string) {
@@ -352,7 +354,7 @@ export class DevToolsPanel {
     }
 
     private async onSocketCssMirrorContent(message: string) {
-        if (!SettingsProvider.instance.getCSSMirrorContentSettings()) {
+        if (!getCSSMirrorContentEnabled(this.context)) {
             return;
         }
 
@@ -487,7 +489,7 @@ export class DevToolsPanel {
         const stylesUri = this.panel.webview.asWebviewUri(stylesPath);
 
         const theme = SettingsProvider.instance.getThemeFromUserSetting();
-        const cssMirrorContent = SettingsProvider.instance.getCSSMirrorContentSettings();
+        const cssMirrorContent = getCSSMirrorContentEnabled(this.context);
         const standaloneScreencast = SettingsProvider.instance.getScreencastSettings();
 
         // The headless query param is used to show/hide the DevTools screencast on launch

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -39,7 +39,6 @@ import {
 } from './utils';
 import { LaunchConfigManager } from './launchConfigManager';
 import { ErrorReporter } from './errorReporter';
-import { SettingsProvider } from './common/settingsProvider';
 import { ErrorCodes } from './common/errorCodes';
 import {
     LanguageClient,

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -235,7 +235,7 @@ export function activate(context: vscode.ExtensionContext): void {
 
     context.subscriptions.push(vscode.commands.registerCommand(`${SETTINGS_VIEW_NAME}.cssMirrorContent`, () => {
         const cssMirrorContent = getCSSMirrorContentEnabled(context);
-        setCSSMirrorContentEnabled(context, !cssMirrorContent);
+        void setCSSMirrorContentEnabled(context, !cssMirrorContent);
     }));
 
     void vscode.commands.executeCommand('setContext', 'titleCommandsRegistered', true);

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -34,6 +34,8 @@ import {
     reportChangedExtensionSetting,
     reportExtensionSettings,
     reportUrlType,
+    getCSSMirrorContentEnabled,
+    setCSSMirrorContentEnabled,
 } from './utils';
 import { LaunchConfigManager } from './launchConfigManager';
 import { ErrorReporter } from './errorReporter';
@@ -231,11 +233,9 @@ export function activate(context: vscode.ExtensionContext): void {
             void vscode.env.openExternal(vscode.Uri.parse('https://docs.microsoft.com/en-us/microsoft-edge/visual-studio-code/microsoft-edge-devtools-extension'));
         }));
 
-    const cssMirrorContent = SettingsProvider.instance.getCSSMirrorContentSettings();
-    void vscode.commands.executeCommand('setContext', 'cssMirrorContent', cssMirrorContent);
-    context.subscriptions.push(vscode.commands.registerCommand(`${SETTINGS_VIEW_NAME}.cssMirrorContent`, (args: {isEnabled: boolean}) => {
-        SettingsProvider.instance.setCSSMirrorContentSettings(args.isEnabled);
-        void vscode.commands.executeCommand('setContext', 'cssMirrorContent', args.isEnabled);
+    context.subscriptions.push(vscode.commands.registerCommand(`${SETTINGS_VIEW_NAME}.cssMirrorContent`, () => {
+        const cssMirrorContent = getCSSMirrorContentEnabled(context);
+        setCSSMirrorContentEnabled(context, !cssMirrorContent);
     }));
 
     void vscode.commands.executeCommand('setContext', 'titleCommandsRegistered', true);

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -343,6 +343,14 @@ export function createTelemetryReporter(_context: vscode.ExtensionContext): Read
 
 }
 
+export function getCSSMirrorContentEnabled(context: vscode.ExtensionContext): boolean {
+    return context.globalState.get<boolean>('cssMirrorContent') ?? true;
+}
+
+export function setCSSMirrorContentEnabled(context: vscode.ExtensionContext, isEnabled: boolean): Thenable<void> {
+    return context.globalState.update('cssMirrorContent', isEnabled);
+}
+
 /**
  * Get the current machine platform
  */

--- a/test/devtoolsPanel.test.ts
+++ b/test/devtoolsPanel.test.ts
@@ -648,16 +648,9 @@ describe("devtoolsPanel", () => {
                     applyPathMapping: jest.fn().mockImplementation((x) => x),
                     fetchUri: jest.fn().mockRejectedValue(null),
                     isHeadlessEnabled: jest.fn(),
-                };
-                const mockSettingsProvider = {
-                    SettingsProvider: {
-                        instance: {
-                            getCSSMirrorContentSettings: jest.fn().mockImplementation(() => true),
-                        }
-                    }
+                    getCSSMirrorContentEnabled: jest.fn().mockImplementation(() => true),
                 };
                 jest.doMock("../src/utils", () => mockUtils);
-                jest.doMock("../src/common/settingsProvider.ts", () => mockSettingsProvider); 
 
                 const dtp = await import("../src/devtoolsPanel");
                 const { TextEncoder } = require('util');


### PR DESCRIPTION
Leaves the checkbox in the DevTools as the primary UI for toggling state.
Also keeps the command for toggling state and fixes it to work when invoked from the command menu.