### PR TITLE
Updates Webhint install failure notification

### DIFF
--- a/package.json
+++ b/package.json
@@ -278,6 +278,11 @@
                     "type": "boolean",
                     "default": true,
                     "description": "Enable feedback from webhint on source files to improve accessibility, compatibility, security and more."
+                },
+                "vscode-edge-devtools.webhintInstallNotification": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "Turn off notification for webhint installation failures."
                 }
             }
         },

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -346,14 +346,20 @@ function startWebhint(context: vscode.ExtensionContext): void {
     void client.onReady().then(() => {
         // Listen for notification that the webhint install failed.
         const installFailedNotification: typeof installFailed = 'vscode-webhint/install-failed';
-        client.onNotification(installFailedNotification, () => {
-            const message = 'Ensure `node` and `npm` are installed to enable automatically reporting issues in source files pertaining to accessibility, compatibility, security, and more.';
-            void vscode.window.showInformationMessage(message, 'OK', 'Disable').then(button => {
-                if (button === 'Disable') {
-                    void vscode.workspace.getConfiguration(SETTINGS_STORE_NAME).update('webhint', false, vscode.ConfigurationTarget.Global);
-                }
+        const disableNotication = vscode.workspace.getConfiguration(SETTINGS_STORE_NAME).get('webhintInstallNotification');
+        if (!disableNotication) {
+            client.onNotification(installFailedNotification, () => {
+                const message = 'Ensure `node` and `npm` are installed to enable automatically reporting issues in source files pertaining to accessibility, compatibility, security, and more.';
+                void vscode.window.showInformationMessage(message, 'Remind me Later', 'Disable Extension', 'Don\'t show again').then(button => {
+                    if (button === 'Disable Extension') {
+                        void vscode.workspace.getConfiguration(SETTINGS_STORE_NAME).update('webhint', false, vscode.ConfigurationTarget.Global);
+                    }
+                    if (button === 'Don\'t show again') {
+                        void vscode.workspace.getConfiguration(SETTINGS_STORE_NAME).update('webhintInstallNotification', true, vscode.ConfigurationTarget.Global);
+                    }
+                });
             });
-        });
+        }
         // Listen for requests to show the output panel for this extension.
         const showOutputNotification: typeof showOutput = 'vscode-webhint/show-output';
         client.onNotification(showOutputNotification, () => {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -346,13 +346,13 @@ function startWebhint(context: vscode.ExtensionContext): void {
     void client.onReady().then(() => {
         // Listen for notification that the webhint install failed.
         const installFailedNotification: typeof installFailed = 'vscode-webhint/install-failed';
-        const disableInstallNotification = vscode.workspace.getConfiguration(SETTINGS_STORE_NAME).get('webhintInstallNotification');
+        const disableInstallFailedNotification = vscode.workspace.getConfiguration(SETTINGS_STORE_NAME).get('webhintInstallNotification');
         client.onNotification(installFailedNotification, () => {
             if (!telemetryReporter) {
                 telemetryReporter = createTelemetryReporter(context);
             }
             telemetryReporter.sendTelemetryEvent('user/webhint/install-failed');
-            if (!disableInstallNotification) {
+            if (!disableInstallFailedNotification) {
                 const message = 'Ensure `node` and `npm` are installed to enable automatically reporting issues in source files pertaining to accessibility, compatibility, security, and more.';
                 void vscode.window.showInformationMessage(message, 'Remind me Later', 'Don\'t show again', 'Disable Extension').then(button => {
                     if (button === 'Disable Extension') {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -346,11 +346,15 @@ function startWebhint(context: vscode.ExtensionContext): void {
     void client.onReady().then(() => {
         // Listen for notification that the webhint install failed.
         const installFailedNotification: typeof installFailed = 'vscode-webhint/install-failed';
-        const disableNotication = vscode.workspace.getConfiguration(SETTINGS_STORE_NAME).get('webhintInstallNotification');
-        if (!disableNotication) {
-            client.onNotification(installFailedNotification, () => {
+        const disableInstallNotification = vscode.workspace.getConfiguration(SETTINGS_STORE_NAME).get('webhintInstallNotification');
+        client.onNotification(installFailedNotification, () => {
+            if (!telemetryReporter) {
+                telemetryReporter = createTelemetryReporter(context);
+            }
+            telemetryReporter.sendTelemetryEvent('user/webhint/install-failed');
+            if (!disableInstallNotification) {
                 const message = 'Ensure `node` and `npm` are installed to enable automatically reporting issues in source files pertaining to accessibility, compatibility, security, and more.';
-                void vscode.window.showInformationMessage(message, 'Remind me Later', 'Disable Extension', 'Don\'t show again').then(button => {
+                void vscode.window.showInformationMessage(message, 'Remind me Later', 'Don\'t show again', 'Disable Extension').then(button => {
                     if (button === 'Disable Extension') {
                         void vscode.workspace.getConfiguration(SETTINGS_STORE_NAME).update('webhint', false, vscode.ConfigurationTarget.Global);
                     }
@@ -358,8 +362,8 @@ function startWebhint(context: vscode.ExtensionContext): void {
                         void vscode.workspace.getConfiguration(SETTINGS_STORE_NAME).update('webhintInstallNotification', true, vscode.ConfigurationTarget.Global);
                     }
                 });
-            });
-        }
+            }
+        });
         // Listen for requests to show the output panel for this extension.
         const showOutputNotification: typeof showOutput = 'vscode-webhint/show-output';
         client.onNotification(showOutputNotification, () => {


### PR DESCRIPTION
Fixes #1145 
- Change `OK` Button for `Remind me later`
- Add `Don't show again` Button, as well as a cached setting that is validated before showing the dialog again. 
- Changes `Disable` for `Disable extension`

Current behavior
![image](https://github.com/microsoft/vscode-edge-devtools/assets/139378688/a9e6a1d2-1988-48db-93b4-8a46a37d10ae)

New behavior:
![image](https://github.com/microsoft/vscode-edge-devtools/assets/139378688/78921177-bc5d-4f71-b24c-8a0c8899cd5e)
![image](https://github.com/microsoft/vscode-edge-devtools/assets/139378688/9d195e0e-057d-457e-a13d-5b5f170f1038)


