### PR TITLE
Move CDN fallback revision from settings to globalState

### DIFF
--- a/package.json
+++ b/package.json
@@ -298,11 +298,6 @@
                     "type": "boolean",
                     "default": true,
                     "description": "Enable feedback from webhint on source files to improve accessibility, compatibility, security and more."
-                },
-                "vscode-edge-devtools.fallbackRevision": {
-                    "type": "string",
-                    "default": "@c438621746b2932668109129d137a7e3a22ef4fd",
-                    "description": "Last known good revision used for when we fail to connect to the CDN with the current target revision."
                 }
             }
         },

--- a/src/devtoolsPanel.ts
+++ b/src/devtoolsPanel.ts
@@ -390,7 +390,7 @@ export class DevToolsPanel {
 
     private onSocketDevToolsConnection(success: string) {
         if (success === 'true') {
-            this.context.globalState.update('fallbackRevision', this.currentRevision);
+            void this.context.globalState.update('fallbackRevision', this.currentRevision);
         } else {
             // Retry connection with fallback.
             const fallbackRevision = this.context.globalState.get<string>('fallbackRevision') ?? '';

--- a/src/devtoolsPanel.ts
+++ b/src/devtoolsPanel.ts
@@ -390,11 +390,10 @@ export class DevToolsPanel {
 
     private onSocketDevToolsConnection(success: string) {
         if (success === 'true') {
-            void vscode.workspace.getConfiguration(SETTINGS_STORE_NAME).update('fallbackRevision', this.currentRevision, true);
+            this.context.globalState.update('fallbackRevision', this.currentRevision);
         } else {
             // Retry connection with fallback.
-            const settingsConfig = vscode.workspace.getConfiguration(SETTINGS_STORE_NAME);
-            const fallbackRevision = settingsConfig.get('fallbackRevision') as string;
+            const fallbackRevision = this.context.globalState.get<string>('fallbackRevision') ?? '';
             if (this.currentRevision) {
                 this.telemetryReporter.sendTelemetryEvent('websocket/failedConnection', {revision: this.currentRevision});
             }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -110,8 +110,8 @@ export const SETTINGS_DEFAULT_ENTRY_POINT = 'index.html';
 const WIN_APP_DATA = process.env.LOCALAPPDATA || '/';
 const msEdgeBrowserMapping: Map<BrowserFlavor, IBrowserPath> = new Map<BrowserFlavor, IBrowserPath>();
 
-// Current Revision: 94.0.992.31
-export const CDN_FALLBACK_REVISION = '@fd65e6bbedc86a22f2393b7cd8d1585c54cada42';
+// Current Revision: 102.0.1235.1
+export const CDN_FALLBACK_REVISION = '@a41122be052fe9616f0def5fe6842fa942930d46';
 
 /** Build-specified flags. */
 declare const DEBUG: boolean;

--- a/src/versionSocketConnection.ts
+++ b/src/versionSocketConnection.ts
@@ -4,6 +4,7 @@
 import { EventEmitter } from 'events';
 import WebSocket from 'ws';
 import { WebSocketEvent } from './common/webviewEvents';
+import { CDN_FALLBACK_REVISION } from './utils';
 
 export type IDevToolsPostMessageCallback = (e: WebSocketEvent, message?: string) => void;
 
@@ -18,7 +19,7 @@ export interface BrowserVersionCdpResponse {
 // Minimum supported version of Edge for source-mapped CSS mirroring
 // TODO: Remove temporary fix to force all current versions to a "known good" revision.
 export const MIN_SUPPORTED_VERSION = '104.0.0.0';
-export const MIN_SUPPORTED_REVISION = '@a41122be052fe9616f0def5fe6842fa942930d46';
+export const MIN_SUPPORTED_REVISION = CDN_FALLBACK_REVISION;
 
 export class BrowserVersionDetectionSocket extends EventEmitter {
     private readonly targetUrl: string;


### PR DESCRIPTION
This primarily needs to hold the most recent successful hash and does not need to be configured by the user.