### PR TITLE
Updating vscode-webhint version to 2.1.10

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
                 "utf-8-validate": "5.0.6",
                 "vscode-chrome-debug-core": "6.8.11",
                 "vscode-extension-telemetry": "0.4.1",
-                "vscode-webhint": "2.1.3",
+                "vscode-webhint": "2.1.10",
                 "ws": "8.2.2",
                 "xmlhttprequest": "1.8.0"
             },
@@ -8741,9 +8741,9 @@
             "integrity": "sha512-8TEXQxlldWAuIODdukIb+TR5s+9Ds40eSJrw+1iDDA9IFORPjMELarNQE3myz5XIkWWpdprmJjm1/SxMlWOC8A=="
         },
         "node_modules/vscode-webhint": {
-            "version": "2.1.3",
-            "resolved": "https://registry.npmjs.org/vscode-webhint/-/vscode-webhint-2.1.3.tgz",
-            "integrity": "sha512-jmm4A6lFyWbZJvlif4wS8l0EysFBDW5YqdjMvvQr+wNWDbm0xKNc+8VggXvA3nMCku1CPCAAAreeNSKtnh0vvQ==",
+            "version": "2.1.10",
+            "resolved": "https://registry.npmjs.org/vscode-webhint/-/vscode-webhint-2.1.10.tgz",
+            "integrity": "sha512-HJiK12kreQCz13nPazYK6ShnpNBaXo2A4NHJRTdqGPf8UcQPG40yH79OCdz0Me+jSaNrBXdl8RGXtsLNr/IBmQ==",
             "engines": {
                 "node": ">=14.0.0",
                 "vscode": "^1.64.0"
@@ -15864,9 +15864,9 @@
             "integrity": "sha512-8TEXQxlldWAuIODdukIb+TR5s+9Ds40eSJrw+1iDDA9IFORPjMELarNQE3myz5XIkWWpdprmJjm1/SxMlWOC8A=="
         },
         "vscode-webhint": {
-            "version": "2.1.3",
-            "resolved": "https://registry.npmjs.org/vscode-webhint/-/vscode-webhint-2.1.3.tgz",
-            "integrity": "sha512-jmm4A6lFyWbZJvlif4wS8l0EysFBDW5YqdjMvvQr+wNWDbm0xKNc+8VggXvA3nMCku1CPCAAAreeNSKtnh0vvQ=="
+            "version": "2.1.10",
+            "resolved": "https://registry.npmjs.org/vscode-webhint/-/vscode-webhint-2.1.10.tgz",
+            "integrity": "sha512-HJiK12kreQCz13nPazYK6ShnpNBaXo2A4NHJRTdqGPf8UcQPG40yH79OCdz0Me+jSaNrBXdl8RGXtsLNr/IBmQ=="
         },
         "w3c-hr-time": {
             "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -678,7 +678,7 @@
         "utf-8-validate": "5.0.6",
         "vscode-chrome-debug-core": "6.8.11",
         "vscode-extension-telemetry": "0.4.1",
-        "vscode-webhint": "2.1.3",
+        "vscode-webhint": "2.1.10",
         "ws": "8.2.2",
         "xmlhttprequest": "1.8.0"
     },


### PR DESCRIPTION
Updating vscode-webhint version to `2.1.10` to bring some code fixes and the `css-reflows` hint.