### PR TITLE
Bump min DevTools version to include the Application panel

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -109,8 +109,8 @@ export const SETTINGS_DEFAULT_ENTRY_POINT = 'index.html';
 const WIN_APP_DATA = process.env.LOCALAPPDATA || '/';
 const msEdgeBrowserMapping: Map<BrowserFlavor, IBrowserPath> = new Map<BrowserFlavor, IBrowserPath>();
 
-// Current Revision: 102.0.1235.1
-export const CDN_FALLBACK_REVISION = '@a41122be052fe9616f0def5fe6842fa942930d46';
+// Current Revision: 103.0.1254.0
+export const CDN_FALLBACK_REVISION = '@ab695ee0d3abb70a2b8ebe6ab22acde216485790';
 
 /** Build-specified flags. */
 declare const DEBUG: boolean;

--- a/src/versionSocketConnection.ts
+++ b/src/versionSocketConnection.ts
@@ -17,7 +17,7 @@ export interface BrowserVersionCdpResponse {
 }
 
 // Minimum supported version of Edge for source-mapped CSS mirroring
-export const MIN_SUPPORTED_VERSION = '103.0.1252.0';
+export const MIN_SUPPORTED_VERSION = '103.0.1254.0';
 export const MIN_SUPPORTED_REVISION = CDN_FALLBACK_REVISION;
 
 export class BrowserVersionDetectionSocket extends EventEmitter {


### PR DESCRIPTION
Zip containing side-loadable VSIX for testing:
[vscode-edge-devtools-app-panel.zip](https://github.com/microsoft/vscode-edge-devtools/files/8673587/vscode-edge-devtools-app-panel.zip)

![image](https://user-images.githubusercontent.com/785009/167951795-dbd0ac90-2da0-43d1-8a07-318f0dd1c2c9.png)

Fix #1014 