### PR TITLE
[Screencast]: Change Open DevTools button to Toggle DevTools

### DIFF
--- a/src/devtoolsPanel.ts
+++ b/src/devtoolsPanel.ts
@@ -157,6 +157,7 @@ export class DevToolsPanel {
         if (!ScreencastPanel.instance && vscode.debug.activeDebugSession?.name.includes(providedHeadlessDebugConfig.name)) {
             void vscode.commands.executeCommand('workbench.action.debug.stop');
         }
+        ScreencastPanel.instance && ScreencastPanel.instance.update();
     }
 
     private postToDevTools(e: WebSocketEvent, message?: string) {
@@ -556,6 +557,7 @@ export class DevToolsPanel {
             });
             panel.iconPath = vscode.Uri.joinPath(context.extensionUri, 'icon.png');
             DevToolsPanel.instance = new DevToolsPanel(panel, context, telemetryReporter, targetUrl, config);
+            ScreencastPanel.instance && ScreencastPanel.instance.update();
         }
     }
 }

--- a/src/screencast/view.css
+++ b/src/screencast/view.css
@@ -194,3 +194,7 @@ body {
 #popover li:last-child {
   margin-bottom: 5px;
 }
+
+.devtools-open {
+  color: #7dbae9;
+}

--- a/src/screencast/view.ts
+++ b/src/screencast/view.ts
@@ -40,7 +40,7 @@ export class ScreencastView {
                   <i class="codicon codicon-refresh"></i>
               </button>
               <input id="url" />
-              <button id="inspect" title="Toggle DevTools">
+              <button id="inspect" title="${isDevToolsOpen ? 'Close DevTools' : 'Open DevTools'}">
                   <i class="codicon codicon-inspect ${isDevToolsOpen ? 'devtools-open' : ''}"></i>
               </button>
           </div>

--- a/src/screencast/view.ts
+++ b/src/screencast/view.ts
@@ -8,7 +8,8 @@ export class ScreencastView {
     private cssPath: Uri
     private codiconsUri: Uri;
     private inspectorUri: Uri
-    private htmlTemplate = (webviewCSP: string, cssPath: Uri, codiconsUri: Uri, inspectorUri: Uri) => `<!doctype html>
+    private isDevToolsOpen: boolean;
+    private htmlTemplate = (webviewCSP: string, cssPath: Uri, codiconsUri: Uri, inspectorUri: Uri, isDevToolsOpen: boolean) => `<!doctype html>
   <html>
   <head>
       <meta http-equiv="content-type" content="text/html; charset=utf-8">
@@ -39,8 +40,8 @@ export class ScreencastView {
                   <i class="codicon codicon-refresh"></i>
               </button>
               <input id="url" />
-              <button id="inspect" title="Open DevTools">
-                  <i class="codicon codicon-inspect"></i>
+              <button id="inspect" title="Toggle DevTools">
+                  <i class="codicon codicon-inspect ${isDevToolsOpen ? 'devtools-open' : ''}"></i>
               </button>
           </div>
           <div id="canvas-wrapper">
@@ -59,14 +60,15 @@ export class ScreencastView {
   </html>
   `;
 
-    constructor(webviewCSP: string, cssPath: Uri, codiconsUri: Uri, inspectorUri: Uri) {
+    constructor(webviewCSP: string, cssPath: Uri, codiconsUri: Uri, inspectorUri: Uri, isDevToolsOpen: boolean) {
         this.webviewCSP = webviewCSP;
         this.cssPath = cssPath;
         this.codiconsUri = codiconsUri;
         this.inspectorUri = inspectorUri;
+        this.isDevToolsOpen = isDevToolsOpen;
     }
 
     render(): string {
-        return this.htmlTemplate(this.webviewCSP, this.cssPath, this.codiconsUri, this.inspectorUri);
+        return this.htmlTemplate(this.webviewCSP, this.cssPath, this.codiconsUri, this.inspectorUri, this.isDevToolsOpen);
     }
 }

--- a/src/screencastPanel.ts
+++ b/src/screencastPanel.ts
@@ -75,7 +75,7 @@ export class ScreencastPanel {
             if (typeof message === 'string') {
                 this.panelSocket.onMessageFromWebview(message);
             } else if ('type' in message && (message as {type:string}).type === 'open-devtools') {
-                this.openDevTools();
+                this.toggleDevTools();
             }
         }, this);
 
@@ -109,9 +109,13 @@ export class ScreencastPanel {
         }
     }
 
-    private openDevTools() {
+    private toggleDevTools() {
         const websocketUrl = this.targetUrl;
-        void vscode.commands.executeCommand(`${SETTINGS_VIEW_NAME}.attach`, { websocketUrl }, this.isJsDebugProxiedCDPConnection);
+        if (DevToolsPanel.instance) {
+            DevToolsPanel.instance.dispose();
+        } else {
+            void vscode.commands.executeCommand(`${SETTINGS_VIEW_NAME}.attach`, { websocketUrl }, this.isJsDebugProxiedCDPConnection);
+        }
     }
 
     toggleInspect(enabled: boolean): void {
@@ -122,7 +126,7 @@ export class ScreencastPanel {
         this.dispose();
     }
 
-    private update() {
+    update(): void {
         this.panel.webview.html = this.getHtmlForWebview();
     }
 
@@ -135,7 +139,7 @@ export class ScreencastPanel {
         const inspectorUri = this.panel.webview.asWebviewUri(inspectorPath);
 		const codiconsUri = this.panel.webview.asWebviewUri(vscode.Uri.joinPath(this.context.extensionUri, 'node_modules', '@vscode/codicons', 'dist', 'codicon.css'));
         const cssPath = this.panel.webview.asWebviewUri(vscode.Uri.joinPath(this.context.extensionUri, 'out/screencast', 'view.css'));
-        const view = new ScreencastView(this.panel.webview.cspSource, cssPath, codiconsUri, inspectorUri);
+        const view = new ScreencastView(this.panel.webview.cspSource, cssPath, codiconsUri, inspectorUri, !!DevToolsPanel.instance);
         return view.render();
     }
 


### PR DESCRIPTION
This PR changes the "Open DevTools" button on the screencast to be "Toggle DevTools"

DevTools Closed:
![image](https://user-images.githubusercontent.com/14304598/168389909-3e13e7ee-d22c-4968-af4c-5e4cf465be71.png)

DevTools Open:
![image](https://user-images.githubusercontent.com/14304598/168389891-7ecf053e-baf1-42ad-83d0-09c2010e55eb.png)

closes #996