### PR TITLE
Feature: Sets different fallback chains.

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -63,6 +63,7 @@ export interface IRuntimeConfig {
     useLocalEdgeWatch: boolean;
     devtoolsBaseUri?: string;
     defaultEntrypoint?: string;
+    browserFlavor: BrowserFlavor;
 }
 export interface IStringDictionary<T> {
     [name: string]: T;
@@ -454,6 +455,7 @@ export function removeTrailingSlash(uri: string): string {
 export function getRuntimeConfig(config: Partial<IUserConfig> = {}): IRuntimeConfig {
     const settings = vscode.workspace.getConfiguration(SETTINGS_STORE_NAME);
     const pathMapping = config.pathMapping || settings.get('pathMapping') || SETTINGS_DEFAULT_PATH_MAPPING;
+    const browserFlavor = config.browserFlavor || settings.get('browserFlavor') || 'Default';
     const sourceMapPathOverrides =
         config.sourceMapPathOverrides || settings.get('sourceMapPathOverrides') || SETTINGS_DEFAULT_PATH_OVERRIDES;
     const webRoot = config.webRoot || settings.get('webRoot') || SETTINGS_DEFAULT_WEB_ROOT;
@@ -499,6 +501,7 @@ export function getRuntimeConfig(config: Partial<IUserConfig> = {}): IRuntimeCon
     return {
         pathMapping: resolvedMappingOverrides,
         sourceMapPathOverrides: resolvedOverrides,
+        browserFlavor,
         sourceMaps,
         webRoot: resolvedWebRoot,
         isJsDebugProxiedCDPConnection: false,

--- a/src/versionSocketConnection.ts
+++ b/src/versionSocketConnection.ts
@@ -17,7 +17,7 @@ export interface BrowserVersionCdpResponse {
 }
 
 // Minimum supported version of Edge
-export const MIN_SUPPORTED_VERSION = '120.0.2210.181';
+export const MIN_SUPPORTED_VERSION = '127.0.2592.0';
 export const MIN_SUPPORTED_REVISION = CDN_FALLBACK_REVISION;
 
 export class BrowserVersionDetectionSocket extends EventEmitter {

--- a/test/devtoolsPanel.test.ts
+++ b/test/devtoolsPanel.test.ts
@@ -174,6 +174,7 @@ describe("devtoolsPanel", () => {
     describe("update", () => {
         it("adds attempts to detect browser version only when visible", async () => {
             const dtp = await import("../src/devtoolsPanel");
+            mockRuntimeConfig.browserFlavor = 'Stable';
             dtp.DevToolsPanel.createOrShow(context, mockTelemetry, "", mockRuntimeConfig);
             expect(mockPanel.onDidChangeViewState).toHaveBeenCalled();
 

--- a/test/devtoolsPanel.test.ts
+++ b/test/devtoolsPanel.test.ts
@@ -48,6 +48,7 @@ describe("devtoolsPanel", () => {
             webRoot: "",
             isJsDebugProxiedCDPConnection: false,
             useLocalEdgeWatch: false,
+            browserFlavor: "Default",
         };
 
         mockPanel = {

--- a/test/helpers/helpers.ts
+++ b/test/helpers/helpers.ts
@@ -87,6 +87,9 @@ export function createFakeVSCode() {
             showTextDocument: jest.fn(),
             showInformationMessage: jest.fn(),
             showWarningMessage: jest.fn().mockResolvedValue({}),
+            activeColorTheme: {
+                kind: 1
+            }
         },
         workspace: {
             createFileSystemWatcher: jest.fn(),
@@ -140,9 +143,11 @@ export function createFakeVSCode() {
  * Create a fake VS Code extension context that can be used in tests
  */
 export function createFakeExtensionContext() {
+    const mockedGlobalState = new Map();
     return {
         extensionPath: "",
         subscriptions: [],
+        globalState: mockedGlobalState,
         workspaceState: {
             get: jest.fn(),
             update: jest.fn(),


### PR DESCRIPTION
This PR introduces two different ways to fallback to the devtools version displayed by the extension:

Before:
We got the version from the storage, if that did not existed or failed, we got the one from the browser and if that failed we got the one from the CDN. This whole process was async and could take up to ~5s leaving the users with the question if the tool was working or not.

After:
User has the ability to select the fallback chain by selecting the browser flavor. If the user wants a specific version (browserFlavor) the extension will behave in the same way as before, otherwise the first thing we will try to get is a working version of the tools from the CDN fallback address. This process takes less than 1s, making it faster for most of the users