### PR TITLE
[Bug Fix]: Fix context menu entrypoint for MacOS

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -248,15 +248,15 @@ export function activate(context: vscode.ExtensionContext): void {
         telemetryReporter.sendTelemetryEvent('contextMenu/launchHtml');
         const edgeDebugConfig = providedHeadlessDebugConfig;
         const devToolsAttachConfig = providedLaunchDevToolsConfig;
-        edgeDebugConfig.url = 'file://' + fileUri.fsPath;
-        devToolsAttachConfig.url = 'file://' + fileUri.fsPath;
+        edgeDebugConfig.url = `file://${fileUri.fsPath}`;
+        devToolsAttachConfig.url = `file://${fileUri.fsPath}`;
         void vscode.debug.startDebugging(undefined, edgeDebugConfig).then(() => vscode.debug.startDebugging(undefined, devToolsAttachConfig));
     }));
 
     context.subscriptions.push(vscode.commands.registerCommand(`${SETTINGS_VIEW_NAME}.launchScreencast`, (fileUri: vscode.Uri): void => {
         telemetryReporter.sendTelemetryEvent('contextMenu/launchScreencast');
         const edgeDebugConfig = providedHeadlessDebugConfig;
-        edgeDebugConfig.url = 'file://' + fileUri.fsPath;
+        edgeDebugConfig.url = `file://${fileUri.fsPath}`;
         void vscode.debug.startDebugging(undefined, edgeDebugConfig).then(() => attach(context, fileUri.fsPath, undefined, true, true));
     }));
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -248,15 +248,15 @@ export function activate(context: vscode.ExtensionContext): void {
         telemetryReporter.sendTelemetryEvent('contextMenu/launchHtml');
         const edgeDebugConfig = providedHeadlessDebugConfig;
         const devToolsAttachConfig = providedLaunchDevToolsConfig;
-        edgeDebugConfig.url = fileUri.fsPath;
-        devToolsAttachConfig.url = fileUri.fsPath;
+        edgeDebugConfig.url = 'file://' + fileUri.fsPath;
+        devToolsAttachConfig.url = 'file://' + fileUri.fsPath;
         void vscode.debug.startDebugging(undefined, edgeDebugConfig).then(() => vscode.debug.startDebugging(undefined, devToolsAttachConfig));
     }));
 
     context.subscriptions.push(vscode.commands.registerCommand(`${SETTINGS_VIEW_NAME}.launchScreencast`, (fileUri: vscode.Uri): void => {
         telemetryReporter.sendTelemetryEvent('contextMenu/launchScreencast');
         const edgeDebugConfig = providedHeadlessDebugConfig;
-        edgeDebugConfig.url = fileUri.fsPath;
+        edgeDebugConfig.url = 'file://' + fileUri.fsPath;
         void vscode.debug.startDebugging(undefined, edgeDebugConfig).then(() => attach(context, fileUri.fsPath, undefined, true, true));
     }));
 


### PR DESCRIPTION
Issue:
- `pwa-msedge`'s  `url` property requires `file://` to prefix the URL for local files when on MacOS.

Changes:
- Adding `file://` to the selected html file's path for all platforms (fixes MacOS, Win works w/ and w/o the prefix)