### PR TITLE
[Accessibility]: Add verbose label to CDPTargets to indicate existence of action buttons on tab

### DIFF
--- a/src/cdpTarget.ts
+++ b/src/cdpTarget.ts
@@ -21,6 +21,7 @@ export class CDPTarget extends vscode.TreeItem {
         this.propertyName = propertyName;
         this.extensionPath = extensionPath;
         this.contextValue = (this.propertyName ? 'cdpTargetProperty' : 'cdpTarget');
+        this.accessibilityInformation = {label: `${this.label}: ${this.description}`, role: 'treegrid'};
 
         // Get the icon for this type of target
         if (this.extensionPath) {

--- a/src/cdpTarget.ts
+++ b/src/cdpTarget.ts
@@ -21,7 +21,14 @@ export class CDPTarget extends vscode.TreeItem {
         this.propertyName = propertyName;
         this.extensionPath = extensionPath;
         this.contextValue = (this.propertyName ? 'cdpTargetProperty' : 'cdpTarget');
-        this.accessibilityInformation = {label: `${this.label}: ${this.description}`, role: 'treegrid'};
+        const treeItemLabel = `${this.label}: ${this.description}.`;
+
+        // collapsibleState = 1 means the treeItem is the base CDPTarget treeItem.
+        // collapsibleState = 0 means the treeItem is a child description treeItem (e.g. id, title, type, etc.)
+        const label = this.collapsibleState ?
+            `${treeItemLabel}. 'Press tab to access action button list. Use left and right arrow keys to navigate action button list.'`
+            : treeItemLabel;
+        this.accessibilityInformation = {label, role: 'treeitem'};
 
         // Get the icon for this type of target
         if (this.extensionPath) {


### PR DESCRIPTION
Issue:
- Screen reader users have no indication that action button items are available on each CDPTarget treeitem
![image](https://user-images.githubusercontent.com/14304598/169610170-52cd4226-ec44-4f01-9194-0a1dc311c65e.png)

Changes:
- Adding verbose label to each tree item. 
    - Items that are expandable/collapsible are identified as CDPTargets and contain the action button list label.
    - Items that are not expandable/collapsible are identified as descriptor tree items and only contain the base label
- The base label is `${this.label}: ${this.description}`.
    - Example:
        - `this.label` = "type"
        - `this.description` = "page"
        - ![image](https://user-images.githubusercontent.com/14304598/169610560-4264ac9e-fffb-4e59-a4c9-19fae5c5b572.png)

