### PR TITLE
Updating version to 2.1.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 2.1.3
+* **[Bug Fix]**: Adding dashes for passing arguments to scripts  - [PR #1624](https://github.com/microsoft/vscode-edge-devtools/pull/1624)
+* **[Feature]**: Reducing size of extension bundle (Produce production builds by default) - [PR #1598](https://github.com/microsoft/vscode-edge-devtools/pull/1598)
+* **[Feature]**: Updating vscode-webhint version to 2.1.10  - [PR #1560](https://github.com/microsoft/vscode-edge-devtools/pull/1560)
+* **[Bug Fix]**: Changed screencast label to toggle browser to comply with docs  - [PR #1331](https://github.com/microsoft/vscode-edge-devtools/pull/1331)
+
 ## 2.1.2
 * **[Bug Fix]**: Updating fallback version for the devtools revision - [PR #1290](https://github.com/microsoft/vscode-edge-devtools/pull/1290)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "vscode-edge-devtools",
-    "version": "2.1.2",
+    "version": "2.1.3",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "vscode-edge-devtools",
-            "version": "2.1.2",
+            "version": "2.1.3",
             "license": "SEE LICENSE IN LICENSE",
             "dependencies": {
                 "@vscode/codicons": "0.0.22",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "vscode-edge-devtools",
     "displayName": "Microsoft Edge Tools for VS Code",
     "description": "Use the Microsoft Edge Tools from within VS Code to see your site's runtime HTML structure, alter its layout, fix styling issues as well as see your site's network requests.",
-    "version": "2.1.2",
+    "version": "2.1.3",
     "license": "SEE LICENSE IN LICENSE",
     "publisher": "ms-edgedevtools",
     "preview": false,


### PR DESCRIPTION
Updating version

* **[Bug Fix]**: Adding dashes for passing arguments to scripts  - [PR #1624](https://github.com/microsoft/vscode-edge-devtools/pull/1624)
* **[Feature]**: Reducing size of extension bundle (Produce production builds by default) - [PR #1598](https://github.com/microsoft/vscode-edge-devtools/pull/1598)
* **[Feature]**: Updating vscode-webhint version to 2.1.10  - [PR #1560](https://github.com/microsoft/vscode-edge-devtools/pull/1560)
* **[Bug Fix]**: Changed screencast label to toggle browser to comply with docs  - [PR #1331](https://github.com/microsoft/vscode-edge-devtools/pull/1331)