### PR TITLE
Breaking: Introducing quickfixes and autofix for webhint reported issues

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,7 @@
     "requires": true,
     "packages": {
         "": {
+            "name": "vscode-edge-devtools",
             "version": "2.1.0",
             "license": "SEE LICENSE IN LICENSE",
             "dependencies": {
@@ -15,7 +16,7 @@
                 "utf-8-validate": "5.0.6",
                 "vscode-chrome-debug-core": "6.8.11",
                 "vscode-extension-telemetry": "0.4.1",
-                "vscode-webhint": "1.6.7",
+                "vscode-webhint": "2.1.2",
                 "ws": "8.2.2",
                 "xmlhttprequest": "1.8.0"
             },
@@ -8787,11 +8788,11 @@
             "integrity": "sha512-8TEXQxlldWAuIODdukIb+TR5s+9Ds40eSJrw+1iDDA9IFORPjMELarNQE3myz5XIkWWpdprmJjm1/SxMlWOC8A=="
         },
         "node_modules/vscode-webhint": {
-            "version": "1.6.7",
-            "resolved": "https://registry.npmjs.org/vscode-webhint/-/vscode-webhint-1.6.7.tgz",
-            "integrity": "sha512-W9aPvA2LVC3sl1AlHHzcvTbxhYnuiTO/JRqy/Bsypz9grSZZdhMmtQSzWM9VwLJsXAAJRW5M7uPx7bclhm48TA==",
+            "version": "2.1.2",
+            "resolved": "https://registry.npmjs.org/vscode-webhint/-/vscode-webhint-2.1.2.tgz",
+            "integrity": "sha512-BTYJTMZJqjQM9snOlOHfhoQSmL+BUn9pcozyFKCb1k5lXtO87JqNdMnd86xmnUhxyDVoeOt2UnFk4eWiVcSXww==",
             "engines": {
-                "node": ">=8.0.0",
+                "node": ">=14.0.0",
                 "vscode": "^1.64.0"
             }
         },
@@ -15934,9 +15935,9 @@
             "integrity": "sha512-8TEXQxlldWAuIODdukIb+TR5s+9Ds40eSJrw+1iDDA9IFORPjMELarNQE3myz5XIkWWpdprmJjm1/SxMlWOC8A=="
         },
         "vscode-webhint": {
-            "version": "1.6.7",
-            "resolved": "https://registry.npmjs.org/vscode-webhint/-/vscode-webhint-1.6.7.tgz",
-            "integrity": "sha512-W9aPvA2LVC3sl1AlHHzcvTbxhYnuiTO/JRqy/Bsypz9grSZZdhMmtQSzWM9VwLJsXAAJRW5M7uPx7bclhm48TA=="
+            "version": "2.1.2",
+            "resolved": "https://registry.npmjs.org/vscode-webhint/-/vscode-webhint-2.1.2.tgz",
+            "integrity": "sha512-BTYJTMZJqjQM9snOlOHfhoQSmL+BUn9pcozyFKCb1k5lXtO87JqNdMnd86xmnUhxyDVoeOt2UnFk4eWiVcSXww=="
         },
         "w3c-hr-time": {
             "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -678,7 +678,7 @@
         "utf-8-validate": "5.0.6",
         "vscode-chrome-debug-core": "6.8.11",
         "vscode-extension-telemetry": "0.4.1",
-        "vscode-webhint": "1.6.7",
+        "vscode-webhint": "2.1.2",
         "ws": "8.2.2",
         "xmlhttprequest": "1.8.0"
     },


### PR DESCRIPTION
This PR updates the vscode-webhint dependency to versio `2.1.2` which contains,

**Breaking change: with this PR the required `node` version goes up to 14.0**

### Quickfixes menu

Adds quick-fixes to the extension-vscode package, this allows it to show 3 new context-menu
suggestions in the Microsoft Edge Devtools extension. These items are:

Ignore "hint"
Ignore "problem"
Edit .hintrc

### Automatic fixes
Applies recommended code fixes to specific problems reported by webhint.

Fix #1065
Fix #973