### PR TITLE
Adapt the ADO mirroring workflow to the new area paths

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,7 +22,7 @@ jobs:
         ado_token: '${{ secrets.ADO_PERSONAL_ACCESS_TOKEN }}'
         ado_organization: 'microsoft'
         ado_project: 'Edge'
-        ado_area_path: 'Edge\Dev Experience\Developer Tools\F12 Tools\VSCode Extension'
+        ado_area_path: 'Edge\Web Experience\Developer Tools\F12 Tools\VSCode Extension'
         ado_tags: 'DevToolsVSCodeExtension_GitHub'
         ado_tag_on_close: 'DevToolsVSCodeExtension_GitHub_Closed'
         ado_bypassrules: false


### PR DESCRIPTION
Area paths changed in the Edge ADO instance. We need to update the one we use in this repository's workflow.