### PR TITLE
[Feature]: Add context menu option to open html file with Edge DevTools

### DIFF
--- a/package.json
+++ b/package.json
@@ -161,6 +161,11 @@
                 "category": "Microsoft Edge Tools",
                 "enablement": "titleCommandsRegistered",
                 "title": "Toggle CSS mirror editing on/off"
+            },
+            {
+                "command": "vscode-edge-devtools-view.launchHtml",
+                "title": "Open with Edge DevTools",
+                "category": "Microsoft Edge Tools"
             }
         ],
         "configuration": {
@@ -548,7 +553,12 @@
                     "when": "view == vscode-edge-devtools-view.targets && viewItem == cdpTargetProperty",
                     "group": "2_contextMenu"
                 }
-            ]
+            ],
+            "explorer/context": [{
+                "when": "resourceLangId == html",
+                "command": "vscode-edge-devtools-view.launchHtml",
+                "group": "navigation"
+            }]
         },
         "viewsContainers": {
             "activitybar": [

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -37,7 +37,7 @@ import {
     getCSSMirrorContentEnabled,
     setCSSMirrorContentEnabled,
 } from './utils';
-import { LaunchConfigManager } from './launchConfigManager';
+import { LaunchConfigManager, providedHeadlessDebugConfig, providedLaunchDevToolsConfig } from './launchConfigManager';
 import { ErrorReporter } from './errorReporter';
 import { ErrorCodes } from './common/errorCodes';
 import {
@@ -225,6 +225,14 @@ export function activate(context: vscode.ExtensionContext): void {
     context.subscriptions.push(vscode.commands.registerCommand(`${SETTINGS_VIEW_NAME}.cssMirrorContent`, () => {
         const cssMirrorContent = getCSSMirrorContentEnabled(context);
         void setCSSMirrorContentEnabled(context, !cssMirrorContent);
+    }));
+
+    context.subscriptions.push(vscode.commands.registerCommand(`${SETTINGS_VIEW_NAME}.launchHtml`, (fileUri: vscode.Uri): void => {
+        const edgeDebugConfig = providedHeadlessDebugConfig;
+        const devToolsAttachConfig = providedLaunchDevToolsConfig;
+        edgeDebugConfig.url = fileUri.fsPath;
+        devToolsAttachConfig.url = fileUri.fsPath;
+        void vscode.debug.startDebugging(undefined, edgeDebugConfig).then(() => vscode.debug.startDebugging(undefined, devToolsAttachConfig));
     }));
 
     void vscode.commands.executeCommand('setContext', 'titleCommandsRegistered', true);

--- a/src/launchConfigManager.ts
+++ b/src/launchConfigManager.ts
@@ -38,7 +38,7 @@ export const providedHeadlessDebugConfig: vscode.DebugConfiguration = {
     },
 };
 
-const providedLaunchDevToolsConfig: vscode.DebugConfiguration = {
+export const providedLaunchDevToolsConfig: vscode.DebugConfiguration = {
     type: 'vscode-edge-devtools.debug',
     name: 'Open Edge DevTools',
     request: 'attach',

--- a/test/extension.test.ts
+++ b/test/extension.test.ts
@@ -83,8 +83,8 @@ describe("extension", () => {
             // Activation should add the commands as subscriptions on the context
             newExtension.activate(context);
 
-            expect(context.subscriptions.length).toBe(17);
-            expect(commandMock).toHaveBeenCalledTimes(16);
+            expect(context.subscriptions.length).toBe(18);
+            expect(commandMock).toHaveBeenCalledTimes(17);
             expect(commandMock)
                 .toHaveBeenNthCalledWith(1, `${SETTINGS_STORE_NAME}.attach`, expect.any(Function));
             expect(commandMock)
@@ -115,6 +115,10 @@ describe("extension", () => {
                 .toHaveBeenNthCalledWith(14, `${SETTINGS_VIEW_NAME}.launchProject`, expect.any(Function));
             expect(commandMock)
                 .toHaveBeenNthCalledWith(15, `${SETTINGS_VIEW_NAME}.viewDocumentation`, expect.any(Function));
+            expect(commandMock)
+                .toHaveBeenNthCalledWith(16, `${SETTINGS_VIEW_NAME}.cssMirrorContent`, expect.any(Function));
+            expect(commandMock)
+                .toHaveBeenNthCalledWith(17, `${SETTINGS_VIEW_NAME}.launchHtml`, expect.any(Function));
             expect(mockRegisterTree)
                 .toHaveBeenNthCalledWith(1, `${SETTINGS_VIEW_NAME}.targets`, expect.any(Object));
         });


### PR DESCRIPTION
This PR adds a new context menu item when right clicking HTML files in the VSCode file explorer:
![image](https://user-images.githubusercontent.com/14304598/171289831-2344896b-9d6d-4d86-bef9-33cf28b4dcdf.png)

Clicking this context menu item will launch a headless version of Edge targeting the page and attach the DevTools.

The end config looks like this:
![image](https://user-images.githubusercontent.com/14304598/171289962-d5fc175f-08fe-42d3-b175-76abce74d8c5.png)

Note that the user does not need a supported `launch.json` to run this workflow.