### PR TITLE
Updating application insights key

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "categories": [
         "Debuggers"
     ],
-    "aiKey": "AIF-d9b70cd4-b9f9-4d70-929b-a071c400b217",
+    "oneDSKey": "0c6ae279ed8443289764825290e4f9e2-1a736e7c-1324-4338-be46-fc2a58ae4d14-7255",
     "main": "./out/extension",
     "sideEffects": false,
     "activationEvents": [

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -338,7 +338,7 @@ export async function getJsDebugCDPProxyWebsocketUrl(debugSessionId: string): Pr
 export function createTelemetryReporter(_context: vscode.ExtensionContext): Readonly<TelemetryReporter> {
     if (packageJson && (_context.extensionMode === vscode.ExtensionMode.Production)) {
         // Use the real telemetry reporter
-        return new TelemetryReporter(packageJson.aiKey);
+        return new TelemetryReporter(packageJson.oneDSKey);
     }
         // Fallback to a fake telemetry reporter
         return new DebugTelemetryReporter();


### PR DESCRIPTION
This commit:
Upgrading typescript and vscode-extension-telemetry (https://github.com/microsoft/vscode-edge-devtools/pull/2704)

Upgraded extension telemetry handler. The new version is not complatible with previous AIF keys but 1DS. From previous documentation it seems the new one has to be updated, otherwise the application will not be registered and it will not work.

https://github.com/microsoft/vscode-azure-ext-sdk/blob/main/readme.md
points to 
https://github.com/Microsoft/vscode-docker/blob/main/package.json

Which contains the new key.