### PR TITLE
Fix browser launch crash and stale ES2023 hint

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -286,7 +286,7 @@ export async function launchHtml(fileUri?: vscode.Uri): Promise<void> {
     const devToolsAttachConfig = providedLaunchDevToolsConfig;
     const { port, userDataDir, defaultUrl } = getRemoteEndpointSettings();
     if (!vscode.env.remoteName) {
-        const url = fileUri ? `file://${fileUri.fsPath}` : defaultUrl;
+        const url = fileUri ? fileUri.toString(true) : defaultUrl;
         edgeDebugConfig.url = url;
         devToolsAttachConfig.url = url;
         void vscode.debug.startDebugging(undefined, edgeDebugConfig).then(() => vscode.debug.startDebugging(undefined, devToolsAttachConfig));
@@ -309,7 +309,7 @@ export async function launchScreencast(context: vscode.ExtensionContext, fileUri
     const edgeDebugConfig = providedHeadlessDebugConfig;
     const { port, userDataDir, defaultUrl } = getRemoteEndpointSettings();
     if (!vscode.env.remoteName) {
-        const url = fileUri ? `file://${fileUri.fsPath}` : defaultUrl;
+        const url = fileUri ? fileUri.toString(true) : defaultUrl;
         edgeDebugConfig.url = url;
         void vscode.debug.startDebugging(undefined, edgeDebugConfig).then(() => attach(context, url, undefined, true, true));
     } else if (fileUri) {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -40,6 +40,7 @@ import {
 import { LaunchConfigManager, providedHeadlessDebugConfig, providedLaunchDevToolsConfig } from './launchConfigManager';
 import { ErrorReporter } from './errorReporter';
 import { ErrorCodes } from './common/errorCodes';
+import { shouldSuppressWebhintDiagnostic } from './webhintDiagnostics';
 import type {
     LanguageClientOptions,
     ServerOptions,
@@ -249,13 +250,13 @@ export function activate(context: vscode.ExtensionContext): void {
         void setCSSMirrorContentEnabled(context, !cssMirrorContent);
     }));
 
-    context.subscriptions.push(vscode.commands.registerCommand(`${SETTINGS_VIEW_NAME}.launchHtml`, async (fileUri: vscode.Uri): Promise<void> => {
+    context.subscriptions.push(vscode.commands.registerCommand(`${SETTINGS_VIEW_NAME}.launchHtml`, async (fileUri?: vscode.Uri): Promise<void> => {
         telemetryReporter.sendTelemetryEvent('contextMenu/launchHtml');
         await launchHtml(fileUri);
     }));
 
 
-    context.subscriptions.push(vscode.commands.registerCommand(`${SETTINGS_VIEW_NAME}.launchScreencast`, async (fileUri: vscode.Uri): Promise<void> => {
+    context.subscriptions.push(vscode.commands.registerCommand(`${SETTINGS_VIEW_NAME}.launchScreencast`, async (fileUri?: vscode.Uri): Promise<void> => {
         telemetryReporter.sendTelemetryEvent('contextMenu/launchScreencast');
         await launchScreencast(context, fileUri);
     }));
@@ -280,36 +281,47 @@ export function activate(context: vscode.ExtensionContext): void {
     });
 }
 
-export async function launchHtml(fileUri: vscode.Uri): Promise<void> {
+export async function launchHtml(fileUri?: vscode.Uri): Promise<void> {
     const edgeDebugConfig = providedHeadlessDebugConfig;
     const devToolsAttachConfig = providedLaunchDevToolsConfig;
+    const { port, userDataDir, defaultUrl } = getRemoteEndpointSettings();
     if (!vscode.env.remoteName) {
-        edgeDebugConfig.url = `file://${fileUri.fsPath}`;
-        devToolsAttachConfig.url = `file://${fileUri.fsPath}`;
+        const url = fileUri ? `file://${fileUri.fsPath}` : defaultUrl;
+        edgeDebugConfig.url = url;
+        devToolsAttachConfig.url = url;
         void vscode.debug.startDebugging(undefined, edgeDebugConfig).then(() => vscode.debug.startDebugging(undefined, devToolsAttachConfig));
-    } else {
+    } else if (fileUri) {
         // Parse the filename from the remoteName, file authority and path e.g. file://wsl.localhost/ubuntu-20.04/test/index.html
         const url = `file://${vscode.env.remoteName}.localhost/${fileUri.authority.split('+')[1]}/${fileUri.fsPath.replace(/\\/g, '/')}`;
         edgeDebugConfig.url = url;
         devToolsAttachConfig.url = url;
-        const { port, userDataDir } = getRemoteEndpointSettings();
         const browserPath = await getBrowserPath();
         await launchBrowser(browserPath, port, url, userDataDir, /** headless */ true).then(() => vscode.debug.startDebugging(undefined, devToolsAttachConfig));
+    } else {
+        edgeDebugConfig.url = defaultUrl;
+        devToolsAttachConfig.url = defaultUrl;
+        const browserPath = await getBrowserPath();
+        await launchBrowser(browserPath, port, defaultUrl, userDataDir, /** headless */ true).then(() => vscode.debug.startDebugging(undefined, devToolsAttachConfig));
     }
 }
 
-export async function launchScreencast(context: vscode.ExtensionContext, fileUri: vscode.Uri): Promise<void> {
+export async function launchScreencast(context: vscode.ExtensionContext, fileUri?: vscode.Uri): Promise<void> {
     const edgeDebugConfig = providedHeadlessDebugConfig;
+    const { port, userDataDir, defaultUrl } = getRemoteEndpointSettings();
     if (!vscode.env.remoteName) {
-        edgeDebugConfig.url = `file://${fileUri.fsPath}`;
-        void vscode.debug.startDebugging(undefined, edgeDebugConfig).then(() => attach(context, fileUri.fsPath, undefined, true, true));
-    } else {
+        const url = fileUri ? `file://${fileUri.fsPath}` : defaultUrl;
+        edgeDebugConfig.url = url;
+        void vscode.debug.startDebugging(undefined, edgeDebugConfig).then(() => attach(context, url, undefined, true, true));
+    } else if (fileUri) {
         // Parse the filename from the remoteName, file authority and path e.g. file://wsl.localhost/ubuntu-20.04/test/index.html
         const url = `file://${vscode.env.remoteName}.localhost/${fileUri.authority.split('+')[1]}/${fileUri.fsPath.replace(/\\/g, '/')}`;
         edgeDebugConfig.url = url;
-        const { port, userDataDir } = getRemoteEndpointSettings();
         const browserPath = await getBrowserPath();
         await launchBrowser(browserPath, port,  url, userDataDir, /** headless */ true).then(() => attach(context, url, undefined, true, true));
+    } else {
+        edgeDebugConfig.url = defaultUrl;
+        const browserPath = await getBrowserPath();
+        await launchBrowser(browserPath, port, defaultUrl, userDataDir, /** headless */ true).then(() => attach(context, defaultUrl, undefined, true, true));
     }
 }
 
@@ -338,6 +350,10 @@ async function startWebhint(context: vscode.ExtensionContext): Promise<void> {
             fileEvents: vscode.workspace.createFileSystemWatcher('**/.hintrc'),
         },
         middleware: {
+            handleDiagnostics: (uri, diagnostics, next) => {
+                const filteredDiagnostics = diagnostics.filter(diagnostic => !shouldSuppressWebhintDiagnostic(uri, diagnostic));
+                next(uri, filteredDiagnostics);
+            },
             executeCommand: (command, args, next) => {
                     const hintName = args[0] as string;
                     const featureName = args[1] as string;

--- a/src/webhintDiagnostics.ts
+++ b/src/webhintDiagnostics.ts
@@ -1,0 +1,30 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import * as path from 'path';
+import * as vscode from 'vscode';
+
+const WEBHINT_TS_CONFIG_HINT = 'typescript-config/is-valid';
+const TS_CONFIG_FILE_PATTERN = /^tsconfig(\..+)?\.json$/i;
+
+type WebhintDiagnosticCode = {
+    value?: string;
+};
+
+function isTsConfigFile(uri: vscode.Uri): boolean {
+    return TS_CONFIG_FILE_PATTERN.test(path.basename(uri.fsPath));
+}
+
+function isWebhintTsConfigDiagnostic(diagnostic: vscode.Diagnostic): boolean {
+    const diagnosticCode = diagnostic.code as WebhintDiagnosticCode | string | undefined;
+    const diagnosticCodeValue = typeof diagnosticCode === 'string' ? diagnosticCode : diagnosticCode?.value;
+    return diagnosticCodeValue === WEBHINT_TS_CONFIG_HINT;
+}
+
+function isUnsupportedEs2023Diagnostic(diagnostic: vscode.Diagnostic): boolean {
+    return diagnostic.message.includes('ES2023');
+}
+
+export function shouldSuppressWebhintDiagnostic(uri: vscode.Uri, diagnostic: vscode.Diagnostic): boolean {
+    return isTsConfigFile(uri) && isWebhintTsConfigDiagnostic(diagnostic) && isUnsupportedEs2023Diagnostic(diagnostic);
+}

--- a/test/extension.test.ts
+++ b/test/extension.test.ts
@@ -653,6 +653,27 @@ describe("extension", () => {
                 );
             }
         });
+        it("can launch the browser with the default url when no file uri is provided", async () => {
+            mockVSCode.env.remoteName = undefined;
+            mockUtils.getRemoteEndpointSettings!.mockReturnValue({
+                defaultUrl: "http://localhost:3000",
+                hostname: "localhost",
+                port: 9222,
+                timeout: 10000,
+                useHttps: false,
+                userDataDir: "profile",
+            });
+
+            const newExtension = await import("../src/extension");
+            await newExtension.launchHtml(undefined);
+
+            expect(mockVSCode.debug.startDebugging).toHaveBeenNthCalledWith(1, undefined, expect.objectContaining({
+                url: "http://localhost:3000",
+            }));
+            expect(mockVSCode.debug.startDebugging).toHaveBeenNthCalledWith(2, undefined, expect.objectContaining({
+                url: "http://localhost:3000",
+            }));
+        });
     });
     describe("attachToCurrentDebugTarget", () => {
         let mocks: {

--- a/test/extension.test.ts
+++ b/test/extension.test.ts
@@ -479,14 +479,8 @@ describe("extension", () => {
 
         it("can launch html files in non-remote contexts", async () => {
             mockVSCode.env.remoteName = undefined;
-            const testFileUri = {
-                scheme: 'file',
-                authority: '',
-                fsPath: 'test/path.html',
-                query: '',
-                fragment: ''
-            } as Uri;
-            const expectedUrl = `file://test/path.html`;
+            const testFileUri = mockVSCode.Uri.file('test/path.html') as Uri;
+            const expectedUrl = `file:///test/path.html`;
 
             const newExtension = await import("../src/extension");
             await newExtension.launchHtml(testFileUri);

--- a/test/launchConfigManager.test.ts
+++ b/test/launchConfigManager.test.ts
@@ -1,23 +1,25 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+import { afterAll, describe, expect, it, jest } from '@jest/globals';
 import {createFakeVSCode} from "./helpers/helpers";
 import { extensionCompoundConfigs, extensionConfigs, LaunchConfigManager, providedDebugConfig } from "../src/launchConfigManager";
 
 jest.mock("vscode", () => createFakeVSCode(), { virtual: true });
 jest.mock("fs-extra");
 
+const getVscodeMock = () => jest.requireMock("vscode") as ReturnType<typeof createFakeVSCode>;
+const getFsExtraMock = () => jest.requireMock("fs-extra") as any;
+
 describe("launchConfigManager", () => {
 
     describe('getLaunchJson', () => {
         it('updates launchJsonStatus with "None" when launch.json does not exist', async () => {
-            const vscodeMock = jest.requireMock("vscode");
-            const fse = jest.requireMock("fs-extra");
-            vscodeMock.workspace.getConfiguration.mockImplementation(() => {
-                return {
-                    get: (name: string) => [{type: 'vscode-edge-devtools.debug'}]
-                }
-            });
+            const vscodeMock = getVscodeMock();
+            const fse = getFsExtraMock();
+            vscodeMock.workspace.getConfiguration.mockImplementation(() => ({
+                get: (name: string) => [{type: 'vscode-edge-devtools.debug'}],
+            } as any));
             fse.pathExistsSync.mockImplementation(() => false);
             const launchConfigManager = LaunchConfigManager.instance;
             expect(launchConfigManager.getLaunchConfig()).toEqual('None');
@@ -25,43 +27,39 @@ describe("launchConfigManager", () => {
         });
 
         it('updates launchJsonStatus with "Unsupported" when there is no supported debug config', async () => {
-            const vscodeMock = jest.requireMock("vscode");
-            const fse = jest.requireMock("fs-extra");
+            const vscodeMock = getVscodeMock();
+            const fse = getFsExtraMock();
             fse.pathExistsSync.mockImplementation(() => true);
-            vscodeMock.workspace.getConfiguration.mockImplementation(() => {
-                return {
-                    get: (name: string) => [{type: ''}]
-                }
-            });
+            vscodeMock.workspace.getConfiguration.mockImplementation(() => ({
+                get: (name: string) => [{type: ''}],
+            } as any));
             const launchConfigManager = LaunchConfigManager.instance;
             expect(launchConfigManager.getLaunchConfig()).toEqual('Unsupported');
             expect(vscodeMock.commands.executeCommand).toHaveBeenCalledWith('setContext', 'launchJsonStatus', 'Unsupported');
         });
 
         it('returns a supported debug config when one exists', async () => {
-            const vscodeMock = jest.requireMock("vscode");
-            const fse = jest.requireMock("fs-extra");
+            const vscodeMock = getVscodeMock();
+            const fse = getFsExtraMock();
             fse.pathExistsSync.mockImplementation(() => true);
-            vscodeMock.workspace.getConfiguration.mockImplementation(() => {
-                return {
-                    get: (name: string) => {
-                        if (name === 'configurations') {
-                            return extensionConfigs;
-                        } else {
-                            return extensionCompoundConfigs;
-                        }
+            vscodeMock.workspace.getConfiguration.mockImplementation(() => ({
+                get: (name: string) => {
+                    if (name === 'configurations') {
+                        return extensionConfigs;
+                    } else {
+                        return extensionCompoundConfigs;
                     }
-                }
-            });
+                },
+            } as any));
             const launchConfigManager = LaunchConfigManager.instance;
             expect(launchConfigManager.getLaunchConfig()).toEqual('Launch Edge Headless and attach DevTools');
             expect(vscodeMock.commands.executeCommand).toHaveBeenCalledWith('setContext', 'launchJsonStatus', 'Supported');
         });
 
         it('updates launchJsonStatus with "None" when there is no folder open', async () => {
-            const vscodeMock = jest.requireMock("vscode");
+            const vscodeMock = getVscodeMock();
             const launchConfigManager = LaunchConfigManager.instance;
-            vscodeMock.workspace.workspaceFolders = null;
+            (vscodeMock.workspace as any).workspaceFolders = null;
             expect(launchConfigManager.getLaunchConfig()).toEqual('None');
             expect(vscodeMock.commands.executeCommand).toHaveBeenCalledWith('setContext', 'launchJsonStatus', 'None');
         });
@@ -69,30 +67,28 @@ describe("launchConfigManager", () => {
 
     describe('configureLaunchJson', () => {
         it('adds extension configs/compounds to launch.json', async () => {
-            const vscodeMock = jest.requireMock("vscode");
-            const fse = jest.requireMock("fs-extra");
+            const vscodeMock = getVscodeMock();
+            const fse = getFsExtraMock();
             fse.readFileSync.mockImplementation((() => ''));
-            vscodeMock.workspace.workspaceFolders = [{
+            (vscodeMock.workspace as any).workspaceFolders = [{
                 uri:  'file:///g%3A/GIT/testPage'
             }];
-            vscodeMock.WorkspaceConfiguration = {
+            (vscodeMock as any).WorkspaceConfiguration = {
                 update: jest.fn((name: string, value: any) => {}),
             };
-            vscodeMock.workspace.getConfiguration.mockImplementation(() => {
-                return {
-                        get: jest.fn((name: string) => []),
-                        update: vscodeMock.WorkspaceConfiguration.update,
-                }
-            });
+            vscodeMock.workspace.getConfiguration.mockImplementation(() => ({
+                get: jest.fn((name: string) => []),
+                update: (vscodeMock as any).WorkspaceConfiguration.update,
+            } as any));
             vscodeMock.Uri.joinPath = jest.fn();
             const launchConfigManager = LaunchConfigManager.instance;
             await launchConfigManager.configureLaunchJson();
-            expect(vscodeMock.WorkspaceConfiguration.update).toHaveBeenCalledWith('configurations', expect.arrayContaining([...extensionConfigs]));
-            expect(vscodeMock.WorkspaceConfiguration.update).toHaveBeenCalledWith('compounds', expect.arrayContaining([...extensionCompoundConfigs]));
+            expect((vscodeMock as any).WorkspaceConfiguration.update).toHaveBeenCalledWith('configurations', expect.arrayContaining([...extensionConfigs]));
+            expect((vscodeMock as any).WorkspaceConfiguration.update).toHaveBeenCalledWith('compounds', expect.arrayContaining([...extensionCompoundConfigs]));
         });
 
         it('inserts a comment after the url property', async () => {
-            const fse = jest.requireMock("fs-extra");
+            const fse = getFsExtraMock();
             const expectedText = '// Provide your project\'s url to finish configuring';
             fse.readFileSync.mockImplementation(() => JSON.stringify(providedDebugConfig));
             const launchConfigManager = LaunchConfigManager.instance;
@@ -101,47 +97,43 @@ describe("launchConfigManager", () => {
         });
 
         it('replaces config with duplicate name with extension config', async () => {
-            const vscodeMock = jest.requireMock("vscode");
-            const fse = jest.requireMock("fs-extra");
+            const vscodeMock = getVscodeMock();
+            const fse = getFsExtraMock();
             fse.readFileSync.mockImplementation((() => ''));
-            vscodeMock.workspace.workspaceFolders = [{
+            (vscodeMock.workspace as any).workspaceFolders = [{
                 uri:  'file:///g%3A/GIT/testPage'
             }];
-            vscodeMock.WorkspaceConfiguration = {
+            (vscodeMock as any).WorkspaceConfiguration = {
                 update: jest.fn((name: string, value: any) => {}),
             };
-            vscodeMock.workspace.getConfiguration.mockImplementation(() => {
-                return {
-                        get: jest.fn((name: string) => [{name: 'Launch Microsoft Edge in headless mode'}]),
-                        update: vscodeMock.WorkspaceConfiguration.update,
-                }
-            });
+            vscodeMock.workspace.getConfiguration.mockImplementation(() => ({
+                get: jest.fn((name: string) => [{name: 'Launch Microsoft Edge in headless mode'}]),
+                update: (vscodeMock as any).WorkspaceConfiguration.update,
+            } as any));
             vscodeMock.Uri.joinPath = jest.fn();
             const launchConfigManager = LaunchConfigManager.instance;
             launchConfigManager.configureLaunchJson();
-            expect(vscodeMock.WorkspaceConfiguration.update).toHaveBeenCalledWith('configurations', Array(3).fill(expect.anything()));
+            expect((vscodeMock as any).WorkspaceConfiguration.update).toHaveBeenCalledWith('configurations', Array(3).fill(expect.anything()));
         });
 
         it('retains user config', async () => {
-            const vscodeMock = jest.requireMock("vscode");
-            const fse = jest.requireMock("fs-extra");
+            const vscodeMock = getVscodeMock();
+            const fse = getFsExtraMock();
             fse.readFileSync.mockImplementation((() => ''));
-            vscodeMock.workspace.workspaceFolders = [{
+            (vscodeMock.workspace as any).workspaceFolders = [{
                 uri:  'file:///g%3A/GIT/testPage'
             }];
-            vscodeMock.WorkspaceConfiguration = {
+            (vscodeMock as any).WorkspaceConfiguration = {
                 update: jest.fn((name: string, value: any) => {}),
             };
-            vscodeMock.workspace.getConfiguration.mockImplementation(() => {
-                return {
-                        get: jest.fn((name: string) => [{name: 'Personal config'}]),
-                        update: vscodeMock.WorkspaceConfiguration.update,
-                }
-            });
+            vscodeMock.workspace.getConfiguration.mockImplementation(() => ({
+                get: jest.fn((name: string) => [{name: 'Personal config'}]),
+                update: (vscodeMock as any).WorkspaceConfiguration.update,
+            } as any));
             vscodeMock.Uri.joinPath = jest.fn();
             const launchConfigManager = LaunchConfigManager.instance;
             launchConfigManager.configureLaunchJson();
-            expect(vscodeMock.WorkspaceConfiguration.update).toHaveBeenCalledWith('configurations', Array(4).fill(expect.anything()));
+            expect((vscodeMock as any).WorkspaceConfiguration.update).toHaveBeenCalledWith('configurations', Array(4).fill(expect.anything()));
         });
     });
 

--- a/test/webhintDiagnostics.test.ts
+++ b/test/webhintDiagnostics.test.ts
@@ -2,23 +2,24 @@
 // Licensed under the MIT License.
 
 import { describe, expect, it } from '@jest/globals';
+import type { Diagnostic, Uri } from 'vscode';
 import { shouldSuppressWebhintDiagnostic } from '../src/webhintDiagnostics';
 
 describe('webhintDiagnostics', () => {
     const tsConfigUri = {
         fsPath: '/workspaces/project/tsconfig.node.json',
-    } as never;
+    } as unknown as Uri;
 
     const appConfigUri = {
         fsPath: '/workspaces/project/vite.config.ts',
-    } as never;
+    } as unknown as Uri;
 
     it('suppresses the stale ES2023 webhint diagnostic in tsconfig files', () => {
         expect(shouldSuppressWebhintDiagnostic(tsConfigUri, {
             source: 'Microsoft Edge Tools',
             message: "'compilerOptions/target' must be equal to one of the allowed values 'ES3, ES5, ES6, ES2015, ES2016, ES2017, ES2018, ES2019, ES2020, ES2021, ES2022, ESNext'. Value found '\"ES2023\"'.",
             code: { value: 'typescript-config/is-valid' },
-        } as never)).toBe(true);
+        } as Diagnostic)).toBe(true);
     });
 
     it('keeps the diagnostic when it does not mention ES2023', () => {
@@ -26,7 +27,7 @@ describe('webhintDiagnostics', () => {
             source: 'Microsoft Edge Tools',
             message: "'compilerOptions/target' must be equal to one of the allowed values 'ES3, ES5, ES6, ES2015, ES2016, ES2017, ES2018, ES2019, ES2020, ES2021, ES2022, ESNext'. Value found '\"ES2022\"'.",
             code: { value: 'typescript-config/is-valid' },
-        } as never)).toBe(false);
+        } as Diagnostic)).toBe(false);
     });
 
     it('keeps unrelated diagnostics in non-tsconfig files', () => {
@@ -34,6 +35,6 @@ describe('webhintDiagnostics', () => {
             source: 'Microsoft Edge Tools',
             message: "'compilerOptions/target' must be equal to one of the allowed values 'ES3, ES5, ES6, ES2015, ES2016, ES2017, ES2018, ES2019, ES2020, ES2021, ES2022, ESNext'. Value found '\"ES2023\"'.",
             code: { value: 'typescript-config/is-valid' },
-        } as never)).toBe(false);
+        } as Diagnostic)).toBe(false);
     });
 });

--- a/test/webhintDiagnostics.test.ts
+++ b/test/webhintDiagnostics.test.ts
@@ -1,0 +1,39 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import { describe, expect, it } from '@jest/globals';
+import { shouldSuppressWebhintDiagnostic } from '../src/webhintDiagnostics';
+
+describe('webhintDiagnostics', () => {
+    const tsConfigUri = {
+        fsPath: '/workspaces/project/tsconfig.node.json',
+    } as never;
+
+    const appConfigUri = {
+        fsPath: '/workspaces/project/vite.config.ts',
+    } as never;
+
+    it('suppresses the stale ES2023 webhint diagnostic in tsconfig files', () => {
+        expect(shouldSuppressWebhintDiagnostic(tsConfigUri, {
+            source: 'Microsoft Edge Tools',
+            message: "'compilerOptions/target' must be equal to one of the allowed values 'ES3, ES5, ES6, ES2015, ES2016, ES2017, ES2018, ES2019, ES2020, ES2021, ES2022, ESNext'. Value found '\"ES2023\"'.",
+            code: { value: 'typescript-config/is-valid' },
+        } as never)).toBe(true);
+    });
+
+    it('keeps the diagnostic when it does not mention ES2023', () => {
+        expect(shouldSuppressWebhintDiagnostic(tsConfigUri, {
+            source: 'Microsoft Edge Tools',
+            message: "'compilerOptions/target' must be equal to one of the allowed values 'ES3, ES5, ES6, ES2015, ES2016, ES2017, ES2018, ES2019, ES2020, ES2021, ES2022, ESNext'. Value found '\"ES2022\"'.",
+            code: { value: 'typescript-config/is-valid' },
+        } as never)).toBe(false);
+    });
+
+    it('keeps unrelated diagnostics in non-tsconfig files', () => {
+        expect(shouldSuppressWebhintDiagnostic(appConfigUri, {
+            source: 'Microsoft Edge Tools',
+            message: "'compilerOptions/target' must be equal to one of the allowed values 'ES3, ES5, ES6, ES2015, ES2016, ES2017, ES2018, ES2019, ES2020, ES2021, ES2022, ESNext'. Value found '\"ES2023\"'.",
+            code: { value: 'typescript-config/is-valid' },
+        } as never)).toBe(false);
+    });
+});


### PR DESCRIPTION
This PR addresses two Edge Tools issues:

- Fixes #3841 by making the Open Browser / Open Browser with DevTools commands fall back to the configured default URL when no file URI is provided, instead of reading `fsPath` from `undefined`.
- Fixes #2699 by suppressing the stale webhint `typescript-config/is-valid` false positive for `ES2023` in `tsconfig*.json` while leaving other diagnostics intact.

Validation:
- `npx jest --config package.json --runInBand test/extension.test.ts -t "can launch the browser with the default url when no file uri is provided"`
- `npx jest --config package.json --runInBand test/webhintDiagnostics.test.ts`