### PR TITLE
Fix: Fixing an issue where webhint was not being loaded

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
                 "utf-8-validate": "6.0.3",
                 "vscode-chrome-debug-core": "6.8.11",
                 "vscode-extension-telemetry": "0.4.1",
-                "vscode-webhint": "2.1.11",
+                "vscode-webhint": "2.1.15",
                 "ws": "8.13.0",
                 "xmlhttprequest": "1.8.0"
             },
@@ -44,7 +44,7 @@
                 "typescript": "4.4.3",
                 "uglify-js": "3.17.4",
                 "unzipper": "0.10.14",
-                "vscode-languageclient": "7.0.0",
+                "vscode-languageclient": "9.0.1",
                 "vscode-test": "1.6.1",
                 "webpack": "5.94.0",
                 "webpack-cli": "5.1.4"
@@ -9143,42 +9143,63 @@
             }
         },
         "node_modules/vscode-jsonrpc": {
-            "version": "6.0.0",
-            "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-6.0.0.tgz",
-            "integrity": "sha512-wnJA4BnEjOSyFMvjZdpiOwhSq9uDoK8e/kpRJDTaMYzwlkrhG1fwDIZI94CLsLzlCK5cIbMMtFlJlfR57Lavmg==",
+            "version": "8.2.0",
+            "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-8.2.0.tgz",
+            "integrity": "sha512-C+r0eKJUIfiDIfwJhria30+TYWPtuHJXHtI7J0YlOmKAo7ogxP20T0zxB7HZQIFhIyvoBPwWskjxrvAtfjyZfA==",
             "dev": true,
             "engines": {
-                "node": ">=8.0.0 || >=10.0.0"
+                "node": ">=14.0.0"
             }
         },
         "node_modules/vscode-languageclient": {
-            "version": "7.0.0",
-            "resolved": "https://registry.npmjs.org/vscode-languageclient/-/vscode-languageclient-7.0.0.tgz",
-            "integrity": "sha512-P9AXdAPlsCgslpP9pRxYPqkNYV7Xq8300/aZDpO35j1fJm/ncize8iGswzYlcvFw5DQUx4eVk+KvfXdL0rehNg==",
+            "version": "9.0.1",
+            "resolved": "https://registry.npmjs.org/vscode-languageclient/-/vscode-languageclient-9.0.1.tgz",
+            "integrity": "sha512-JZiimVdvimEuHh5olxhxkht09m3JzUGwggb5eRUkzzJhZ2KjCN0nh55VfiED9oez9DyF8/fz1g1iBV3h+0Z2EA==",
             "dev": true,
             "dependencies": {
-                "minimatch": "^3.0.4",
-                "semver": "^7.3.4",
-                "vscode-languageserver-protocol": "3.16.0"
+                "minimatch": "^5.1.0",
+                "semver": "^7.3.7",
+                "vscode-languageserver-protocol": "3.17.5"
             },
             "engines": {
-                "vscode": "^1.52.0"
+                "vscode": "^1.82.0"
+            }
+        },
+        "node_modules/vscode-languageclient/node_modules/brace-expansion": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+            "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+            "dev": true,
+            "dependencies": {
+                "balanced-match": "^1.0.0"
+            }
+        },
+        "node_modules/vscode-languageclient/node_modules/minimatch": {
+            "version": "5.1.6",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
+            "integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
+            "dev": true,
+            "dependencies": {
+                "brace-expansion": "^2.0.1"
+            },
+            "engines": {
+                "node": ">=10"
             }
         },
         "node_modules/vscode-languageserver-protocol": {
-            "version": "3.16.0",
-            "resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.16.0.tgz",
-            "integrity": "sha512-sdeUoAawceQdgIfTI+sdcwkiK2KU+2cbEYA0agzM2uqaUy2UpnnGHtWTHVEtS0ES4zHU0eMFRGN+oQgDxlD66A==",
+            "version": "3.17.5",
+            "resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.17.5.tgz",
+            "integrity": "sha512-mb1bvRJN8SVznADSGWM9u/b07H7Ecg0I3OgXDuLdn307rl/J3A9YD6/eYOssqhecL27hK1IPZAsaqh00i/Jljg==",
             "dev": true,
             "dependencies": {
-                "vscode-jsonrpc": "6.0.0",
-                "vscode-languageserver-types": "3.16.0"
+                "vscode-jsonrpc": "8.2.0",
+                "vscode-languageserver-types": "3.17.5"
             }
         },
         "node_modules/vscode-languageserver-types": {
-            "version": "3.16.0",
-            "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.16.0.tgz",
-            "integrity": "sha512-k8luDIWJWyenLc5ToFQQMaSrqCHiLwyKPHKPQZ5zz21vM+vIVUSvsRpcbiECH4WR88K2XZqc4ScRcZ7nk/jbeA==",
+            "version": "3.17.5",
+            "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.17.5.tgz",
+            "integrity": "sha512-Ld1VelNuX9pdF39h2Hgaeb5hEZM2Z3jUrrMgWQAu82jMtZp7p3vJT3BzToKtZI7NgQssZje5o0zryOrhQvzQAg==",
             "dev": true
         },
         "node_modules/vscode-nls": {
@@ -9208,12 +9229,12 @@
             "integrity": "sha512-8TEXQxlldWAuIODdukIb+TR5s+9Ds40eSJrw+1iDDA9IFORPjMELarNQE3myz5XIkWWpdprmJjm1/SxMlWOC8A=="
         },
         "node_modules/vscode-webhint": {
-            "version": "2.1.11",
-            "resolved": "https://registry.npmjs.org/vscode-webhint/-/vscode-webhint-2.1.11.tgz",
-            "integrity": "sha512-L8ZPg13sXbe9b/7L/aRw9QWhGQWIYntsw/G1a56xJNrurIKTcaqf3pXHhGVErLUexLFN9Nznsipt6o+/uURnDg==",
+            "version": "2.1.15",
+            "resolved": "https://registry.npmjs.org/vscode-webhint/-/vscode-webhint-2.1.15.tgz",
+            "integrity": "sha512-sRveRRdhbjqZqdNhk9dpLT5LU69VzMfEOJEv7jDHEqpRsXGeYEP/cgyV0tbfuXZWNePzJQwpi+Owkn4FHZabwQ==",
             "engines": {
                 "node": ">=14.0.0",
-                "vscode": "^1.64.0"
+                "vscode": "^1.86.1"
             }
         },
         "node_modules/w3c-hr-time": {
@@ -16585,36 +16606,56 @@
             "integrity": "sha512-GUH42rpRlQc/yj0FTj/nTbDavtLqLCPNj/SvSrK1J4XazPC8vOTCOY0cyrf08Z8udolzBbVrxhXbFtPwbNyWPg=="
         },
         "vscode-jsonrpc": {
-            "version": "6.0.0",
-            "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-6.0.0.tgz",
-            "integrity": "sha512-wnJA4BnEjOSyFMvjZdpiOwhSq9uDoK8e/kpRJDTaMYzwlkrhG1fwDIZI94CLsLzlCK5cIbMMtFlJlfR57Lavmg==",
+            "version": "8.2.0",
+            "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-8.2.0.tgz",
+            "integrity": "sha512-C+r0eKJUIfiDIfwJhria30+TYWPtuHJXHtI7J0YlOmKAo7ogxP20T0zxB7HZQIFhIyvoBPwWskjxrvAtfjyZfA==",
             "dev": true
         },
         "vscode-languageclient": {
-            "version": "7.0.0",
-            "resolved": "https://registry.npmjs.org/vscode-languageclient/-/vscode-languageclient-7.0.0.tgz",
-            "integrity": "sha512-P9AXdAPlsCgslpP9pRxYPqkNYV7Xq8300/aZDpO35j1fJm/ncize8iGswzYlcvFw5DQUx4eVk+KvfXdL0rehNg==",
+            "version": "9.0.1",
+            "resolved": "https://registry.npmjs.org/vscode-languageclient/-/vscode-languageclient-9.0.1.tgz",
+            "integrity": "sha512-JZiimVdvimEuHh5olxhxkht09m3JzUGwggb5eRUkzzJhZ2KjCN0nh55VfiED9oez9DyF8/fz1g1iBV3h+0Z2EA==",
             "dev": true,
             "requires": {
-                "minimatch": "^3.0.4",
-                "semver": "^7.3.4",
-                "vscode-languageserver-protocol": "3.16.0"
+                "minimatch": "^5.1.0",
+                "semver": "^7.3.7",
+                "vscode-languageserver-protocol": "3.17.5"
+            },
+            "dependencies": {
+                "brace-expansion": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+                    "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+                    "dev": true,
+                    "requires": {
+                        "balanced-match": "^1.0.0"
+                    }
+                },
+                "minimatch": {
+                    "version": "5.1.6",
+                    "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
+                    "integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
+                    "dev": true,
+                    "requires": {
+                        "brace-expansion": "^2.0.1"
+                    }
+                }
             }
         },
         "vscode-languageserver-protocol": {
-            "version": "3.16.0",
-            "resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.16.0.tgz",
-            "integrity": "sha512-sdeUoAawceQdgIfTI+sdcwkiK2KU+2cbEYA0agzM2uqaUy2UpnnGHtWTHVEtS0ES4zHU0eMFRGN+oQgDxlD66A==",
+            "version": "3.17.5",
+            "resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.17.5.tgz",
+            "integrity": "sha512-mb1bvRJN8SVznADSGWM9u/b07H7Ecg0I3OgXDuLdn307rl/J3A9YD6/eYOssqhecL27hK1IPZAsaqh00i/Jljg==",
             "dev": true,
             "requires": {
-                "vscode-jsonrpc": "6.0.0",
-                "vscode-languageserver-types": "3.16.0"
+                "vscode-jsonrpc": "8.2.0",
+                "vscode-languageserver-types": "3.17.5"
             }
         },
         "vscode-languageserver-types": {
-            "version": "3.16.0",
-            "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.16.0.tgz",
-            "integrity": "sha512-k8luDIWJWyenLc5ToFQQMaSrqCHiLwyKPHKPQZ5zz21vM+vIVUSvsRpcbiECH4WR88K2XZqc4ScRcZ7nk/jbeA==",
+            "version": "3.17.5",
+            "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.17.5.tgz",
+            "integrity": "sha512-Ld1VelNuX9pdF39h2Hgaeb5hEZM2Z3jUrrMgWQAu82jMtZp7p3vJT3BzToKtZI7NgQssZje5o0zryOrhQvzQAg==",
             "dev": true
         },
         "vscode-nls": {
@@ -16640,9 +16681,9 @@
             "integrity": "sha512-8TEXQxlldWAuIODdukIb+TR5s+9Ds40eSJrw+1iDDA9IFORPjMELarNQE3myz5XIkWWpdprmJjm1/SxMlWOC8A=="
         },
         "vscode-webhint": {
-            "version": "2.1.11",
-            "resolved": "https://registry.npmjs.org/vscode-webhint/-/vscode-webhint-2.1.11.tgz",
-            "integrity": "sha512-L8ZPg13sXbe9b/7L/aRw9QWhGQWIYntsw/G1a56xJNrurIKTcaqf3pXHhGVErLUexLFN9Nznsipt6o+/uURnDg=="
+            "version": "2.1.15",
+            "resolved": "https://registry.npmjs.org/vscode-webhint/-/vscode-webhint-2.1.15.tgz",
+            "integrity": "sha512-sRveRRdhbjqZqdNhk9dpLT5LU69VzMfEOJEv7jDHEqpRsXGeYEP/cgyV0tbfuXZWNePzJQwpi+Owkn4FHZabwQ=="
         },
         "w3c-hr-time": {
             "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -683,7 +683,7 @@
         "utf-8-validate": "6.0.3",
         "vscode-chrome-debug-core": "6.8.11",
         "vscode-extension-telemetry": "0.4.1",
-        "vscode-webhint": "2.1.11",
+        "vscode-webhint": "2.1.15",
         "ws": "8.13.0",
         "xmlhttprequest": "1.8.0"
     },
@@ -711,7 +711,7 @@
         "uglify-js": "3.17.4",
         "unzipper": "0.10.14",
         "@vscode/vsce": "^2.19.0",
-        "vscode-languageclient": "7.0.0",
+        "vscode-languageclient": "9.0.1",
         "vscode-test": "1.6.1",
         "webpack": "5.94.0",
         "webpack-cli": "5.1.4"


### PR DESCRIPTION
Webhint was failing to install due to node security release CVE
https://nodejs.org/en/blog/vulnerability/april-2024-security-releases-2

Close https://github.com/microsoft/vscode-edge-devtools/issues/2390

Fixed by:
https://github.com/webhintio/hint/pull/5923