### PR TITLE
Fix URL in favicon test

### DIFF
--- a/test/cdpTargetsProvider.test.ts
+++ b/test/cdpTargetsProvider.test.ts
@@ -120,7 +120,7 @@ describe("CDPTargetsProvider", () => {
             url: '',
             webSocketDebuggerUrl: ''
         }
-        template.url = "https://docs.microsoft.com/en-us/microsoft-edge/";
+        template.url = "https://learn.microsoft.com/en-us/microsoft-edge/";
         await provider.downloadFaviconFromSitePromise(template);
         const microsoftIcon = template.faviconUrl;
         template.url = "https://www.bing.com/";


### PR DESCRIPTION
**Issue:**

` CDPTargetsProvider › check if favicons are downloaded and cleared correctly `
was failing in the CI pipeline

**Root:**
A URL used in the test changed

**Fix:**
Change the URL to point to the new location instead of the redirected location.
