### PR TITLE
Adding launchURL argument for the vscode-edge-devtools.launch command

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4310,9 +4310,9 @@
             }
         },
         "node_modules/cross-spawn": {
-            "version": "7.0.3",
-            "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
-            "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+            "version": "7.0.6",
+            "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+            "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
             "dev": true,
             "dependencies": {
                 "path-key": "^3.1.0",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -83,8 +83,8 @@ export function activate(context: vscode.ExtensionContext): void {
         void attach(context);
     }));
 
-    context.subscriptions.push(vscode.commands.registerCommand(`${SETTINGS_STORE_NAME}.launch`, (): void => {
-        void launch(context);
+    context.subscriptions.push(vscode.commands.registerCommand(`${SETTINGS_STORE_NAME}.launch`, ( opts: {launchUrl: string} = {launchUrl: ""} ): void => {
+        void launch(context, opts.launchUrl);
     }));
 
     context.subscriptions.push(vscode.commands.registerCommand(`${SETTINGS_STORE_NAME}.attachToCurrentDebugTarget`, (debugSessionId: string | undefined, config: Partial<IUserConfig>): void => {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -83,7 +83,7 @@ export function activate(context: vscode.ExtensionContext): void {
         void attach(context);
     }));
 
-    context.subscriptions.push(vscode.commands.registerCommand(`${SETTINGS_STORE_NAME}.launch`, ( opts: {launchUrl: string} = {launchUrl: ""} ): void => {
+    context.subscriptions.push(vscode.commands.registerCommand(`${SETTINGS_STORE_NAME}.launch`, (opts: {launchUrl: string} = {launchUrl: ''}): void => {
         void launch(context, opts.launchUrl);
     }));
 


### PR DESCRIPTION
This PR adds a new argument `launchUrl` to the `vscode.commands.registerCommand` method in the `extension.ts` file.
Close #2677 #1768