### PR TITLE
Use substituted config instead of raw

### DIFF
--- a/src/launchDebugProvider.ts
+++ b/src/launchDebugProvider.ts
@@ -42,7 +42,7 @@ export class LaunchDebugProvider implements vscode.DebugConfigurationProvider {
         return Promise.resolve([providedDebugConfig]);
     }
 
-    resolveDebugConfiguration(
+    resolveDebugConfigurationWithSubstitutedVariables(
         folder: vscode.WorkspaceFolder | undefined,
         config: vscode.DebugConfiguration, _token?: vscode.CancellationToken):
         vscode.ProviderResult<vscode.DebugConfiguration> {

--- a/test/launchDebugProvider.test.ts
+++ b/test/launchDebugProvider.test.ts
@@ -40,14 +40,14 @@ describe("launchDebugProvider", () => {
         });
     });
 
-    describe("resolveDebugConfiguration", () => {
+    describe("resolveDebugConfigurationWithSubstitutedVariables", () => {
         it("calls attach", async () => {
             const mockConfig = {
                 name: "config",
                 request: "attach",
                 type: `${SETTINGS_STORE_NAME}.debug`,
             };
-            await host.resolveDebugConfiguration(undefined, mockConfig, undefined);
+            await host.resolveDebugConfigurationWithSubstitutedVariables(undefined, mockConfig, undefined);
             expect(attach).toHaveBeenCalled();
         });
 
@@ -57,7 +57,7 @@ describe("launchDebugProvider", () => {
                 request: "launch",
                 type: `${SETTINGS_STORE_NAME}.debug`,
             };
-            await host.resolveDebugConfiguration(undefined, mockConfig, undefined);
+            await host.resolveDebugConfigurationWithSubstitutedVariables(undefined, mockConfig, undefined);
             expect(launch).toHaveBeenCalled();
         });
 
@@ -68,11 +68,11 @@ describe("launchDebugProvider", () => {
                 request: "launch",
                 type: `${SETTINGS_STORE_NAME}.debug`,
             };
-            await host.resolveDebugConfiguration(undefined, mockConfig, undefined);
+            await host.resolveDebugConfigurationWithSubstitutedVariables(undefined, mockConfig, undefined);
             expect(launch).toHaveBeenCalledWith(expect.any(Object), "file:///index.html", mockConfig);
 
             mockConfig.file = "/index.html";
-            await host.resolveDebugConfiguration(undefined, mockConfig, undefined);
+            await host.resolveDebugConfigurationWithSubstitutedVariables(undefined, mockConfig, undefined);
             expect(launch).toHaveBeenCalledWith(expect.any(Object), "file:///index.html", mockConfig);
 
             const mockFolder = {
@@ -81,7 +81,7 @@ describe("launchDebugProvider", () => {
                 uri: { path: "path" },
             };
             mockConfig.file = "${workspaceFolder}/index.html";
-            await host.resolveDebugConfiguration(mockFolder as any, mockConfig, undefined);
+            await host.resolveDebugConfigurationWithSubstitutedVariables(mockFolder as any, mockConfig, undefined);
             expect(launch).toHaveBeenCalledWith(expect.any(Object), "file:///path/index.html", mockConfig);
         });
 
@@ -92,12 +92,12 @@ describe("launchDebugProvider", () => {
                 type: `${SETTINGS_STORE_NAME}.debug`,
                 url: "http://localhost/index.html",
             };
-            await host.resolveDebugConfiguration(undefined, mockConfig, undefined);
+            await host.resolveDebugConfigurationWithSubstitutedVariables(undefined, mockConfig, undefined);
             expect(launch).toHaveBeenCalledWith(expect.any(Object), mockConfig.url, mockConfig);
         });
 
         it("reports error on no config", async () => {
-            const result = await host.resolveDebugConfiguration(undefined, null as any, undefined);
+            const result = await host.resolveDebugConfigurationWithSubstitutedVariables(undefined, null as any, undefined);
             expect(result).toBeUndefined();
             expect(mockReporter.sendTelemetryEvent).toHaveBeenCalled();
         });


### PR DESCRIPTION
See this link for details. https://code.visualstudio.com/api/references/vscode-api#DebugConfigurationProvider → resolveDebugConfigurationWithSubstitutedVariables

This commit fixes the [issue](https://github.com/microsoft/vscode-edge-devtools/issues/2472) that variables in debug configs are not resolved, and instead passed as-is to msedge.exe. Using the proper VS Code API easily solves it.

## Before
![master](https://github.com/user-attachments/assets/32c2ac4c-0a38-4a80-b543-88249a33034d)

## After
![fix-subst](https://github.com/user-attachments/assets/720a55bb-d887-4f90-9e52-27dbe36a1ec4)