### PR TITLE
[Screencast]: Add text-only clipboard functionality

### DIFF
--- a/src/common/webviewEvents.ts
+++ b/src/common/webviewEvents.ts
@@ -3,7 +3,7 @@
 
 export type WebviewEvent = 'getState' | 'getUrl' | 'openInEditor' | 'cssMirrorContent' | 'ready' | 'setState' | 'telemetry' | 'websocket'
 | 'getVscodeSettings' | 'copyText' | 'focusEditor' | 'focusEditorGroup' | 'openUrl' | 'toggleScreencast' | 'toggleInspect' | 'replayConsoleMessages'
-| 'devtoolsConnection' | 'toggleCSSMirrorContent';
+| 'devtoolsConnection' | 'toggleCSSMirrorContent' | 'clipboard';
 export const webviewEventNames: WebviewEvent[] = [
     'getState',
     'getUrl',
@@ -23,6 +23,7 @@ export const webviewEventNames: WebviewEvent[] = [
     'replayConsoleMessages',
     'devtoolsConnection',
     'toggleCSSMirrorContent',
+    'clipboard',
 ];
 
 export type FrameToolsEvent = 'sendMessageToBackend' | 'openInNewTab' | 'recordEnumeratedHistogram' |

--- a/src/common/webviewEvents.ts
+++ b/src/common/webviewEvents.ts
@@ -3,7 +3,7 @@
 
 export type WebviewEvent = 'getState' | 'getUrl' | 'openInEditor' | 'cssMirrorContent' | 'ready' | 'setState' | 'telemetry' | 'websocket'
 | 'getVscodeSettings' | 'copyText' | 'focusEditor' | 'focusEditorGroup' | 'openUrl' | 'toggleScreencast' | 'toggleInspect' | 'replayConsoleMessages'
-| 'devtoolsConnection' | 'toggleCSSMirrorContent' | 'clipboard';
+| 'devtoolsConnection' | 'toggleCSSMirrorContent' | 'writeToClipboard' | 'readClipboard';
 export const webviewEventNames: WebviewEvent[] = [
     'getState',
     'getUrl',
@@ -23,7 +23,8 @@ export const webviewEventNames: WebviewEvent[] = [
     'replayConsoleMessages',
     'devtoolsConnection',
     'toggleCSSMirrorContent',
-    'clipboard',
+    'writeToClipboard',
+    'readClipboard',
 ];
 
 export type FrameToolsEvent = 'sendMessageToBackend' | 'openInNewTab' | 'recordEnumeratedHistogram' |

--- a/src/screencast/input.ts
+++ b/src/screencast/input.ts
@@ -52,6 +52,13 @@ export class ScreencastInputHandler {
             keyboardEvent.preventDefault();
             keyboardEvent.stopPropagation();
         }
+        if (keyboardEvent.ctrlKey && (keyboardEvent.key === 'c' || keyboardEvent.key === 'x') && keyboardEvent.type === 'keydown') {
+            this.cdpConnection.sendMessageToBackend('Runtime.evaluate', {
+                expression: 'document.getSelection().toString()',
+            }, (text: {result: {value: string}}): string => {
+                return text.result.value;
+            }, true);
+        }
         if (keyboardEvent.type === 'keydown' || keyboardEvent.type === 'keyup') {
             const text = hasNonShiftModifier ? '' : this.textFromEvent(keyboardEvent);
             this.cdpConnection.sendMessageToBackend('Input.dispatchKeyEvent', {
@@ -63,7 +70,7 @@ export class ScreencastInputHandler {
                 modifiers: this.modifiersForEvent(keyboardEvent),
                 windowsVirtualKeyCode: keyboardEvent.keyCode,
                 nativeVirtualKeyCode: keyboardEvent.keyCode,
-                text
+                text,
             });
         }
     }

--- a/src/screencast/input.ts
+++ b/src/screencast/input.ts
@@ -55,11 +55,11 @@ export class ScreencastInputHandler {
         if (keyboardEvent.ctrlKey && (keyboardEvent.key === 'c' || keyboardEvent.key === 'x') && keyboardEvent.type === 'keydown') {
             this.cdpConnection.sendMessageToBackend('Runtime.evaluate', {
                 expression: 'document.getSelection().toString()',
-            }, (text: {result: {value: string}}): string => {
-                return text.result.value;
-            }, true);
+            }, undefined, true);
         }
-        if (keyboardEvent.type === 'keydown' || keyboardEvent.type === 'keyup') {
+        if (keyboardEvent.ctrlKey && keyboardEvent.key === 'v' && keyboardEvent.type === 'keydown') {
+            this.cdpConnection.readClipboardAndPasteRequest();
+        } else if (keyboardEvent.type === 'keydown' || keyboardEvent.type === 'keyup') {
             const text = hasNonShiftModifier ? '' : this.textFromEvent(keyboardEvent);
             this.cdpConnection.sendMessageToBackend('Input.dispatchKeyEvent', {
                 type: keyboardEvent.type === 'keyup' ? 'keyUp' : (text ? 'keyDown' : 'rawKeyDown'),

--- a/src/screencast/input.ts
+++ b/src/screencast/input.ts
@@ -52,12 +52,17 @@ export class ScreencastInputHandler {
             keyboardEvent.preventDefault();
             keyboardEvent.stopPropagation();
         }
-        if (keyboardEvent.ctrlKey && (keyboardEvent.key === 'c' || keyboardEvent.key === 'x') && keyboardEvent.type === 'keydown') {
+        if ((keyboardEvent.ctrlKey || keyboardEvent.metaKey) && (keyboardEvent.key === 'c' || keyboardEvent.key === 'x') && keyboardEvent.type === 'keydown') {
+            // We make a call to CDP to get the currently selected text in the screencast.
+            // By passing "true" for the "isCutOrCopy" parameter in "sendMessageToBackend", the cdpConnection class will
+            // handle the response to the Runtime.evaluate call and update the user's system clipboard.
             this.cdpConnection.sendMessageToBackend('Runtime.evaluate', {
                 expression: 'document.getSelection().toString()',
             }, undefined, true);
         }
-        if (keyboardEvent.ctrlKey && keyboardEvent.key === 'v' && keyboardEvent.type === 'keydown') {
+        if ((keyboardEvent.ctrlKey || keyboardEvent.metaKey) && keyboardEvent.key === 'v' && keyboardEvent.type === 'keydown') {
+            // If the user inputs a paste command shortcut, we send a request to VSCode to retrieve the user's system clipboard contents.
+            // When the clipboard contents are sent back to the screencast, we insert that text into the screencast-focused input via "pasteClipboardContents"
             this.cdpConnection.readClipboardAndPasteRequest();
         } else if (keyboardEvent.type === 'keydown' || keyboardEvent.type === 'keyup') {
             const text = hasNonShiftModifier ? '' : this.textFromEvent(keyboardEvent);

--- a/src/screencast/screencast.ts
+++ b/src/screencast/screencast.ts
@@ -152,11 +152,7 @@ export class Screencast {
         this.cdpConnection.registerForEvent('DevTools.toggleInspect', result => this.onToggleInspect(result));
         this.cdpConnection.registerWriteToClipboardFunction(result => this.onSaveToClipboard(result));
         this.cdpConnection.registerReadClipboardAndPasteFunction(() => this.getClipboardContents());
-        this.cdpConnection.registerForEvent('readClipboard', clipboardText => {
-            this.cdpConnection.sendMessageToBackend('Runtime.evaluate', {
-                expression: `document.execCommand("insertText", false, "${clipboardText}");`,
-            });
-        });
+        this.cdpConnection.registerForEvent('readClipboard', clipboardContents => this.pasteClipboardContents(clipboardContents));
 
         this.inputHandler = new ScreencastInputHandler(this.cdpConnection);
 
@@ -405,6 +401,12 @@ export class Screencast {
 
     private getClipboardContents(): void {
         encodeMessageForChannel(msg => vscode.postMessage(msg, '*'), 'readClipboard');
+    }
+
+    private pasteClipboardContents(message: string) {
+        this.cdpConnection.sendMessageToBackend('Runtime.evaluate', {
+            expression: `document.execCommand("insertText", false, "${message}");`,
+        });
     }
 
     private setTouchMode(enabled: boolean): void {

--- a/src/screencast/screencast.ts
+++ b/src/screencast/screencast.ts
@@ -405,7 +405,7 @@ export class Screencast {
 
     private pasteClipboardContents(message: string) {
         this.cdpConnection.sendMessageToBackend('Runtime.evaluate', {
-            expression: `document.execCommand("insertText", false, "${message}");`,
+            expression: `document.execCommand("insertText", false, "${message.replace(/"/g,'\\"')}");`,
         });
     }
 

--- a/src/screencast/screencast.ts
+++ b/src/screencast/screencast.ts
@@ -150,6 +150,7 @@ export class Screencast {
 
         // This message comes from the DevToolsPanel instance.
         this.cdpConnection.registerForEvent('DevTools.toggleInspect', result => this.onToggleInspect(result));
+        this.cdpConnection.registerClipboardFunction(result => this.onSaveToClipboard(result));
 
         this.inputHandler = new ScreencastInputHandler(this.cdpConnection);
 
@@ -375,6 +376,14 @@ export class Screencast {
 
     private onToggleInspect({ enabled }: any): void {
         this.setTouchMode(!enabled as boolean);
+    }
+
+    private onSaveToClipboard(message: string): void {
+        encodeMessageForChannel(msg => vscode.postMessage(msg, '*'), 'clipboard', {
+            data: {
+                message,
+            },
+        });
     }
 
     private sendEmulationTelemetry(event: string, value: string) {

--- a/src/screencastPanel.ts
+++ b/src/screencastPanel.ts
@@ -53,6 +53,7 @@ export class ScreencastPanel {
         }
         this.panelSocket.on('close', () => this.onSocketClose());
         this.panelSocket.on('telemetry', message => this.onSocketTelemetry(message));
+        this.panelSocket.on('clipboard', message => this.onSaveToClipboard(message));
 
         // Handle closing
         this.panel.onDidDispose(() => {
@@ -153,6 +154,11 @@ export class ScreencastPanel {
             `devtools/${telemetry.name}/${telemetry.data.event}`, {
                 'value': telemetry.data.value as string,
             });
+    }
+
+    private onSaveToClipboard(message: string): void {
+        const clipboardMessage = JSON.parse(message) as {data: {message: string}};
+        void vscode.env.clipboard.writeText(clipboardMessage.data.message);
     }
 
     static createOrShow(context: vscode.ExtensionContext,

--- a/src/screencastPanel.ts
+++ b/src/screencastPanel.ts
@@ -53,7 +53,8 @@ export class ScreencastPanel {
         }
         this.panelSocket.on('close', () => this.onSocketClose());
         this.panelSocket.on('telemetry', message => this.onSocketTelemetry(message));
-        this.panelSocket.on('clipboard', message => this.onSaveToClipboard(message));
+        this.panelSocket.on('writeToClipboard', message => this.onSaveToClipboard(message));
+        this.panelSocket.on('readClipboard', () => this.onGetClipboardText());
 
         // Handle closing
         this.panel.onDidDispose(() => {
@@ -159,6 +160,12 @@ export class ScreencastPanel {
     private onSaveToClipboard(message: string): void {
         const clipboardMessage = JSON.parse(message) as {data: {message: string}};
         void vscode.env.clipboard.writeText(clipboardMessage.data.message);
+    }
+
+    private onGetClipboardText(): void {
+        void vscode.env.clipboard.readText().then(clipboardText => {
+            encodeMessageForChannel(msg => this.panel.webview.postMessage(msg) as unknown as void, 'readClipboard', { clipboardText });
+        });
     }
 
     static createOrShow(context: vscode.ExtensionContext,

--- a/test/devtoolsPanel.test.ts
+++ b/test/devtoolsPanel.test.ts
@@ -196,7 +196,8 @@ describe("devtoolsPanel", () => {
             // We need to account for webview events that are not used in the DevTools panel.
             const screencastOnlyWebviewEvents = [
                 'toggleInspect',
-                'clipboard',
+                'writeToClipboard',
+                'readClipboard',
             ]
             const hookedEvents: string[] = [];
             mockPanelSocket.on.mockImplementation(((name: string | symbol, ...args: any) => {

--- a/test/devtoolsPanel.test.ts
+++ b/test/devtoolsPanel.test.ts
@@ -196,6 +196,7 @@ describe("devtoolsPanel", () => {
             // We need to account for webview events that are not used in the DevTools panel.
             const screencastOnlyWebviewEvents = [
                 'toggleInspect',
+                'clipboard',
             ]
             const hookedEvents: string[] = [];
             mockPanelSocket.on.mockImplementation(((name: string | symbol, ...args: any) => {


### PR DESCRIPTION
This PR implements text-only clipboard functionality to the screencast. We achieve this functionality in this PR through these steps:

Scenario: Copying text from the screencast and pasting it outside screencast
1. We add a `clipboardRequests` set to `cdp.ts` to track request/response ids of CDP messages that relate to clipboard interaction
2. We register a clipboard handler function called `onSaveToClipboard` from `screencast.ts` on `cdp.ts` to handle incoming clipboard responses
3. We send a CDP call to `Runtime.evaluate` and run `document.getSelection().toString()` to request the selected text and store the request ID to `clipboardRequests`
4. When we get a response ID that matches an ID in `clipboardRequests`, we call the `onSaveToClipboard` function and delete the ID from the `clipboardRequests` set.
5. `onSaveToClipboard` posts the message for `ScreencastPanel` to listen and copy to the system keyboard via `vscode.env.clipboard.writeText(s)` 

Scenario: Copying text from outside the screencast and pasting in the screencast
1.  When detecting a paste keyboard shortcut, we make a request to `ScreencastPanel` to send over clipboard contents
(Get shortcut -> call `this.cdpConnection.readClipboardAndPasteRequest()` / `getClipboardContents()`)
2. `ScreencastPanel` reads the system clipboard and sends message back with `readClipboard` event name.
3. `cdpConnection` receives `readClipboard` event and calls registered callback which is `pasteClipboardContents()`
4. `pasteClipboardContents()` sends a `Runtime.evaluate` message to insert the received clipboard text to the current user selection.

closes #998 