### PR TITLE
Patch for missing icons

### DIFF
--- a/src/versionSocketConnection.ts
+++ b/src/versionSocketConnection.ts
@@ -79,7 +79,7 @@ export class BrowserVersionDetectionSocket extends EventEmitter {
 
         // TODO: Workaround https://github.com/microsoft/vscode-edge-devtools/issues/1992
         // remove when it has been fixed
-        if (parseFloat(versionNum) > 120) {
+        if (parseFloat(versionNum) > 121) {
             return {revision: '@d550f77b048ac142a3292397c64cdb693e4aca08', isHeadless};
         }
 

--- a/src/versionSocketConnection.ts
+++ b/src/versionSocketConnection.ts
@@ -76,6 +76,13 @@ export class BrowserVersionDetectionSocket extends EventEmitter {
         const currentVersion = versionNum.split('.').map(part => Number(part));
         const minSupportedVersion = MIN_SUPPORTED_VERSION.split('.').map(part => Number(part));
         const currentRevision = data.result.revision || '';
+
+        // TODO: Workaround https://github.com/microsoft/vscode-edge-devtools/issues/1992
+        // remove when it has been fixed
+        if (parseFloat(versionNum) > 120) {
+            return {revision: '@d550f77b048ac142a3292397c64cdb693e4aca08', isHeadless};
+        }
+
         for (let i = 0; i < currentVersion.length; i++) {
             // Loop through from Major to minor numbers
             if (currentVersion[i] > minSupportedVersion[i]) {


### PR DESCRIPTION
This PR patches an issue where the icons are being displayed as white squares. The issue is still being root caused but with this patch Edge Devtools version 122+ will default to last working version 121